### PR TITLE
Consistently include the current rack from the list returned by getSeeds()

### DIFF
--- a/priam/src/test/java/com/netflix/priam/backup/identity/InstanceIdentityTest.java
+++ b/priam/src/test/java/com/netflix/priam/backup/identity/InstanceIdentityTest.java
@@ -63,9 +63,6 @@ public class InstanceIdentityTest extends InstanceTestUtils
     public void testGetSeeds() throws Exception
     {
         createInstances();
-        identity = createInstanceIdentity("az1", "fakeinstancex");
-        assertEquals(2, identity.getSeeds().size());
-
         identity = createInstanceIdentity("az1", "fakeinstance1");
         assertEquals(3, identity.getSeeds().size());
     }


### PR DESCRIPTION
...urned by getSeeds()
