### PR TITLE
Added ColumnFamily name to backup path

### DIFF
--- a/gradle/netflix-oss.gradle
+++ b/gradle/netflix-oss.gradle
@@ -23,7 +23,7 @@ rootProject {
         def cassDep = deps.find { it.group == 'org.apache.cassandra' && it.name == 'cassandra-all' }
         if (cassDep != null) {
             deps.remove(cassDep)
-            project.dependencies.add('compile', 'apache-cassandra:apache-cassandra:1.1.4.0') // 1.1.2 no longer has OutputHandler
+            project.dependencies.add('compile', 'apache-cassandra:apache-cassandra:1.1.5.0') // 1.1.2 no longer has OutputHandler
             project.dependencies.add('compile', 'edu.stanford.ppl:snaptree:0.1') 
             project.dependencies.add('compile', 'com.yammer.metrics:metrics-core:2.0.3') 
             project.dependencies.add('compile', 'libthrift:libthrift:0.7.0') 

--- a/priam/src/main/java/com/netflix/priam/aws/S3BackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3BackupPath.java
@@ -23,7 +23,7 @@ public class S3BackupPath extends AbstractBackupPath
 
     /**
      * Format of backup path:
-     * BASE/REGION/CLUSTER/TOKEN/[SNAPSHOTTIME]/[SST|SNP|META]/KEYSPACE/FILE
+     * BASE/REGION/CLUSTER/TOKEN/[SNAPSHOTTIME]/[SST|SNP|META]/KEYSPACE/COLUMNFAMILY/FILE
      */
     @Override
     public String getRemotePath()
@@ -36,7 +36,7 @@ public class S3BackupPath extends AbstractBackupPath
         buff.append(getFormat().format(time)).append(S3BackupPath.PATH_SEP);
         buff.append(type).append(S3BackupPath.PATH_SEP);
         if (type != BackupFileType.META && type != BackupFileType.CL)
-            buff.append(keyspace).append(S3BackupPath.PATH_SEP);
+            buff.append(keyspace).append(S3BackupPath.PATH_SEP).append(columnFamily).append(S3BackupPath.PATH_SEP);
         buff.append(fileName);
         return buff.toString();
     }
@@ -65,6 +65,7 @@ public class S3BackupPath extends AbstractBackupPath
             if (type != BackupFileType.META && type != BackupFileType.CL)
             {
                 keyspace = pieces.get(6);
+                columnFamily = pieces.get(7);
             }
             // append the rest
             fileName = pieces.get(pieces.size() - 1);

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileIterator.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileIterator.java
@@ -34,7 +34,7 @@ public class S3FileIterator implements Iterator<AbstractBackupPath>
         this.till = till;
         this.pathProvider = pathProvider;
         ListObjectsRequest listReq = new ListObjectsRequest();
-        String[] paths = path.split(String.valueOf(S3BackupPath.PATH_SEP));        
+        String[] paths = path.split(String.valueOf(S3BackupPath.PATH_SEP));
         listReq.setBucketName(paths[0]);
         listReq.setPrefix(pathProvider.get().remotePrefix(start, till, path));
         this.s3Client = s3Client;
@@ -53,7 +53,7 @@ public class S3FileIterator implements Iterator<AbstractBackupPath>
         {
             while(objectListing.isTruncated() && !iterator.hasNext()) 
             {
-                objectListing = s3Client.listNextBatchOfObjects(objectListing);                
+                objectListing = s3Client.listNextBatchOfObjects(objectListing);
                 iterator = createIterator();
             }
 

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
@@ -30,6 +30,7 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
     protected BackupFileType type;
     protected String clusterName;
     protected String keyspace;
+    protected String columnFamily;
     protected String fileName;
     protected String baseDir;
     protected String token;
@@ -71,7 +72,10 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
         this.token = factory.getInstance().getToken();
         this.type = type;
         if (type != BackupFileType.META && type != BackupFileType.CL)
+        {
             this.keyspace = elements[0];
+            this.columnFamily = elements[1];
+        }
         if (type == BackupFileType.SNAP)
             time = DAY_FORMAT.parse(elements[3]);
         if (type == BackupFileType.SST || type == BackupFileType.CL)
@@ -102,7 +106,7 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
         StringBuffer buff = new StringBuffer();
         buff.append(config.getDataFileLocation()).append(PATH_SEP);
         if (type != BackupFileType.META)
-            buff.append(keyspace).append(PATH_SEP);
+            buff.append(keyspace).append(PATH_SEP).append(columnFamily).append(PATH_SEP);
         buff.append(fileName);
         File return_ = new File(buff.toString());
         File parent = new File(return_.getParent());
@@ -164,6 +168,11 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
     public String getKeyspace()
     {
         return keyspace;
+    }
+
+    public String getColumnFamily()
+    {
+        return columnFamily;
     }
 
     public String getFileName()

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractRestore.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractRestore.java
@@ -79,7 +79,7 @@ public abstract class AbstractRestore extends Task
             @Override
             public Integer retriableCall() throws Exception
             {
-                logger.info("Downloading file: " + path);
+                logger.info("Downloading file: " + path + " to: " + restoreLocation);
                 fs.download(path, new FileOutputStream(restoreLocation));
                 tracker.adjustAndAdd(path);
                 // TODO: fix me -> if there is exception the why hang?

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -274,7 +274,7 @@ public class FakeConfiguration implements IConfiguration
     public String getCassStartupScript()
     {
         // TODO Auto-generated method stub
-        return null;
+        return "true";
     }
 
     @Override
@@ -307,7 +307,7 @@ public class FakeConfiguration implements IConfiguration
     @Override
     public String getCassStopScript()
     {
-        return "teststopscript";
+        return "yes";
     }
 
     @Override

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackupFile.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackupFile.java
@@ -66,11 +66,12 @@ public class TestBackupFile
         backupfile.parseLocal(new File(snapshotfile), BackupFileType.SNAP);
         Assert.assertEquals(BackupFileType.SNAP, backupfile.type);
         Assert.assertEquals("Keyspace1", backupfile.keyspace);
+        Assert.assertEquals("Standard1", backupfile.columnFamily);
         Assert.assertEquals("1234567", backupfile.token);
         Assert.assertEquals("fake-app", backupfile.clusterName);
         Assert.assertEquals("fake-region", backupfile.region);
         Assert.assertEquals("casstestbackup", backupfile.baseDir);
-        Assert.assertEquals("casstestbackup/fake-region/fake-app/1234567/201108082320/SNAP/Keyspace1/Keyspace1-Standard1-ia-5-Data.db", backupfile.getRemotePath());
+        Assert.assertEquals("casstestbackup/fake-region/fake-app/1234567/201108082320/SNAP/Keyspace1/Standard1/Keyspace1-Standard1-ia-5-Data.db", backupfile.getRemotePath());
     }
 
     @Test
@@ -82,12 +83,13 @@ public class TestBackupFile
         backupfile.parseLocal(bfile, BackupFileType.SST);
         Assert.assertEquals(BackupFileType.SST, backupfile.type);
         Assert.assertEquals("Keyspace1", backupfile.keyspace);
+        Assert.assertEquals("Standard1", backupfile.columnFamily);
         Assert.assertEquals("1234567", backupfile.token);
         Assert.assertEquals("fake-app", backupfile.clusterName);
         Assert.assertEquals("fake-region", backupfile.region);
         Assert.assertEquals("casstestbackup", backupfile.baseDir);
         String datestr = AbstractBackupPath.DAY_FORMAT.format(new Date(bfile.lastModified()));
-        Assert.assertEquals("casstestbackup/fake-region/fake-app/1234567/" + datestr + "/SST/Keyspace1/Keyspace1-Standard1-ia-5-Data.db", backupfile.getRemotePath());
+        Assert.assertEquals("casstestbackup/fake-region/fake-app/1234567/" + datestr + "/SST/Keyspace1/Standard1/Keyspace1-Standard1-ia-5-Data.db", backupfile.getRemotePath());
     }
 
     @Test

--- a/priam/src/test/java/com/netflix/priam/backup/TestFileIterator.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestFileIterator.java
@@ -52,7 +52,7 @@ public class TestFileIterator
         injector = Guice.createInjector(new BRTestModule());
         conf = injector.getInstance(IConfiguration.class);
         factory = injector.getInstance(InstanceIdentity.class);
-        
+
         Mockit.setUpMock(AmazonS3Client.class, MockAmazonS3Client.class);
         Mockit.setUpMock(ObjectListing.class, MockObjectListing.class);
         s3client = new AmazonS3Client();
@@ -161,10 +161,10 @@ public class TestFileIterator
         while (fileIterator.hasNext())
             files.add(fileIterator.next().getRemotePath());
         Assert.assertEquals(3, files.size());
-        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110030/SNAP/ks1/f1.db"));
-        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110430/SST/ks1/f2.db"));
+        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110030/SNAP/ks1/cf1/f1.db"));
+        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110430/SST/ks1/cf1/f2.db"));
         Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110030/META/meta.json"));
-        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201108110600/SST/ks1/f3.db"));
+        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201108110600/SST/ks1/cf1/f3.db"));
     }
 
     @Test
