### PR TITLE
Add REST endpoint for InstanceIdentity (SimpleDB) management

### DIFF
--- a/src/main/java/com/netflix/priam/aws/SDBInstanceData.java
+++ b/src/main/java/com/netflix/priam/aws/SDBInstanceData.java
@@ -42,8 +42,8 @@ public class SDBInstanceData
         public final static String HOSTNAME = "hostname";
     }
     public static final String DOMAIN = "InstanceIdentity";
-    public static String ALL_QUERY = "select * from " + DOMAIN + " where " + Attributes.APP_ID + "='%s'";
-    public static String INSTANCE_QUERY = "select * from " + DOMAIN + " where " + Attributes.APP_ID + "='%s' and " + Attributes.ID + "='%d'";
+    public static final String ALL_QUERY = "select * from " + DOMAIN + " where " + Attributes.APP_ID + "='%s'";
+    public static final String INSTANCE_QUERY = "select * from " + DOMAIN + " where " + Attributes.APP_ID + "='%s' and " + Attributes.ID + "='%d'";
 
     private final ICredential provider;
     
@@ -56,11 +56,9 @@ public class SDBInstanceData
     /**
      * Get the instance details from SimpleDB
      * 
-     * @param app
-     *            Cluster name
-     * @param id
-     *            Node ID
-     * @return
+     * @param app Cluster name
+     * @param id Node ID
+     * @return the node with the given {@code id}, or {@code null} if no such node exists
      */
     public PriamInstance getInstance(String app, int id)
     {
@@ -73,11 +71,10 @@ public class SDBInstanceData
     }
 
     /**
-     * Get a list of all nodes in the cluster
+     * Get the set of all nodes in the cluster
      * 
-     * @param app
-     *            Cluster name
-     * @return
+     * @param app Cluster name
+     * @return the set of all instances in the given {@code app}
      */
     public Set<PriamInstance> getAllIds(String app)
     {

--- a/src/main/java/com/netflix/priam/aws/SDBInstanceFactory.java
+++ b/src/main/java/com/netflix/priam/aws/SDBInstanceFactory.java
@@ -46,15 +46,20 @@ public class SDBInstanceFactory implements IPriamInstanceFactory
         }
         sort(return_);
         return return_;
-
     }
 
     @Override
