### PR TITLE
Fix appId determinition by ASG

### DIFF
--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -223,7 +223,7 @@ public class PriamConfiguration implements IConfiguration
         config.put(CONFIG_ASG_NAME, ASG_NAME);
         config.put(CONFIG_REGION_NAME, REGION);
         String nextToken = null;
-        String appid = ASG_NAME.lastIndexOf('-') > 0 ? ASG_NAME.substring(0, ASG_NAME.indexOf('-')): ASG_NAME;
+        String appid = ASG_NAME.lastIndexOf('-') > 0 ? ASG_NAME.substring(0, ASG_NAME.lastIndexOf('-')): ASG_NAME;
         logger.info(String.format("appid used to fetch properties is: %s",appid));
         do
         {


### PR DESCRIPTION
`some-long-group-name-ZONE` availability zone corresponds to `some-long-group-name` app id, not `some` app id