@@ -182,14 +182,14 @@ public class TestFileIterator
         while (fileIterator.hasNext())
             files.add(fileIterator.next().getRemotePath());
         Assert.assertEquals(5, files.size());
-        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110030/SNAP/ks1/f1.db"));
-        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110430/SST/ks1/f2.db"));
+        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110030/SNAP/ks1/cf1/f1.db"));
+        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110430/SST/ks1/cf1/f2.db"));
         Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110030/META/meta.json"));
-        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201108110600/SST/ks1/f3.db"));
+        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201108110600/SST/ks1/cf1/f3.db"));
 
-        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110030/SNAP/ks2/f1.db"));
-        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110430/SST/ks2/f2.db"));
-        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201108110600/SST/ks2/f3.db"));
+        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110030/SNAP/ks2/cf1/f1.db"));
+        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110430/SST/ks2/cf1/f2.db"));
+        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201108110600/SST/ks2/cf1/f3.db"));
 
     }
 
@@ -208,14 +208,14 @@ public class TestFileIterator
         while (fileIterator.hasNext())
             files.add(fileIterator.next().getRemotePath());
         Assert.assertEquals(2, files.size());
-        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201107110030/SNAP/ks1/f1.db"));
-        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201107110430/SST/ks1/f2.db"));
+        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201107110030/SNAP/ks1/cf1/f1.db"));
+        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201107110430/SST/ks1/cf1/f2.db"));
         Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201107110030/META/meta.json"));