-    public PriamInstance create(String app, int id, String instanceID, String hostname, String ip, String rac, Map<String, Object> volumes, String payload)
+    public PriamInstance getInstance(String appName, int id)
+    {
+      return dao.getInstance(appName, id);
+    }
+
+    @Override
+    public PriamInstance create(String app, int id, String instanceID, String hostname, String ip, String rac, Map<String, Object> volumes, String token)
     {
         try
         {
-            PriamInstance ins = makePriamInstance(app, id, instanceID, hostname, ip, rac, volumes, payload);
+            PriamInstance ins = makePriamInstance(app, id, instanceID, hostname, ip, rac, volumes, token);
             // remove old data node which are dead.
             if (app.endsWith("-dead"))
             {
@@ -134,7 +139,7 @@ public class SDBInstanceFactory implements IPriamInstanceFactory
         // TODO Auto-generated method stub
     }
 
-    private PriamInstance makePriamInstance(String app, int id, String instanceID, String hostname, String ip, String rac, Map<String, Object> volumes, String payload)
+    private PriamInstance makePriamInstance(String app, int id, String instanceID, String hostname, String ip, String rac, Map<String, Object> volumes, String token)
     {
         Map<String, Object> v = (volumes == null) ? new HashMap<String, Object>() : volumes;
         PriamInstance ins = new PriamInstance();
@@ -145,7 +150,7 @@ public class SDBInstanceFactory implements IPriamInstanceFactory
         ins.setId(id);
         ins.setInstanceId(instanceID);
         ins.setDC(config.getDC());
-        ins.setToken(payload);
+        ins.setToken(token);
         ins.setVolumes(v);
         return ins;
     }

--- a/src/main/java/com/netflix/priam/identity/IPriamInstanceFactory.java
+++ b/src/main/java/com/netflix/priam/identity/IPriamInstanceFactory.java
@@ -12,10 +12,18 @@ public interface IPriamInstanceFactory
 {
     /**
      * Return a list of all Cassandra server nodes registered.
-     * @param appName
-     * @return
+     * @param appName the cluster name
+     * @return a list of all nodes in {@code appName}
      */
     public List<PriamInstance> getAllIds(String appName);
+
+    /**
+     * Return the Cassandra server node with the given {@code id}.
+     * @param appName the cluster name
+     * @param id the node id
+     * @return the node with the given {@code id}, or {@code null} if none found
+     */
+    public PriamInstance getInstance(String appName, int id);
 
     /**
      * Create/Register an instance of the server with its info.
@@ -26,26 +34,26 @@ public interface IPriamInstanceFactory
      * @param ip
      * @param rac
      * @param volumes
-     * @param payload
-     * @return
+     * @param token
+     * @return the new node
      */
-    public PriamInstance create(String app, int id, String instanceID, String hostname, String ip, String rac, Map<String, Object> volumes, String payload);
+    public PriamInstance create(String app, int id, String instanceID, String hostname, String ip, String rac, Map<String, Object> volumes, String token);
 
     /**
      * Delete the server node from the registry
-     * @param inst
+     * @param inst the node to delete
      */
     public void delete(PriamInstance inst);
 
     /**
      * Update the details of the server node in registry
-     * @param inst
+     * @param inst the node to update
      */
     public void update(PriamInstance inst);
 
     /**
      * Sort the list by instance ID
-     * @param return_
+     * @param return_ the list of nodes to sort
      */
     public void sort(List<PriamInstance> return_);
 

--- a/src/main/java/com/netflix/priam/identity/PriamInstance.java
+++ b/src/main/java/com/netflix/priam/identity/PriamInstance.java
@@ -109,7 +109,7 @@ public class PriamInstance implements Serializable
     @Override
     public String toString()
     {
-        return String.format("Hostname: %s, InstanceId: %s, APP_NAME: %s, RAC : %s Location %s, Slot: %s: Token: %s", getHostName(), getInstanceId(), getApp(), getRac(), getDC(), getId(),
+        return String.format("Hostname: %s, InstanceId: %s, APP_NAME: %s, RAC : %s Location %s, Id: %s: Token: %s", getHostName(), getInstanceId(), getApp(), getRac(), getDC(), getId(),
                 getToken());
     }
 

--- a/src/main/java/com/netflix/priam/resources/BackupServlet.java
+++ b/src/main/java/com/netflix/priam/resources/BackupServlet.java
@@ -225,6 +225,10 @@ public class BackupServlet
         return TokenManager.findClosestToken(new BigInteger(token), tokenList).toString();
     }
 
+    /*
+     * TODO: decouple the servlet, config, and restorer. this should not rely on a side
+     *       effect of a list mutation on the config object (treating it as global var).
+     */
     private void setRestoreKeyspaces(String keyspaces)
     {
         List<String> list = config.getRestoreKeySpaces();

--- a/src/main/java/com/netflix/priam/resources/CassandraConfig.java
+++ b/src/main/java/com/netflix/priam/resources/CassandraConfig.java
@@ -66,6 +66,7 @@ public class CassandraConfig
         }
         catch (Exception e)
         {
+            // TODO: can this ever happen? if so, what conditions would cause an exception here?
             logger.error("Error while executing get_token", e);
             return Response.serverError().build();
         }
@@ -82,6 +83,7 @@ public class CassandraConfig
         }
         catch (Exception e)
         {
+            // TODO: can this ever happen? if so, what conditions would cause an exception here?
             logger.error("Error while executing is_replace_token", e);
             return Response.serverError().build();
         }

--- a/src/main/java/com/netflix/priam/resources/PriamInstanceResource.java
+++ b/src/main/java/com/netflix/priam/resources/PriamInstanceResource.java
@@ -1,0 +1,131 @@
+package com.netflix.priam.resources;
+
+import java.net.URI;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
+import com.google.inject.Inject;
+import com.netflix.priam.IConfiguration;
+import com.netflix.priam.identity.IPriamInstanceFactory;
+import com.netflix.priam.identity.PriamInstance;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resource for manipulating priam instances.
+ */
+@Path("/v1/instances")
+@Produces(MediaType.TEXT_PLAIN)
+public class PriamInstanceResource
+{
+    private static final Logger log = LoggerFactory.getLogger(PriamInstanceResource.class);
+
+    private final IConfiguration config;
+    private final IPriamInstanceFactory factory;
+
+    @Inject
+    public PriamInstanceResource(IConfiguration config, IPriamInstanceFactory factory)
+    {
+        this.config = config;
+        this.factory = factory;
+    }
+
+    /**
+     * Get the list of all priam instances
+     * @return the list of all priam instances
+     */
+    @GET
+    public String getInstances()
+    {
+        StringBuilder response = new StringBuilder();
+        for (PriamInstance node : factory.getAllIds(config.getAppName()))
+        {
+            response.append(node.toString());
+            response.append("\n");
+        }
+        return response.toString();
+    }
+
+    /**
+     * Returns an individual priam instance by id
+     * 
+     * @param id the node id
+     * @return the priam instance
+     * @throws WebApplicationException(404) if no priam instance found with {@code id}
+     */
+    @GET
+    @Path("{id}")
+    public String getInstance(@PathParam("id") int id)
+    {
+        PriamInstance node = getByIdIfFound(id);
+        return node.toString();
+    }
+
+    /**
+     * Creates a new instance with the given parameters
+     *
+     * @param id the node id
+     * @return Response (201) if the instance was created
+     */
+    @POST
+    public Response createInstance(
+        @QueryParam("id") int id, @QueryParam("instanceID") String instanceID,
+        @QueryParam("hostname") String hostname, @QueryParam("ip") String ip,
+        @QueryParam("rack") String rack, @QueryParam("token") String token)
+    {
+        log.info("Creating instance [id={}, instanceId={}, hostname={}, ip={}, rack={}, token={}",
+            new Object[]{ id, instanceID, hostname, ip, rack, token });
+        PriamInstance instance = factory.create(config.getAppName(), id, instanceID, hostname, ip, rack, null, token);
+        URI uri = UriBuilder.fromPath("/{id}").build(instance.getId());
+        return Response.created(uri).build();
+    }
+
+    /**
+     * Deletes the instance with the given {@code id}.
+     * 
+     * @param id the node id
+     * @return Response (204) if the instance was deleted
+     * @throws WebApplicationException (404) if no priam instance found with {@code id}
+     */
+    @DELETE
+    @Path("{id}")
+    public Response deleteInstance(@PathParam("id") int id)
+    {
+        PriamInstance instance = getByIdIfFound(id);
+        factory.delete(instance);
+        return Response.noContent().build();
+    }
+
+    /**
+     * Returns the PriamInstance with the given {@code id}, or
+     * throws a WebApplicationException if none found.
+     * 
+     * @param id the node id
+     * @return PriamInstance with the given {@code id}
+     * @throws WebApplicationException (400)
+     */
+    private PriamInstance getByIdIfFound(int id)
+    {
+        PriamInstance instance = factory.getInstance(config.getAppName(), id);
+        if (instance == null) {
+            throw notFound(String.format("No priam instance with id %s found", id));
+        }
+        return instance;
+    }
+
+    private static WebApplicationException notFound(String message)
+    {
+        return new WebApplicationException(Response.status(Response.Status.NOT_FOUND).entity(message).build());
+    }
+}

--- a/src/test/java/com/netflix/priam/FakePriamInstanceFactory.java
+++ b/src/test/java/com/netflix/priam/FakePriamInstanceFactory.java
@@ -6,6 +6,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import com.netflix.priam.IConfiguration;
 import com.netflix.priam.identity.IPriamInstanceFactory;
@@ -13,8 +14,8 @@ import com.netflix.priam.identity.PriamInstance;
 
 public class FakePriamInstanceFactory implements IPriamInstanceFactory
 {
-    List<PriamInstance> instances = new ArrayList<PriamInstance>();
-    private IConfiguration config;
+    private final Map<Integer,PriamInstance> instances = Maps.newHashMap();
+    private final IConfiguration config;
 
     @Inject
     public FakePriamInstanceFactory(IConfiguration config)
@@ -25,9 +26,14 @@ public class FakePriamInstanceFactory implements IPriamInstanceFactory
     @Override
     public List<PriamInstance> getAllIds(String appName)
     {
-        return new ArrayList<PriamInstance>(instances);
+        return new ArrayList<PriamInstance>(instances.values());
     }
     
+    @Override
+    public PriamInstance getInstance(String appName, int id) {
+      return instances.get(id);
+    }
+
     @Override
     public PriamInstance create(String app, int id, String instanceID, String hostname, String ip, String rac, Map<String, Object> volumes, String payload)
     {
@@ -40,20 +46,20 @@ public class FakePriamInstanceFactory implements IPriamInstanceFactory
         ins.setToken(payload);
         ins.setVolumes(volumes);
         ins.setDC(config.getDC());
-        instances.add(ins);
+        instances.put(id, ins);
         return ins;
     }
 
     @Override
     public void delete(PriamInstance inst)
     {
-        instances.remove(inst);
+        instances.remove(inst.getId());
     }
 
     @Override
     public void update(PriamInstance inst)
     {
-        instances.add(inst);
+        instances.put(inst.getId(), inst);
     }
 
     @Override

--- a/src/test/java/com/netflix/priam/backup/identity/InstanceIdentityTest.java
+++ b/src/test/java/com/netflix/priam/backup/identity/InstanceIdentityTest.java
@@ -62,10 +62,10 @@ public class InstanceIdentityTest extends InstanceTestUtils
     {
         createInstances();
         identity = createInstanceIdentity("az1", "fakeinstancex");
-        assertEquals(3, identity.getSeeds().size());
+        assertEquals(2, identity.getSeeds().size());
 
         identity = createInstanceIdentity("az1", "fakeinstance1");
-        assertEquals(2, identity.getSeeds().size());
+        assertEquals(3, identity.getSeeds().size());
     }
 
     @Test

--- a/src/test/java/com/netflix/priam/resources/BackupServletTest.java
+++ b/src/test/java/com/netflix/priam/resources/BackupServletTest.java
@@ -1,0 +1,363 @@
+package com.netflix.priam.resources;
+
+import java.util.Date;
+import java.util.List;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.inject.Provider;
+import com.netflix.priam.IConfiguration;
+import com.netflix.priam.PriamServer;
+import com.netflix.priam.backup.AbstractBackupPath;
+import com.netflix.priam.backup.IBackupFileSystem;
+import com.netflix.priam.backup.Restore;
+import com.netflix.priam.backup.SnapshotBackup;
+import com.netflix.priam.identity.IPriamInstanceFactory;
+import com.netflix.priam.identity.InstanceIdentity;
+import com.netflix.priam.identity.PriamInstance;
+import com.netflix.priam.utils.TuneCassandra;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.NonStrict;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BackupServletTest
+{
+    private @NonStrict PriamServer priamServer;
+    private @NonStrict IConfiguration config;
+    private @Mocked IBackupFileSystem fs;
+    private @Mocked Restore restoreObj;
+    private @Mocked Provider<AbstractBackupPath> pathProvider;
+    private @Mocked TuneCassandra tuneCassandra;
+    private @Mocked SnapshotBackup snapshotBackup;
+    private @Mocked IPriamInstanceFactory factory;
+    private BackupServlet resource;
+
+    @Before
+    public void setUp()
+    {
+        resource = new BackupServlet(priamServer, config, fs, restoreObj, pathProvider,
+            tuneCassandra, snapshotBackup, factory);
+    }
+
+    @Test
+    public void backup() throws Exception
+    {
+        new Expectations() {{
+            snapshotBackup.execute();
+        }};
+
+        Response response = resource.backup();
+        assertEquals(200, response.getStatus());
+        assertEquals("[\"ok\"]", response.getEntity());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMetadata().get("Content-Type").get(0));
+    }
+
+    @Test
+    public void restore_minimal() throws Exception
+    {
+        final String dateRange = null;
+        final String newRegion = null;
+        final String newToken = null;
+        final String keyspaces = null;
+
+        final String oldRegion = "us-east-1";
+        final String oldToken = "1234";
+
+        new Expectations() {
+            @NonStrict InstanceIdentity identity;
+            PriamInstance instance;
+  
+            {
+                config.getDC(); result = oldRegion;
+                priamServer.getId(); result = identity; times = 2;
+                identity.getInstance(); result = instance; times = 2;
+                instance.getToken(); result = oldToken;
+
+                config.isRestoreClosestToken(); result = false;
+  
+                restoreObj.restore((Date) any, (Date) any); // TODO: test default value
+  
+                config.setDC(oldRegion);
+                instance.setToken(oldToken);
+                tuneCassandra.updateYaml(false);
+            }
+        };
+
+        expectCassandraStartup();
+
+        Response response = resource.restore(dateRange, newRegion, newToken, keyspaces);
+        assertEquals(200, response.getStatus());
+        assertEquals("[\"ok\"]", response.getEntity());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMetadata().get("Content-Type").get(0));
+    }
+
+    @Test
+    public void restore_withDateRange() throws Exception
+    {
+        final String dateRange = "201101010000,201112312359";
+        final String newRegion = null;
+        final String newToken = null;
+        final String keyspaces = null;
+
+        final String oldRegion = "us-east-1";
+        final String oldToken = "1234";
+
+        new Expectations() {
+            @NonStrict InstanceIdentity identity;
+            PriamInstance instance;
+            AbstractBackupPath backupPath;
+  
+            {
+                pathProvider.get(); result = backupPath;
+                backupPath.getFormat(); result = AbstractBackupPath.DAY_FORMAT; times = 2;
+
+                config.getDC(); result = oldRegion;
+                priamServer.getId(); result = identity; times = 2;
+                identity.getInstance(); result = instance; times = 2;
+                instance.getToken(); result = oldToken;
+
+                config.isRestoreClosestToken(); result = false;
+
+                restoreObj.restore(
+                    new DateTime(2011, 01, 01, 00, 00).toDate(),
+                    new DateTime(2011, 12, 31, 23, 59).toDate());
+  
+                config.setDC(oldRegion);
+                instance.setToken(oldToken);
+                tuneCassandra.updateYaml(false);
+            }
+        };
+
+        expectCassandraStartup();
+
+        Response response = resource.restore(dateRange, newRegion, newToken, keyspaces);
+        assertEquals(200, response.getStatus());
+        assertEquals("[\"ok\"]", response.getEntity());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMetadata().get("Content-Type").get(0));
+    }
+
+//    @Test
+//    public void restore_withRegion() throws Exception
+//    {
+//        final String dateRange = null;
+//        final String newRegion = "us-west-1";
+//        final String newToken = null;
+//        final String keyspaces = null;
+//
+//        final String oldRegion = "us-east-1";
+//        final String oldToken = "1234";
+//        final String appName = "myApp";
+//
+//        new Expectations() {
+//            @NonStrict InstanceIdentity identity;
+//            PriamInstance instance;
+//            @NonStrict PriamInstance instance1, instance2, instance3;
+//  
+//            {
+//                config.getDC(); result = oldRegion;
+//                priamServer.getId(); result = identity; times = 3;
+//                identity.getInstance(); result = instance; times = 3;
+//                instance.getToken(); result = oldToken;
+//
+//                config.isRestoreClosestToken(); result = false;
+//                
+//                config.setDC(newRegion);
+//                instance.getToken(); result = oldToken;
+//                config.getAppName(); result = appName;
+//                factory.getAllIds(appName); result = ImmutableList.of(instance, instance1, instance2, instance3);
+//                instance.getDC();  result = oldRegion;
+//                instance.getToken(); result = oldToken;
+//                instance1.getDC(); result = oldRegion;
+//                instance2.getDC(); result = oldRegion;
+//                instance3.getDC(); result = oldRegion;
+//                instance1.getToken(); result = "1234";
+//                instance2.getToken(); result = "5678";
+//                instance3.getToken(); result = "9000";
+//                instance.setToken((String) any); // TODO: test mocked closest token
+//
+//                restoreObj.restore((Date) any, (Date) any); // TODO: test default value
+//  
+//                config.setDC(oldRegion);
+//                instance.setToken(oldToken);
+//                tuneCassandra.updateYaml(false);
+//            }
+//        };
+//
+//        expectCassandraStartup();
+//
+//        Response response = resource.restore(dateRange, newRegion, newToken, keyspaces);
+//        assertEquals(200, response.getStatus());
+//        assertEquals("[\"ok\"]", response.getEntity());
+//        assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMetadata().get("Content-Type").get(0));
+//    }
+
+    @Test
+    public void restore_withToken() throws Exception
+    {
+        final String dateRange = null;
+        final String newRegion = null;
+        final String newToken = "myNewToken";
+        final String keyspaces = null;
+
+        final String oldRegion = "us-east-1";
+        final String oldToken = "1234";
+
+        new Expectations() {
+            @NonStrict InstanceIdentity identity;
+            PriamInstance instance;
+  
+            {
+                config.getDC(); result = oldRegion;
+                priamServer.getId(); result = identity; times = 3;
+                identity.getInstance(); result = instance; times = 3;
+                instance.getToken(); result = oldToken;
+                instance.setToken(newToken);
+
+                config.isRestoreClosestToken(); result = false;
+
+                restoreObj.restore((Date) any, (Date) any); // TODO: test default value
+  
+                config.setDC(oldRegion);
+                instance.setToken(oldToken);
+                tuneCassandra.updateYaml(false);
+            }
+        };
+
+        expectCassandraStartup();
+
+        Response response = resource.restore(dateRange, newRegion, newToken, keyspaces);
+        assertEquals(200, response.getStatus());
+        assertEquals("[\"ok\"]", response.getEntity());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMetadata().get("Content-Type").get(0));
+    }
+
+    @Test
+    public void restore_withKeyspaces() throws Exception
+    {
+        final String dateRange = null;
+        final String newRegion = null;
+        final String newToken = null;
+        final String keyspaces = "keyspace1,keyspace2";
+
+        final String oldRegion = "us-east-1";
+        final String oldToken = "1234";
+
+        new Expectations() {
+            @NonStrict InstanceIdentity identity;
+            PriamInstance instance;
+  
+            {
+                config.getDC(); result = oldRegion;
+                priamServer.getId(); result = identity; times = 2;
+                identity.getInstance(); result = instance; times = 2;
+                instance.getToken(); result = oldToken;
+
+                config.isRestoreClosestToken(); result = false;
+  
+                List<String> restoreKeyspaces = Lists.newArrayList();
+                config.getRestoreKeySpaces(); result = restoreKeyspaces;
+                restoreKeyspaces.clear();
+                restoreKeyspaces.addAll(ImmutableList.of("keyspace1", "keyspace2"));
+
+                restoreObj.restore((Date) any, (Date) any); // TODO: test default value
+  
+                config.setDC(oldRegion);
+                instance.setToken(oldToken);
+                tuneCassandra.updateYaml(false);
+            }
+        };
+
+        expectCassandraStartup();
+
+        Response response = resource.restore(dateRange, newRegion, newToken, keyspaces);
+        assertEquals(200, response.getStatus());
+        assertEquals("[\"ok\"]", response.getEntity());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMetadata().get("Content-Type").get(0));
+    }
+
+    // TODO: this should also set/test newRegion and keyspaces
+    @Test
+    public void restore_maximal() throws Exception
+    {
+        final String dateRange = "201101010000,201112312359";
+        final String newRegion = null;
+        final String newToken = "5678";
+        final String keyspaces = null;
+
+        final String oldRegion = "us-east-1";
+        final String oldToken = "1234";
+        final String appName = "myApp";
+
+        new Expectations() {
+            @NonStrict InstanceIdentity identity;
+            PriamInstance instance;
+            @NonStrict PriamInstance instance1, instance2, instance3;
+            AbstractBackupPath backupPath;
+
+            {
+                pathProvider.get(); result = backupPath;
+                backupPath.getFormat(); result = AbstractBackupPath.DAY_FORMAT; times = 2;
+
+                config.getDC(); result = oldRegion; times = 2;
+                priamServer.getId(); result = identity; times = 5;
+                identity.getInstance(); result = instance; times = 5;
+                instance.getToken(); result = oldToken;
+                instance.setToken(newToken);
+
+                config.isRestoreClosestToken(); result = true;
+                instance.getToken(); result = oldToken;
+                config.getAppName(); result = appName;
+                factory.getAllIds(appName); result = ImmutableList.of(instance, instance1, instance2, instance3);
+                instance.getDC();  result = oldRegion;
+                instance.getToken(); result = oldToken;
+                instance1.getDC(); result = oldRegion;
+                instance2.getDC(); result = oldRegion;
+                instance3.getDC(); result = oldRegion;
+                instance1.getToken(); result = "1234";
+                instance2.getToken(); result = "5678";
+                instance3.getToken(); result = "9000";
+                instance.setToken((String) any); // TODO: test mocked closest token
+
+                restoreObj.restore(
+                    new DateTime(2011, 01, 01, 00, 00).toDate(),
+                    new DateTime(2011, 12, 31, 23, 59).toDate());
+  
+                config.setDC(oldRegion);
+                instance.setToken(oldToken);
+                tuneCassandra.updateYaml(false);
+            }
+        };
+
+        expectCassandraStartup();
+
+        Response response = resource.restore(dateRange, newRegion, newToken, keyspaces);
+        assertEquals(200, response.getStatus());
+        assertEquals("[\"ok\"]", response.getEntity());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMetadata().get("Content-Type").get(0));
+    }
+
+    // TODO: create CassandraController interface and inject, instead of static util method
+    private Expectations expectCassandraStartup() {
+        return new Expectations() {{
+            config.getCassStartupScript(); result = "/usr/bin/false";
+            config.getHeapNewSize(); result = "2G";
+            config.getHeapSize(); result = "8G";
+            config.getDataFileLocation(); result = "/var/lib/cassandra/data";
+            config.getCommitLogLocation(); result = "/var/lib/cassandra/commitlog";
+            config.getBackupLocation(); result = "backup";
+            config.getCacheLocation(); result = "/var/lib/cassandra/saved_caches";
+            config.getJmxPort(); result = 7199;
+            config.getMaxDirectMemory(); result = "50G";
+        }};
+    }
+}

