### PR TITLE
Consistently exclude the current rack from the list returned by getSeeds()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>11.0.1</version>
+			<version>r05</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.inject</groupId>

--- a/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -40,10 +40,10 @@ public class InstanceIdentity
     private final IConfiguration config;
     private final Sleeper sleeper;
 
-    private final Predicate<PriamInstance> differentHostPredicate = new Predicate<PriamInstance>() {
+    private final Predicate<String> differentRack = new Predicate<String>() {
       @Override
-      public boolean apply(PriamInstance instance) {
-        return !instance.getHostName().equals(myInstance.getHostName());
+      public boolean apply(String rack) {
+        return !rack.equals(myInstance.getRac());
       }
     };
 
@@ -189,12 +189,8 @@ public class InstanceIdentity
             if (locMap.get(myInstance.getRac()).size() > 1 && locMap.get(myInstance.getRac()).get(0).getHostName().equals(myInstance.getHostName()))
                 seeds.add(locMap.get(myInstance.getRac()).get(1).getHostName());
         }
-        for (String loc : locMap.keySet())
-        {
-            PriamInstance instance = Iterables.tryFind(locMap.get(loc), differentHostPredicate).orNull();
-            if (instance != null)
-                seeds.add(instance.getHostName());
-        }
+        for (String loc : Iterables.filter(locMap.keySet(), differentRack))
+            seeds.add(locMap.get(loc).get(0).getHostName());
         return seeds;
     }
 

--- a/src/test/java/com/netflix/priam/backup/identity/InstanceIdentityTest.java
+++ b/src/test/java/com/netflix/priam/backup/identity/InstanceIdentityTest.java
@@ -62,7 +62,7 @@ public class InstanceIdentityTest extends InstanceTestUtils
     {
         createInstances();
         identity = createInstanceIdentity("az1", "fakeinstancex");
-        assertEquals(3, identity.getSeeds().size());
+        assertEquals(2, identity.getSeeds().size());
     }
 
     @Test


### PR DESCRIPTION
The current implementation sometimes includes a node on the current rack with the cassandra co-process, but other times doesn't. It depends on the order of the nodes in this region's list, as returned by the multimap, which in turn depends on the order of the nodes returned by the PriamInstanceFactory. If the first node in the region's list happens to be this node, then the region is excluded; otherwise, a node from this region is included.

This change is to make the behavior more consistent and decoupled from the unspecified return order of the factory. We specifically filter out the current rack before adding the seeds, which ensures that no node from the current rack is ever added to the seeds list.
