### PR TITLE
Replace SDF with joda-time; catch exceptions in the middle of backup process

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backup/MetaData.java
+++ b/priam/src/main/java/com/netflix/priam/backup/MetaData.java
@@ -55,7 +55,7 @@ public class MetaData
         }
         AbstractBackupPath backupfile = pathFactory.get();
         backupfile.parseLocal(metafile, BackupFileType.META);
-        backupfile.time = backupfile.getFormat().parse(snapshotName);
+        backupfile.time = backupfile.parseDate(snapshotName);
         try
         {
             upload(backupfile);

--- a/priam/src/main/java/com/netflix/priam/backup/Restore.java
+++ b/priam/src/main/java/com/netflix/priam/backup/Restore.java
@@ -55,8 +55,8 @@ public class Restore extends AbstractRestore
             logger.info("Starting restore for " + config.getRestoreSnapshot());
             String[] restore = config.getRestoreSnapshot().split(",");
             AbstractBackupPath path = pathProvider.get();
-            final Date startTime = path.getFormat().parse(restore[0]);
-            final Date endTime = path.getFormat().parse(restore[1]);
+            final Date startTime = path.parseDate(restore[0]);
+            final Date endTime = path.parseDate(restore[1]);
             String origToken = id.getInstance().getToken();
             try
             {

--- a/priam/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
@@ -41,7 +41,7 @@ public class SnapshotBackup extends AbstractBackup
     public void execute() throws Exception
     {
         Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
-        String snapshotName = pathFactory.get().getFormat().format(cal.getTime());
+        String snapshotName = pathFactory.get().formatDate(cal.getTime());
         try
         {
             logger.info("Starting snapshot " + snapshotName);

--- a/priam/src/main/java/com/netflix/priam/cli/Restorer.java
+++ b/priam/src/main/java/com/netflix/priam/cli/Restorer.java
@@ -1,13 +1,12 @@
 package com.netflix.priam.cli;
 
 import java.util.Date;
-import java.text.ParseException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.netflix.priam.backup.Restore;
 import com.netflix.priam.backup.AbstractBackupPath;
+import com.netflix.priam.backup.Restore;
 
 public class Restorer
 {
@@ -30,17 +29,9 @@ public class Restorer
                 displayHelp();
                 return;
             }
-            try
-            {
-                AbstractBackupPath path = Application.getInjector().getInstance(AbstractBackupPath.class);
-                startTime = path.getFormat().parse(args[0]);
-                endTime = path.getFormat().parse(args[1]);
-            } catch (ParseException e)
-            {
-                logger.error("Unable to parse: ", e);
-                displayHelp();
-                return;
-            }
+            AbstractBackupPath path = Application.getInjector().getInstance(AbstractBackupPath.class);
+            startTime = path.parseDate(args[0]);
+            endTime = path.parseDate(args[1]);
 
             Restore restorer = Application.getInjector().getInstance(Restore.class);
             try

--- a/priam/src/main/java/com/netflix/priam/resources/BackupServlet.java
+++ b/priam/src/main/java/com/netflix/priam/resources/BackupServlet.java
@@ -99,8 +99,8 @@ public class BackupServlet
         {
             String[] restore = daterange.split(",");
             AbstractBackupPath path = pathProvider.get();
-            startTime = path.getFormat().parse(restore[0]);
-            endTime = path.getFormat().parse(restore[1]);
+            startTime = path.parseDate(restore[0]);
+            endTime = path.parseDate(restore[1]);
         }
         restore(token, region, startTime, endTime, keyspaces);
         return Response.ok(REST_SUCCESS, MediaType.APPLICATION_JSON).build();
@@ -131,8 +131,8 @@ public class BackupServlet
         {
             String[] restore = daterange.split(",");
             AbstractBackupPath path = pathProvider.get();
-            startTime = path.getFormat().parse(restore[0]);
-            endTime = path.getFormat().parse(restore[1]);
+            startTime = path.parseDate(restore[0]);
+            endTime = path.parseDate(restore[1]);
         }
         Iterator<AbstractBackupPath> it = fs.list(config.getBackupPrefix(), startTime, endTime);
         JSONObject object = new JSONObject();
@@ -141,7 +141,7 @@ public class BackupServlet
             AbstractBackupPath p = it.next();
             if (filter != null && BackupFileType.valueOf(filter) != p.getType())
                 continue;
-            object.put(p.getRemotePath(), p.getFormat().format(p.getTime()));
+            object.put(p.getRemotePath(), p.formatDate(p.getTime()));
         }
         return Response.ok(object.toString(), MediaType.APPLICATION_JSON).build();
     }

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackupFile.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackupFile.java
@@ -7,8 +7,6 @@ import java.io.IOException;
 import java.sql.Date;
 import java.text.ParseException;
 
-import junit.framework.Assert;
-
 import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -17,9 +15,9 @@ import org.junit.Test;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.netflix.priam.aws.S3BackupPath;
-import com.netflix.priam.backup.AbstractBackupPath;
 import com.netflix.priam.backup.AbstractBackupPath.BackupFileType;
 import com.netflix.priam.identity.InstanceIdentity;
+import junit.framework.Assert;
 
 public class TestBackupFile
 {
@@ -88,7 +86,7 @@ public class TestBackupFile
         Assert.assertEquals("fake-app", backupfile.clusterName);
         Assert.assertEquals("fake-region", backupfile.region);
         Assert.assertEquals("casstestbackup", backupfile.baseDir);
-        String datestr = AbstractBackupPath.DAY_FORMAT.format(new Date(bfile.lastModified()));
+        String datestr = backupfile.formatDate(new Date(bfile.lastModified()));
         Assert.assertEquals("casstestbackup/fake-region/fake-app/1234567/" + datestr + "/SST/Keyspace1/Standard1/Keyspace1-Standard1-ia-5-Data.db", backupfile.getRemotePath());
     }
 
@@ -99,7 +97,7 @@ public class TestBackupFile
         String filestr = "cass/data/1234567.meta";
         File bfile = new File(filestr);
         S3BackupPath backupfile = injector.getInstance(S3BackupPath.class);
-        backupfile.time = backupfile.getFormat().parse("201108082320");
+        backupfile.time = backupfile.parseDate("201108082320");
         backupfile.parseLocal(bfile, BackupFileType.META);
         Assert.assertEquals(BackupFileType.META, backupfile.type);
         Assert.assertEquals("1234567", backupfile.token);

--- a/priam/src/test/java/com/netflix/priam/backup/TestS3FileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestS3FileSystem.java
@@ -32,7 +32,6 @@ import com.netflix.priam.aws.DataPart;
 import com.netflix.priam.aws.S3BackupPath;
 import com.netflix.priam.aws.S3FileSystem;
 import com.netflix.priam.aws.S3PartUploader;
-import com.netflix.priam.backup.BackupRestoreException;
 import com.netflix.priam.backup.AbstractBackupPath.BackupFileType;
 import com.netflix.priam.utils.RetryableCallable;
 
@@ -40,7 +39,7 @@ public class TestS3FileSystem
 {
     private static Injector injector;
     private static final Logger logger = LoggerFactory.getLogger(TestBackup.class);
-    private static String FILE_PATH = "target/data/Keyspace1/Standard1/backups/1340995548037/Keyspace1-Standard1-ia-1-Data.db";
+    private static String FILE_PATH = "target/data/Keyspace1/Standard1/backups/201108082320/Keyspace1-Standard1-ia-1-Data.db";
 
     @BeforeClass
     public static void setup() throws InterruptedException, IOException
@@ -49,7 +48,7 @@ public class TestS3FileSystem
         Mockit.setUpMock(AmazonS3Client.class, MockAmazonS3Client.class);
         injector = Guice.createInjector(new BRTestModule());
 
-        File dir1 = new File("target/data/Keyspace1/Standard1/backups/1340995548037");
+        File dir1 = new File("target/data/Keyspace1/Standard1/backups/201108082320");
         if (!dir1.exists())
             dir1.mkdirs();
         File file = new File(FILE_PATH);
@@ -75,7 +74,7 @@ public class TestS3FileSystem
     {
         MockS3PartUploader.setup();
         S3FileSystem fs = injector.getInstance(S3FileSystem.class);
-        // String snapshotfile = "target/data/Keyspace1/Standard1/backups/1340995548037/Keyspace1-Standard1-ia-1-Data.db";
+        // String snapshotfile = "target/data/Keyspace1/Standard1/backups/201108082320/Keyspace1-Standard1-ia-1-Data.db";
         S3BackupPath backupfile = injector.getInstance(S3BackupPath.class);
         backupfile.parseLocal(new File(FILE_PATH), BackupFileType.SNAP);
         fs.upload(backupfile, backupfile.localReader());
@@ -88,7 +87,7 @@ public class TestS3FileSystem
         MockS3PartUploader.setup();
         MockS3PartUploader.partFailure = true;
         S3FileSystem fs = injector.getInstance(S3FileSystem.class);
-        String snapshotfile = "target/data/Keyspace1/Standard1/backups/1340995548037/Keyspace1-Standard1-ia-1-Data.db";
+        String snapshotfile = "target/data/Keyspace1/Standard1/backups/201108082320/Keyspace1-Standard1-ia-1-Data.db";
         S3BackupPath backupfile = injector.getInstance(S3BackupPath.class);
         backupfile.parseLocal(new File(snapshotfile), BackupFileType.SNAP);
         try
@@ -109,7 +108,7 @@ public class TestS3FileSystem
         MockS3PartUploader.setup();
         MockS3PartUploader.completionFailure = true;
         S3FileSystem fs = injector.getInstance(S3FileSystem.class);
-        String snapshotfile = "target/data/Keyspace1/Standard1/backups/1340995548037/Keyspace1-Standard1-ia-1-Data.db";
+        String snapshotfile = "target/data/Keyspace1/Standard1/backups/201108082320/Keyspace1-Standard1-ia-1-Data.db";
         S3BackupPath backupfile = injector.getInstance(S3BackupPath.class);
         backupfile.parseLocal(new File(snapshotfile), BackupFileType.SNAP);
         try

--- a/priam/src/test/java/com/netflix/priam/resources/BackupServletTest.java
+++ b/priam/src/test/java/com/netflix/priam/resources/BackupServletTest.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Lists;
 import com.google.inject.Provider;
 import com.netflix.priam.IConfiguration;
 import com.netflix.priam.PriamServer;
+import com.netflix.priam.aws.S3BackupPath;
 import com.netflix.priam.backup.AbstractBackupPath;
 import com.netflix.priam.backup.IBackupFileSystem;
 import com.netflix.priam.backup.Restore;
@@ -104,7 +105,7 @@ public class BackupServletTest
     @Test
     public void restore_withDateRange() throws Exception
     {
-        final String dateRange = "201101010000,201112312359";
+        final String dateRange = "201101010000,20111231259";
         final String newRegion = null;
         final String newToken = null;
         final String keyspaces = null;
@@ -115,11 +116,12 @@ public class BackupServletTest
         new Expectations() {
             @NonStrict InstanceIdentity identity;
             PriamInstance instance;
-            AbstractBackupPath backupPath;
+            AbstractBackupPath backupPath = new S3BackupPath(null, null);
   
             {
                 pathProvider.get(); result = backupPath;
-                backupPath.getFormat(); result = AbstractBackupPath.DAY_FORMAT; times = 2;
+                backupPath.parseDate(dateRange.split(",")[0]); result = new DateTime(2011, 01, 01, 00, 00).toDate(); times = 1;
+                backupPath.parseDate(dateRange.split(",")[1]); result = new DateTime(2011, 12, 31, 23, 59).toDate(); times = 1;
 
                 config.getDC(); result = oldRegion;
                 priamServer.getId(); result = identity; times = 2;
@@ -289,7 +291,7 @@ public class BackupServletTest
     @Test
     public void restore_maximal() throws Exception
     {
-        final String dateRange = "201101010000,201112312359";
+        final String dateRange = "201101010000,20111231259";
         final String newRegion = null;
         final String newToken = "5678";
         final String keyspaces = null;
@@ -306,7 +308,8 @@ public class BackupServletTest
 
             {
                 pathProvider.get(); result = backupPath;
-                backupPath.getFormat(); result = AbstractBackupPath.DAY_FORMAT; times = 2;
+                backupPath.parseDate(dateRange.split(",")[0]); result = new DateTime(2011, 01, 01, 00, 00).toDate(); times = 1;
+                backupPath.parseDate(dateRange.split(",")[1]); result = new DateTime(2011, 12, 31, 23, 59).toDate(); times = 1;
 
                 config.getDC(); result = oldRegion; times = 2;
                 priamServer.getId(); result = identity; times = 5;


### PR DESCRIPTION
1) Discovered unsafe use of SimpleDateFormat in AbstractBackupPath. Found it under heavily loaded backup (~100,000 files with LCS cluster) where we were strangely getting NumberFormatExceptions in very odd circumstances (i.e. multithreading through the SDF). Replacing SDF with joda-time implementation and hiding it from external callers; they now call parseDate() and formatDate(). This is thread safe.

In the future, might want to move the date format/parsing to a seperate class as many invocations of ABP for the formatter are just plain wrong. But for now, let's just solve the threading data-race at hand.

2) Catch any exceptions that occur while uploading. Before this change, the entire backup would stop if there were any problems (see recent change regarding SDF thread data-races). Now, we'll try the overall upload for the file 3 times (an arbitrary value greater than 1), log the failed file, and continue with the rest of the backup upload.