-        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201107110600/SST/ks1/f3.db"));
+        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201107110600/SST/ks1/cf1/f3.db"));
 
-        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110030/SNAP/ks2/f1.db"));
-        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110430/SST/ks2/f2.db"));
-        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201108110600/SST/ks2/f3.db"));
+        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110030/SNAP/ks2/cf1/f1.db"));
+        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110430/SST/ks2/cf1/f2.db"));
+        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201108110600/SST/ks2/cf1/f3.db"));
         
     }
 
@@ -237,14 +237,14 @@ public class TestFileIterator
             files.add(fileIterator.next().getRemotePath());
 
         Assert.assertEquals(5, files.size());
-        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110030/SNAP/ks1/f1.db"));
-        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110430/SST/ks1/f2.db"));
+        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110030/SNAP/ks1/cf1/f1.db"));
+        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110430/SST/ks1/cf1/f2.db"));
         Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110030/META/meta.json"));
-        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201108110600/SST/ks1/f3.db"));
+        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201108110600/SST/ks1/cf1/f3.db"));
 
-        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110030/SNAP/ks2/f1.db"));
-        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110430/SST/ks2/f2.db"));
-        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201108110600/SST/ks2/f3.db"));
+        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110030/SNAP/ks2/cf1/f1.db"));
+        Assert.assertTrue(files.contains("test_backup/fake-region/fakecluster/123456/201108110430/SST/ks2/cf1/f2.db"));
+        Assert.assertFalse(files.contains("test_backup/fake-region/fakecluster/123456/201108110600/SST/ks2/cf1/f3.db"));
 
     }
 