--- a/src/test/java/com/netflix/priam/resources/CassandraConfigTest.java
+++ b/src/test/java/com/netflix/priam/resources/CassandraConfigTest.java
@@ -1,0 +1,231 @@
+package com.netflix.priam.resources;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.List;
+
+import javax.ws.rs.core.Response;
+
+import com.google.common.collect.ImmutableList;
+import com.netflix.priam.PriamServer;
+import com.netflix.priam.identity.DoubleRing;
+import com.netflix.priam.identity.InstanceIdentity;
+import com.netflix.priam.identity.PriamInstance;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.NonStrictExpectations;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class CassandraConfigTest
+{
+    private @Mocked PriamServer priamServer;
+    private @Mocked DoubleRing doubleRing;
+    private CassandraConfig resource;
+
+    @Before
+    public void setUp()
+    {
+        resource = new CassandraConfig(priamServer, doubleRing);
+    }
+
+    @Test
+    public void getSeeds() throws Exception
+    {
+        final List<String> seeds = ImmutableList.of("seed1", "seed2", "seed3");
+        new NonStrictExpectations() {
+            InstanceIdentity identity;
+
+            {
+                priamServer.getId(); result = identity; times = 2;
+                identity.getSeeds(); result = seeds; times = 2;
+            }
+        };
+
+        Response response = resource.getSeeds();
+        assertEquals(200, response.getStatus());
+        assertEquals("seed1,seed2,seed3", response.getEntity());
+    }
+
+    @Test
+    public void getSeeds_notFound() throws Exception
+    {
+        final List<String> seeds = ImmutableList.of();
+        new NonStrictExpectations() {
+            InstanceIdentity identity;
+
+            {
+                priamServer.getId(); result = identity; times = 2;
+                identity.getSeeds(); result = seeds; times = 2;
+            }
+        };
+
+        Response response = resource.getSeeds();
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void getSeeds_handlesUnknownHostException() throws Exception
+    {
+        new Expectations() {
+            InstanceIdentity identity;
+
+            {
+                priamServer.getId(); result = identity;
+                identity.getSeeds(); result = new UnknownHostException();
+            }
+        };
+
+        Response response = resource.getSeeds();
+        assertEquals(500, response.getStatus());
+    }
+
+    @Test
+    public void getToken()
+    {
+        final String token = "myToken";
+        new NonStrictExpectations() {
+            InstanceIdentity identity;
+            PriamInstance instance;
+
+            {
+                priamServer.getId(); result = identity; times = 2;
+                identity.getInstance(); result = instance; times = 2;
+                instance.getToken(); result = token; times = 2;
+            }
+        };
+
+        Response response = resource.getToken();
+        assertEquals(200, response.getStatus());
+        assertEquals(token, response.getEntity());
+    }
+
+    @Test
+    public void getToken_notFound()
+    {
+        final String token = "";
+        new NonStrictExpectations() {
+            InstanceIdentity identity;
+            PriamInstance instance;
+
+            {
+                priamServer.getId(); result = identity;
+                identity.getInstance(); result = instance;
+                instance.getToken(); result = token;
+            }
+        };
+
+        Response response = resource.getToken();
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void getToken_handlesException()
+    {
+        new NonStrictExpectations() {
+            InstanceIdentity identity;
+            PriamInstance instance;
+
+            {
+                priamServer.getId(); result = identity;
+                identity.getInstance(); result = instance;
+                instance.getToken(); result = new RuntimeException();
+            }
+        };
+
+        Response response = resource.getToken();
+        assertEquals(500, response.getStatus());
+    }
+
+    @Test
+    public void isReplaceToken()
+    {
+        new NonStrictExpectations() {
+            InstanceIdentity identity;
+
+            {
+                priamServer.getId(); result = identity;
+                identity.isReplace(); result = true;
+            }
+        };
+
+        Response response = resource.isReplaceToken();
+        assertEquals(200, response.getStatus());
+        assertEquals("true", response.getEntity());
+    }
+
+    @Test
+    public void isReplaceToken_handlesException()
+    {
+        new Expectations() {
+            InstanceIdentity identity;
+
+            {
+                priamServer.getId(); result = identity;
+                identity.isReplace(); result = new RuntimeException();
+            }
+        };
+
+        Response response = resource.isReplaceToken();
+        assertEquals(500, response.getStatus());
+    }
+
+    @Test
+    public void doubleRing() throws Exception
+    {
+        new NonStrictExpectations() {{
+            doubleRing.backup();
+            doubleRing.doubleSlots();
+        }};
+
+        Response response = resource.doubleRing();
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void doubleRing_ioExceptionInBackup() throws Exception
+    {
+        final IOException exception = new IOException();
+        new NonStrictExpectations() {{
+            doubleRing.backup(); result = exception;
+            doubleRing.restore();
+        }};
+
+        try
+        {
+          resource.doubleRing();
+          fail("Excepted RuntimeException");
+        }
+        catch (RuntimeException e)
+        {
+          assertEquals(exception, e.getCause());
+        }
+    }
+
+    @Test(expected=IOException.class)
+    public void doubleRing_ioExceptionInRestore() throws Exception
+    {
+        new NonStrictExpectations() {{
+            doubleRing.backup(); result = new IOException();
+            doubleRing.restore(); result = new IOException();
+        }};
+
+        resource.doubleRing();
+    }
+
+    @Test(expected=ClassNotFoundException.class)
+    public void doubleRing_classNotFoundExceptionInRestore() throws Exception
+    {
+        new NonStrictExpectations() {{
+            doubleRing.backup(); result = new IOException();
+            doubleRing.restore(); result = new ClassNotFoundException();
+        }};
+
+        resource.doubleRing();
+    }
+}

--- a/src/test/java/com/netflix/priam/resources/PriamInstanceResourceTest.java
+++ b/src/test/java/com/netflix/priam/resources/PriamInstanceResourceTest.java
@@ -1,0 +1,151 @@
+package com.netflix.priam.resources;
+
+import java.util.List;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+import com.google.common.collect.ImmutableList;
+import com.netflix.priam.IConfiguration;
+import com.netflix.priam.identity.IPriamInstanceFactory;
+import com.netflix.priam.identity.PriamInstance;
+
+import mockit.Expectations;
+import mockit.Mocked;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class PriamInstanceResourceTest
+{
+    private static final String APP_NAME = "myApp";
+    private static final int NODE_ID = 3;
+
+    private @Mocked IConfiguration config;
+    private @Mocked IPriamInstanceFactory factory;
+    private PriamInstanceResource resource;
+
+    @Before
+    public void setUp()
+    {
+        resource = new PriamInstanceResource(config, factory);
+    }
+
+    @Test
+    public void getInstances()
+    {
+        new Expectations() {
+            PriamInstance instance1, instance2, instance3;
+            List<PriamInstance> instances = ImmutableList.of(instance1, instance2, instance3);
+
+            {
+                config.getAppName(); result = APP_NAME;
+                factory.getAllIds(APP_NAME); result = instances;
+                instance1.toString(); result = "instance1";
+                instance2.toString(); result = "instance2";
+                instance3.toString(); result = "instance3";
+            }
+        };
+
+        assertEquals("instance1\ninstance2\ninstance3\n", resource.getInstances());
+    }
+
+    @Test
+    public void getInstance()
+    {
+        final String expected = "plain text describing the instance";
+        new Expectations() {
+            PriamInstance instance;
+
+            {
+                config.getAppName(); result = APP_NAME;
+                factory.getInstance(APP_NAME, NODE_ID); result = instance;
+                instance.toString(); result = expected;
+            }
+        };
+
+        assertEquals(expected, resource.getInstance(NODE_ID));
+    }
+
+    @Test
+    public void getInstance_notFound()
+    {
+        new Expectations() {{
+            config.getAppName(); result = APP_NAME;
+            factory.getInstance(APP_NAME, NODE_ID); result = null;
+        }};
+
+        try
+        {
+            resource.getInstance(NODE_ID);
+            fail("Expected WebApplicationException thrown");
+        } catch(WebApplicationException e)
+        {
+            assertEquals(404, e.getResponse().getStatus());
+            assertEquals("No priam instance with id " + NODE_ID + " found", e.getResponse().getEntity());
+        }
+    }
+
+    @Test
+    public void createInstance()
+    {
+        final String instanceID = "i-abc123";
+        final String hostname = "dom.com";
+        final String ip = "123.123.123.123";
+        final String rack = "us-east-1a";
+        final String token = "1234567890";
+
+        new Expectations() {
+          PriamInstance instance;
+
+          {
+              config.getAppName(); result = APP_NAME;
+              factory.create(APP_NAME, NODE_ID, instanceID, hostname, ip, rack, null, token); result = instance;
+              instance.getId(); result = NODE_ID;
+          }
+        };
+
+        Response response = resource.createInstance(NODE_ID, instanceID, hostname, ip, rack, token);
+        assertEquals(201, response.getStatus());
+        assertEquals("/"+NODE_ID, response.getMetadata().getFirst("location").toString());
+    }
+
+    @Test
+    public void deleteInstance()
+    {
+        new Expectations() {
+          PriamInstance instance;
+
+          {
+              config.getAppName(); result = APP_NAME;
+              factory.getInstance(APP_NAME, NODE_ID); result = instance;
+              factory.delete(instance);
+          }
+        };
+
+        Response response = resource.deleteInstance(NODE_ID);
+        assertEquals(204, response.getStatus());
+    }
+
+    @Test
+    public void deleteInstance_notFound()
+    {
+        new Expectations() {{
+            config.getAppName(); result = APP_NAME;
+            factory.getInstance(APP_NAME, NODE_ID); result = null;
+        }};
+
+        try
+        {
+            resource.getInstance(NODE_ID);
+            fail("Expected WebApplicationException thrown");
+        } catch(WebApplicationException e)
+        {
+            assertEquals(404, e.getResponse().getStatus());
+            assertEquals("No priam instance with id " + NODE_ID + " found", e.getResponse().getEntity());
+        }
+    }
+}


### PR DESCRIPTION
Adds a new REST endpoint to list/view/create/update priam instances in SimpleDB. Required adding a new method to the PriamInstanceFactory that calls through to the InstanceData DAO.

Also added unit tests for most of the existing endpoints (resources). CassandraAdmin isn't easy to unit test because it relies directly on JMXNodeTool singleton. Will need to refactor that before we can write tests for it.
