### PR TITLE
Minor fix for writing out the global cache properties.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 // Establish version and status
-ext.releaseVersion = '1.1.7'
+ext.releaseVersion = '1.1.8'
 ext.githubProjectName = 'Priam'
 
 buildscript {

--- a/priam/src/main/java/com/netflix/priam/utils/TuneCassandra.java
+++ b/priam/src/main/java/com/netflix/priam/utils/TuneCassandra.java
@@ -102,21 +102,21 @@ public class TuneCassandra extends Task
         final String keyCacheSize = config.getKeyCacheSizeInMB();
         if(keyCacheSize != null)
         {
-            yaml.put("key_cache_size_in_mb", keyCacheSize);
+            yaml.put("key_cache_size_in_mb", Integer.valueOf(keyCacheSize));
 
             final String keyCount = config.getKeyCacheKeysToSave();
             if(keyCount != null)
-                yaml.put("key_cache_keys_to_save", keyCount);
+                yaml.put("key_cache_keys_to_save", Integer.valueOf(keyCount));
         }
 
         final String rowCacheSize = config.getRowCacheSizeInMB();
         if(rowCacheSize != null)
         {
-            yaml.put("row_cache_size_in_mb", rowCacheSize);
+            yaml.put("row_cache_size_in_mb", Integer.valueOf(rowCacheSize));
 
             final String rowCount = config.getRowCacheKeysToSave();
             if(rowCount != null)
-                yaml.put("row_cache_keys_to_save", rowCount);
+                yaml.put("row_cache_keys_to_save", Integer.valueOf(rowCount));
         }
     }
 


### PR DESCRIPTION
AS it was writing out a string (rather than an int),

the extry in the yaml woud like like (after serialized being by snake yaml):

key_cache_size_in_mb: '100' (with the single quote)

Luckily, cassandra, using snake yaml, didn't have a problem read the value. But, for cleanliness,
am switching it do do the right thing.