@@ -252,13 +252,13 @@ public class TestFileIterator
     {
         List<S3ObjectSummary> list = new ArrayList<S3ObjectSummary>();
         S3ObjectSummary summary = new S3ObjectSummary();
-        summary.setKey("test_backup/fake-region/fakecluster/123456/201108110030/SNAP/ks1/f1.db");
+        summary.setKey("test_backup/fake-region/fakecluster/123456/201108110030/SNAP/ks1/cf1/f1.db");
         list.add(summary);
         summary = new S3ObjectSummary();
-        summary.setKey("test_backup/fake-region/fakecluster/123456/201108110430/SST/ks1/f2.db");
+        summary.setKey("test_backup/fake-region/fakecluster/123456/201108110430/SST/ks1/cf1/f2.db");
         list.add(summary);
         summary = new S3ObjectSummary();
-        summary.setKey("test_backup/fake-region/fakecluster/123456/201108110600/SST/ks1/f3.db");
+        summary.setKey("test_backup/fake-region/fakecluster/123456/201108110600/SST/ks1/cf1/f3.db");
         list.add(summary);
         summary = new S3ObjectSummary();
         summary.setKey("test_backup/fake-region/fakecluster/123456/201108110030/META/meta.json");
@@ -276,13 +276,13 @@ public class TestFileIterator
     {
         List<S3ObjectSummary> list = new ArrayList<S3ObjectSummary>();
         S3ObjectSummary summary = new S3ObjectSummary();
-        summary.setKey("test_backup/fake-region/fakecluster/123456/201108110030/SNAP/ks2/f1.db");
+        summary.setKey("test_backup/fake-region/fakecluster/123456/201108110030/SNAP/ks2/cf1/f1.db");
         list.add(summary);
         summary = new S3ObjectSummary();
-        summary.setKey("test_backup/fake-region/fakecluster/123456/201108110430/SST/ks2/f2.db");
+        summary.setKey("test_backup/fake-region/fakecluster/123456/201108110430/SST/ks2/cf1/f2.db");
         list.add(summary);
         summary = new S3ObjectSummary();
-        summary.setKey("test_backup/fake-region/fakecluster/123456/201108110600/SST/ks2/f3.db");
+        summary.setKey("test_backup/fake-region/fakecluster/123456/201108110600/SST/ks2/cf1/f3.db");
         list.add(summary);
         return list;
     }

--- a/priam/src/test/java/com/netflix/priam/backup/TestRestore.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestRestore.java
@@ -27,7 +27,7 @@ public class TestRestore
     private static ArrayList<String> fileList;
     private static Calendar cal;    
     private static IConfiguration conf;
-    
+
     @BeforeClass
     public static void setup() throws InterruptedException, IOException
     {
@@ -50,19 +50,19 @@ public class TestRestore
     public static void populateBackupFileSystem(String baseDir){
         fileList.clear();
         fileList.add(baseDir + "/fake-region/fakecluster/123456/201108110030/META/meta.json");
-        fileList.add(baseDir + "/fake-region/fakecluster/123456/201108110030/SNAP/ks1/f1.db");
-        fileList.add(baseDir + "/fake-region/fakecluster/123456/201108110030/SNAP/ks1/f2.db");
-        fileList.add(baseDir + "/fake-region/fakecluster/123456/201108110030/SNAP/ks2/f2.db");
-        fileList.add(baseDir + "/fake-region/fakecluster/123456/201108110530/SST/ks2/f3.db");
-        fileList.add(baseDir + "/fake-region/fakecluster/123456/201108110600/SST/ks2/f4.db");
+        fileList.add(baseDir + "/fake-region/fakecluster/123456/201108110030/SNAP/ks1/cf1/f1.db");
+        fileList.add(baseDir + "/fake-region/fakecluster/123456/201108110030/SNAP/ks1/cf1/f2.db");
+        fileList.add(baseDir + "/fake-region/fakecluster/123456/201108110030/SNAP/ks2/cf1/f2.db");
+        fileList.add(baseDir + "/fake-region/fakecluster/123456/201108110530/SST/ks2/cf1/f3.db");
+        fileList.add(baseDir + "/fake-region/fakecluster/123456/201108110600/SST/ks2/cf1/f4.db");
         filesystem.baseDir = baseDir;
         filesystem.region = "fake-region";
         filesystem.clusterName = "fakecluster";
         filesystem.setupTest(fileList);
     }
-    
+
     @Test
-    public void testRestore() throws Exception 
+    public void testRestore() throws Exception
     {
         populateBackupFileSystem("test_backup");
         File tmpdir = new File(conf.getDataFileLocation() + "/test");
@@ -86,7 +86,7 @@ public class TestRestore
 
     //Pick latest file
     @Test 
-    public void testRestoreLatest() throws Exception 
+    public void testRestoreLatest() throws Exception
     {
         populateBackupFileSystem("test_backup");
         String metafile = "test_backup/fake-region/fakecluster/123456/201108110130/META/meta.json";
@@ -107,11 +107,11 @@ public class TestRestore
     }
 
     @Test
-    public void testNoSnapshots() throws Exception 
+    public void testNoSnapshots() throws Exception
     {
-        try {        
+        try {
             filesystem.setupTest(new ArrayList<String>());
-            Restore restore = injector.getInstance(Restore.class);            
+            Restore restore = injector.getInstance(Restore.class);
             cal.set(2011, 8, 11, 0, 30);
             Date startTime = cal.getTime();
             cal.add(Calendar.HOUR, 5);

--- a/priam/src/test/java/com/netflix/priam/stream/StreamingTest.java
+++ b/priam/src/test/java/com/netflix/priam/stream/StreamingTest.java
@@ -51,33 +51,33 @@ public class StreamingTest
         for (int i = 10; i < 30; i++)
         {
             S3BackupPath path = new S3BackupPath(conf, factory);
-            path.parseRemote("test_backup/fake-region/fakecluster/123456/201108" + i + "0000" + "/SNAP/ks1/f1" + i + ".db");
+            path.parseRemote("test_backup/fake-region/fakecluster/123456/201108" + i + "0000" + "/SNAP/ks1/cf2/f1" + i + ".db");
             queue.adjustAndAdd(path);
         }
 
         for (int i = 10; i < 30; i++)
         {
             S3BackupPath path = new S3BackupPath(conf, factory);
-            path.parseRemote("test_backup/fake-region/fakecluster/123456/201108" + i + "0000" + "/SNAP/ks1/f2" + i + ".db");
+            path.parseRemote("test_backup/fake-region/fakecluster/123456/201108" + i + "0000" + "/SNAP/ks1/cf2/f2" + i + ".db");
             queue.adjustAndAdd(path);
         }
 
         for (int i = 10; i < 30; i++)
         {
             S3BackupPath path = new S3BackupPath(conf, factory);
-            path.parseRemote("test_backup/fake-region/fakecluster/123456/201108" + i + "0000" + "/SNAP/ks1/f3" + i + ".db");
+            path.parseRemote("test_backup/fake-region/fakecluster/123456/201108" + i + "0000" + "/SNAP/ks1/cf2/f3" + i + ".db");
             queue.adjustAndAdd(path);
         }
 
         S3BackupPath path = new S3BackupPath(conf, factory);
-        path.parseRemote("test_backup/fake-region/fakecluster/123456/201108290000" + "/SNAP/ks1/f129.db");
+        path.parseRemote("test_backup/fake-region/fakecluster/123456/201108290000" + "/SNAP/ks1/cf2/f129.db");
         Assert.assertTrue(queue.contains(path));
-        path.parseRemote("test_backup/fake-region/fakecluster/123456/201108290000" + "/SNAP/ks1/f229.db");
+        path.parseRemote("test_backup/fake-region/fakecluster/123456/201108290000" + "/SNAP/ks1/cf2/f229.db");
         Assert.assertTrue(queue.contains(path));
-        path.parseRemote("test_backup/fake-region/fakecluster/123456/201108290000" + "/SNAP/ks1/f329.db");
+        path.parseRemote("test_backup/fake-region/fakecluster/123456/201108290000" + "/SNAP/ks1/cf2/f329.db");
         Assert.assertTrue(queue.contains(path));
 
-        path.parseRemote("test_backup/fake-region/fakecluster/123456/201108260000/SNAP/ks1/f326.db To: cass/data/ks1/f326.db");
+        path.parseRemote("test_backup/fake-region/fakecluster/123456/201108260000/SNAP/ks1/cf2/f326.db To: cass/data/ks1/cf2/f326.db");
         Assert.assertEquals(path, queue.first());
     }
 


### PR DESCRIPTION
My previous commit which fixed the lookup of SSTable files on 1.1.x filesystem
for backup did not take into account the fact that directory higherarchy now
includes the column families in 1.1.x and for backup and restore to be able to
work properly we should include the ColumnFamily name in the path. This patch
addresses that issue.

Backups made to S3 using the master branch so far aren't restorable to correct
location. I recommend changing backups prefix after upgrade to this patch so
that your new backup location includes the correct directory structure.

This patch also enable future development possibilities to add restoration of
a specific column family only. I didn't have time to implement that yet, but I
will be glad to add the feature once time allows.

Main things changed in this patch:
- S3BackupPath and AbstractBackupPath now include the CF name;
- AbstractRestore is changed to respect the CF name addition;
- All instances of Unit Tests updated to have CF names in the paths;

Secondary Changes:
- Tests were not passing for me because the configured Cassandra start/stop
  script in FakeConfiguration was something junk that didn't exist and
  SystemUtils would get ArrayOutOfBound because of it. I changed them to
  return program "yes" which should be exist on all nix systems. This made
  the steps in TestRestore that stops/starts fake cassandra to fall through.
- Updated Cassandra source dependency to 1.1.5
