### PR TITLE
Support for Cassandra 1.1 Backup Directory Structure

### DIFF
--- a/src/main/java/com/netflix/priam/backup/AbstractBackup.java
+++ b/src/main/java/com/netflix/priam/backup/AbstractBackup.java
@@ -48,9 +48,6 @@ public abstract class AbstractBackup extends Task
         {
             final AbstractBackupPath bp = pathFactory.get();
             bp.parseLocal(file, type);
-            String[] cfPrefix = bp.fileName.split("-");
-            if (cfPrefix.length > 1 && FILTER_COLUMN_FAMILY.contains(cfPrefix[0]))
-                continue;
             upload(bp);
             bps.add(bp);
             file.delete();
@@ -77,12 +74,15 @@ public abstract class AbstractBackup extends Task
     /**
      * Filters unwanted keyspaces and column families
      */
-    public boolean isValidBackupDir(File keyspaceDir, File backupDir)
+    public boolean isValidBackupDir(File keyspaceDir, File columnFamilyDir, File backupDir)
     {
         if (!backupDir.isDirectory() && !backupDir.exists())
             return false;
         String keyspaceName = keyspaceDir.getName();
         if (FILTER_KEYSPACE.contains(keyspaceName))
+            return false;
+        String columnFamilyName = columnFamilyDir.getName();
+        if (FILTER_COLUMN_FAMILY.contains(columnFamilyName))
             return false;
         return true;
     }

--- a/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
+++ b/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
@@ -74,7 +74,7 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
         if (type != BackupFileType.META && type != BackupFileType.CL)
             this.keyspace = elements[0];
         if (type == BackupFileType.SNAP)
-            time = DAY_FORMAT.parse(elements[2]);
+            time = DAY_FORMAT.parse(elements[3]);
         if (type == BackupFileType.SST || type == BackupFileType.CL)
             time = new Date(file.lastModified());
         this.fileName = file.getName();

--- a/src/main/java/com/netflix/priam/backup/IncrementalBackup.java
+++ b/src/main/java/com/netflix/priam/backup/IncrementalBackup.java
@@ -35,10 +35,13 @@ public class IncrementalBackup extends AbstractBackup
         logger.debug("Scanning for backup in: " + dataDir.getAbsolutePath());
         for (File keyspaceDir : dataDir.listFiles())
         {
-            File backupDir = new File(keyspaceDir, "backups");
-            if (!isValidBackupDir(keyspaceDir, backupDir))
-                continue;
-            upload(backupDir, BackupFileType.SST);
+            for (File columnFamilyDir : keyspaceDir.listFiles())
+            {
+                File backupDir = new File(columnFamilyDir, "backups");
+                if (!isValidBackupDir(keyspaceDir, columnFamilyDir, backupDir))
+                    continue;
+                upload(backupDir, BackupFileType.SST);
+            }
         }
     }
 

--- a/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
+++ b/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
@@ -49,16 +49,18 @@ public class SnapshotBackup extends AbstractBackup
             // Collect all snapshot dir's under keyspace dir's
             List<AbstractBackupPath> bps = Lists.newArrayList();
             File dataDir = new File(config.getDataFileLocation());
-            File[] keyspaceDirs = dataDir.listFiles();
-            for (File keyspaceDir : keyspaceDirs)
+            for (File keyspaceDir : dataDir.listFiles())
             {
-                File snpDir = new File(keyspaceDir, "snapshots");
-                if (!isValidBackupDir(keyspaceDir, snpDir))
-                    continue;
-                File snapshotDir = getValidSnapshot(keyspaceDir, snpDir, snapshotName);
-                // Add files to this dir
-                if (null != snapshotDir)
-                    bps.addAll(upload(snapshotDir, BackupFileType.SNAP));
+                for (File columnFamilyDir : keyspaceDir.listFiles())
+                {
+                    File snpDir = new File(columnFamilyDir, "snapshots");
+                    if (!isValidBackupDir(keyspaceDir, columnFamilyDir, snpDir))
+                        continue;
+                    File snapshotDir = getValidSnapshot(columnFamilyDir, snpDir, snapshotName);
+                    // Add files to this dir
+                    if (null != snapshotDir)
+                        bps.addAll(upload(snapshotDir, BackupFileType.SNAP));
+                }
             }
             // Upload meta file
             metaData.set(bps, snapshotName);
@@ -77,7 +79,7 @@ public class SnapshotBackup extends AbstractBackup
         }
     }
 
-    private File getValidSnapshot(File keyspaceDir, File snpDir, String snapshotName)
+    private File getValidSnapshot(File columnFamilyDir, File snpDir, String snapshotName)
     {
         for (File snapshotDir : snpDir.listFiles())
             if (snapshotDir.getName().matches(snapshotName))


### PR DESCRIPTION
- Cassandra 1.1 stores backup and snapshot per ColumnFamily dir.
  This change needed for Priam so that it could look into right
  directoried for backup/snapshot files
