### PR TITLE
Support for CloudFormation ASG Names and EC2 Security Group Configuration

### DIFF
--- a/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/src/main/java/com/netflix/priam/IConfiguration.java
@@ -200,6 +200,11 @@ public interface IConfiguration
      * Amazon specific setting to query ASG Membership
      */
     public String getASGName();
+    
+    /**
+     * Get the security group associated with nodes in this cluster
+     */
+    public String getACLGroupName();
 
     /**
      * @return true if incremental backups are enabled

--- a/src/main/java/com/netflix/priam/aws/AWSMembership.java
+++ b/src/main/java/com/netflix/priam/aws/AWSMembership.java
@@ -111,7 +111,7 @@ public class AWSMembership implements IMembership
             client = getEc2Client();
             List<IpPermission> ipPermissions = new ArrayList<IpPermission>();
             ipPermissions.add(new IpPermission().withFromPort(from).withIpProtocol("tcp").withIpRanges(listIPs).withToPort(to));
-            client.authorizeSecurityGroupIngress(new AuthorizeSecurityGroupIngressRequest(config.getAppName(), ipPermissions));
+            client.authorizeSecurityGroupIngress(new AuthorizeSecurityGroupIngressRequest(config.getACLGroupName(), ipPermissions));
             logger.info("Done adding ACL to: " + StringUtils.join(listIPs, ","));
         }
         finally
@@ -132,7 +132,7 @@ public class AWSMembership implements IMembership
             client = getEc2Client();
             List<IpPermission> ipPermissions = new ArrayList<IpPermission>();
             ipPermissions.add(new IpPermission().withFromPort(from).withIpProtocol("tcp").withIpRanges(listIPs).withToPort(to));
-            client.revokeSecurityGroupIngress(new RevokeSecurityGroupIngressRequest(config.getAppName(), ipPermissions));
+            client.revokeSecurityGroupIngress(new RevokeSecurityGroupIngressRequest(config.getACLGroupName(), ipPermissions));
         }
         finally
         {
@@ -151,7 +151,7 @@ public class AWSMembership implements IMembership
         {
             client = getEc2Client();
             List<String> ipPermissions = new ArrayList<String>();
-            DescribeSecurityGroupsRequest req = new DescribeSecurityGroupsRequest().withGroupNames(Arrays.asList(config.getAppName()));
+            DescribeSecurityGroupsRequest req = new DescribeSecurityGroupsRequest().withGroupNames(Arrays.asList(config.getACLGroupName()));
             DescribeSecurityGroupsResult result = client.describeSecurityGroups(req);
             for (SecurityGroup group : result.getSecurityGroups())
                 for (IpPermission perm : group.getIpPermissions())

--- a/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -85,6 +85,7 @@ public class PriamConfiguration implements IConfiguration
     // Amazon specific
     private static final String CONFIG_ASG_NAME = PRIAM_PRE + ".az.asgname";
     private static final String CONFIG_REGION_NAME = PRIAM_PRE + ".az.region";
+    private static final String CONFIG_ACL_GROUP_NAME = PRIAM_PRE + ".acl.groupname";
     private final String RAC = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/placement/availability-zone");
     private final String PUBLIC_HOSTNAME = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/public-hostname");
     private final String PUBLIC_IP = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/public-ipv4");
@@ -92,7 +93,7 @@ public class PriamConfiguration implements IConfiguration
     private final String INSTANCE_TYPE = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/instance-type");
     private static String ASG_NAME = System.getenv("ASG_NAME");
     private static String REGION = System.getenv("EC2_REGION");
-
+    
     // Defaults 
     private final String DEFAULT_CLUSTER_NAME = "cass_cluster";
     private final String DEFAULT_DATA_LOCATION = "/var/lib/cassandra/data";
@@ -193,7 +194,7 @@ public class PriamConfiguration implements IConfiguration
         }
         return null;
     }
-    
+
     /**
      * Get the fist 3 available zones in the region 
      */
@@ -483,6 +484,12 @@ public class PriamConfiguration implements IConfiguration
     public String getASGName()
     {
         return config.getProperty(CONFIG_ASG_NAME, "");
+    }
+    
+    @Override
+    public String getACLGroupName()
+    {
+    	return config.getProperty(CONFIG_ACL_GROUP_NAME, this.getAppName());
     }
 
     @Override

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -2,7 +2,7 @@ log4j.debug=TRUE
 log4j.rootLogger=INFO, R, stdout
 
 log4j.appender.R=org.apache.log4j.RollingFileAppender
-log4j.appender.R.File=${catalina.home}/logs/tomcat.log
+log4j.appender.R.File=/var/log/tomcat7/priam.log
 log4j.appender.R.MaxFileSize=5MB
 log4j.appender.R.MaxBackupIndex=5
 log4j.appender.R.layout=org.apache.log4j.PatternLayout

--- a/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -153,6 +153,12 @@ public class FakeConfiguration implements IConfiguration
     }
 
     @Override
+    public String getACLGroupName()
+    {
+        return this.getAppName();
+    }
+
+    @Override
     public int getMaxBackupUploadThreads()
     {
         // TODO Auto-generated method stub


### PR DESCRIPTION
The ASG naming scheme was using that part before last segment of the ASG name splited by '-'. CloudFormation does not allow '-' in ASG naming, however if you name your ASG's like 'useast1' and then use appId as your Stack name, it will create an ASG name like appId-useast1-{some_random_string} which is very close to what Priam wants except the last part. If we alway assume the first part of this before the first '-' is the appId, we are good. I have change the method to extract that appId that way.

It would be nice to be able to have security groups named different that your app. I made it configurable in SimpleDB.
