### PR TITLE
Upgrading to latest version of aws-jdk, Updating Credential properties, ...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ subprojects {
         compile "commons-httpclient:commons-httpclient:3.1"
         compile "com.sun.jersey.contribs:jersey-multipart:1.1.4.1"
         compile "com.sun.jersey:jersey-json:1.9.1"
-        compile "com.amazonaws:aws-java-sdk:1.3.11"
+        compile "com.amazonaws:aws-java-sdk:1.3.22"
         compile "com.google.guava:guava:11.0.1"
         compile "com.google.inject:guice:3.0"
         compile "com.sun.jersey:jersey-bundle:1.9.1"

--- a/gradle/netflix-oss.gradle
+++ b/gradle/netflix-oss.gradle
@@ -11,7 +11,7 @@ rootProject {
         if (awsDep != null) {
             def version = awsDep.version
             deps.remove(awsDep)
-            project.dependencies.add('compile', "com.amazon:aws-java-sdk:${version}")
+            project.dependencies.add('compile', "com.amazonaws:aws-java-sdk:${version}")
         }
 
         def httpCoreDep = deps.find { it.group == 'org.apache.httpcomponents' && it.name == 'httpcore' }

--- a/priam/src/main/java/com/netflix/priam/ICredential.java
+++ b/priam/src/main/java/com/netflix/priam/ICredential.java
@@ -1,6 +1,7 @@
 package com.netflix.priam;
 
 import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
 
 /**
  * Credential file interface for services supporting 
@@ -28,5 +29,11 @@ public interface ICredential
      * Added this method to handle potential data races in calling {code}getAccessKeyId{code}
      * and {code}getSecretAccessKey{code} sequentially.
      */
+    @Deprecated
     AWSCredentials getCredentials();
+    
+    /**
+     * Retrieve AWS Credential Provider object 
+     */
+    AWSCredentialsProvider getAwsCredentialProvider();
 }

--- a/priam/src/main/java/com/netflix/priam/aws/AWSMembership.java
+++ b/priam/src/main/java/com/netflix/priam/aws/AWSMembership.java
@@ -193,14 +193,14 @@ public class AWSMembership implements IMembership
 
     protected AmazonAutoScaling getAutoScalingClient()
     {
-        AmazonAutoScaling client = new AmazonAutoScalingClient(provider.getCredentials());
+        AmazonAutoScaling client = new AmazonAutoScalingClient(provider.getAwsCredentialProvider());
         client.setEndpoint("autoscaling." + config.getDC() + ".amazonaws.com");
         return client;
     }
 
     protected AmazonEC2 getEc2Client()
     {
-        AmazonEC2 client = new AmazonEC2Client(provider.getCredentials());
+        AmazonEC2 client = new AmazonEC2Client(provider.getAwsCredentialProvider());
         client.setEndpoint("ec2." + config.getDC() + ".amazonaws.com");
         return client;
     }

--- a/priam/src/main/java/com/netflix/priam/aws/IAMCredential.java
+++ b/priam/src/main/java/com/netflix/priam/aws/IAMCredential.java
@@ -1,6 +1,7 @@
 package com.netflix.priam.aws;
 
 import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.netflix.priam.ICredential;
 
@@ -27,4 +28,9 @@ public class IAMCredential implements ICredential
     {
         return iamCredProvider.getCredentials();
     }
+
+	public AWSCredentialsProvider getAwsCredentialProvider() 
+	{
+		return iamCredProvider;
+	}
 }

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -250,7 +250,7 @@ public class S3FileSystem implements IBackupFileSystem, S3FileSystemMBean
 
     private AmazonS3 getS3Client()
     {
-        return new AmazonS3Client(cred.getCredentials());
+        return new AmazonS3Client(cred.getAwsCredentialProvider());
     }
 
     /**

--- a/priam/src/main/java/com/netflix/priam/aws/SDBInstanceData.java
+++ b/priam/src/main/java/com/netflix/priam/aws/SDBInstanceData.java
@@ -213,6 +213,6 @@ public class SDBInstanceData
     
     private AmazonSimpleDBClient getSimpleDBClient(){
         //Create per request
-        return new AmazonSimpleDBClient(provider.getCredentials());
+        return new AmazonSimpleDBClient(provider.getAwsCredentialProvider());
     }
 }

--- a/priam/src/main/java/com/netflix/priam/backup/IncrementalBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/IncrementalBackup.java
@@ -15,6 +15,7 @@ import com.netflix.priam.backup.AbstractBackupPath.BackupFileType;
 import com.netflix.priam.backup.IMessageObserver.BACKUP_MESSAGE_TYPE;
 import com.netflix.priam.scheduler.SimpleTimer;
 import com.netflix.priam.scheduler.TaskTimer;
+import com.netflix.priam.utils.CassandraMonitor;
 
 /*
  * Incremental/SSTable backup
@@ -35,8 +36,14 @@ public class IncrementalBackup extends AbstractBackup
     
     @Override
     public void execute() throws Exception
-    {
-    		logger.info("Starting Incremental Backup ...");
+    {   	
+        //If Cassandra is started then only start Incremental Backup
+    		if(!CassandraMonitor.isCassadraStarted())
+    		{
+        		logger.debug("Cassandra is not yet started, hence Incremental Backup will start later ...");
+    			return;
+    		}
+
     		//Clearing remotePath List
     		incrementalRemotePaths.clear();
         File dataDir = new File(config.getDataFileLocation());

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/ClearCredential.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/ClearCredential.java
@@ -4,12 +4,14 @@ import java.io.FileInputStream;
 import java.util.Properties;
 
 import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import org.apache.cassandra.io.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.netflix.priam.ICredential;
+import com.netflix.priam.aws.IAMCredential;
 
 /**
  * This is a basic implementation of ICredentials. User should prefer to
@@ -66,4 +68,18 @@ public class ClearCredential implements ICredential
     {
         return new BasicAWSCredentials(getAccessKeyId(), getSecretAccessKey());
     }
+
+	@Override
+	public AWSCredentialsProvider getAwsCredentialProvider() {
+		return new AWSCredentialsProvider(){
+			public AWSCredentials getCredentials(){
+				return getCredentials();				
+			}
+
+			@Override
+			public void refresh() {
+				// NOP				
+			}
+		};
+	}
 }

--- a/priam/src/main/java/com/netflix/priam/utils/BoundedExponentialRetryCallable.java
+++ b/priam/src/main/java/com/netflix/priam/utils/BoundedExponentialRetryCallable.java
@@ -1,0 +1,79 @@
+package com.netflix.priam.utils;
+
+import java.util.concurrent.CancellationException;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class BoundedExponentialRetryCallable<T> extends RetryableCallable<T>
+{    
+    public final static long MAX_SLEEP = 10000;
+    public final static long MIN_SLEEP = 1000;
+    public final static int MAX_RETRIES = 3600;
+
+    private static final Logger logger = LoggerFactory.getLogger(BoundedExponentialRetryCallable.class);
+    private long max;
+    private long min;
+    private int maxRetries;
+    private final ThreadSleeper sleeper = new ThreadSleeper();
+    
+    public BoundedExponentialRetryCallable()
+    {
+        this.max = MAX_SLEEP;
+        this.min = MIN_SLEEP;
+        this.maxRetries = MAX_RETRIES;
+    }
+
+    public BoundedExponentialRetryCallable(long minSleep, long maxSleep, int maxNumRetries)
+    {
+        this.max = maxSleep;
+        this.min = minSleep;
+        this.maxRetries = maxNumRetries;
+    }
+
+    public T call() throws Exception
+    {
+        long delay = min;// ms
+        int retry = 0;
+        int logCounter = 0;
+        while (true)
+        {
+            try
+            {
+                return retriableCall();
+            }
+            catch (CancellationException e)
+            {
+                throw e;
+            }
+            catch (Exception e)
+            {                
+            		retry++;
+            		
+            		if (delay < max && retry <= maxRetries)
+                {
+            			delay *= 2;
+                    logger.error(String.format("Retry #%d for: %s",retry, e.getMessage()));
+                    if(++logCounter == 1)
+                       logger.info("Exception --> "+ExceptionUtils.getFullStackTrace(e));
+                    sleeper.sleep(delay);            			
+                }
+            		else if(delay >= max && retry <= maxRetries)
+            		{
+            			logger.error(String.format("Retry #%d for: %s",retry, e.getMessage()));
+            			sleeper.sleep(max); 
+            		}
+            		else
+            		{
+            			throw e;
+            		}
+            }
+            finally
+            {
+                forEachExecution();
+            }
+        }
+    }
+
+}

--- a/priam/src/main/java/com/netflix/priam/utils/CassandraMonitor.java
+++ b/priam/src/main/java/com/netflix/priam/utils/CassandraMonitor.java
@@ -35,21 +35,24 @@ public class CassandraMonitor extends Task{
 
         try
         {
-                        //This returns pid for the Cassandra process
+        		//This returns pid for the Cassandra process
         		Process p = Runtime.getRuntime().exec("pgrep -f " + CASSANDRA_PROCESS_NAME);
         		BufferedReader input = new BufferedReader(new InputStreamReader(p.getInputStream()));
-                        String line;
-        		if ((line = input.readLine()) != null&& !isCassadraStarted())
+            String line = input.readLine();
+        		if (line != null&& !isCassadraStarted())
         		{
-        			logger.debug("Setting Cassandra server started flag to true");
         			//Setting cassandra flag to true
         			isCassandraStarted.set(true);
+        		}
+        		else if(line  == null&& isCassadraStarted())
+        		{
+        			//Setting cassandra flag to false
+        			isCassandraStarted.set(false);
         		}
         }
         catch(Exception e)
         {
         		logger.warn("Exception thrown while checking if Cassandra is running or not ", e);
-            logger.info("Setting Cassandra server started flag to false");
             //Setting Cassandra flag to false
             isCassandraStarted.set(false);
         }
@@ -72,4 +75,10 @@ public class CassandraMonitor extends Task{
         return isCassandraStarted.get();
     }
 
+    //Added for testing only
+    public static void setIsCassadraStarted()
+    {
+		//Setting cassandra flag to true
+		isCassandraStarted.set(true);
+	}
 }

--- a/priam/src/test/java/com/netflix/priam/backup/FakeCredentials.java
+++ b/priam/src/test/java/com/netflix/priam/backup/FakeCredentials.java
@@ -1,6 +1,7 @@
 package com.netflix.priam.backup;
 
 import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.netflix.priam.ICredential;
 
@@ -23,4 +24,10 @@ public class FakeCredentials implements ICredential
     {
         return new BasicAWSCredentials(getAccessKeyId(), getSecretAccessKey());
     }
+
+	@Override
+	public AWSCredentialsProvider getAwsCredentialProvider() {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }

--- a/priam/src/test/java/com/netflix/priam/backup/FakeNullCredential.java
+++ b/priam/src/test/java/com/netflix/priam/backup/FakeNullCredential.java
@@ -1,6 +1,7 @@
 package com.netflix.priam.backup;
 
 import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.netflix.priam.ICredential;
 
@@ -23,4 +24,10 @@ public class FakeNullCredential implements ICredential
     {
         return new BasicAWSCredentials(getAccessKeyId(), getSecretAccessKey());
     }
+
+	@Override
+	public AWSCredentialsProvider getAwsCredentialProvider() {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackup.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackup.java
@@ -26,6 +26,7 @@ import com.google.inject.Injector;
 import com.netflix.priam.backup.IBackupFileSystem;
 import com.netflix.priam.backup.IncrementalBackup;
 import com.netflix.priam.backup.SnapshotBackup;
+import com.netflix.priam.utils.CassandraMonitor;
 
 /**
  * Unit test case to test a snapshot backup and incremental backup
@@ -60,6 +61,8 @@ public class TestBackup
     {
         filesystem.setupTest();
         SnapshotBackup backup = injector.getInstance(SnapshotBackup.class);
+        CassandraMonitor cassMon = injector.getInstance(CassandraMonitor.class);
+        cassMon.setIsCassadraStarted();
         backup.execute();
         Assert.assertEquals(3, filesystem.uploadedFiles.size());
         System.out.println(filesystem.uploadedFiles.size());
@@ -82,6 +85,8 @@ public class TestBackup
         filesystem.setupTest();
         generateIncrementalFiles();
         IncrementalBackup backup = injector.getInstance(IncrementalBackup.class);
+        CassandraMonitor cassMon = injector.getInstance(CassandraMonitor.class);
+        cassMon.setIsCassadraStarted();
         backup.execute();
         Assert.assertEquals(4, filesystem.uploadedFiles.size());
         for (String filePath : expectedFiles)


### PR DESCRIPTION
Upgrading to latest version of aws-jdk, Updating Credential properties, Adding Exponential Backoff Retry capability
1. Upgraded to 1.3.22 aws-jdk version
2. Added Exponential Backoff retry mechanism
3. Added checks to make sure cassandra is running before starting Snapshot & Incremental Backups 
4. Updated JMXNodeTool to use "Exponential Backoff Retry" rather than "RetryForever"
5. We faced some issues of Token expiration while using IAMCredentials. Hence, added the code change which will use AWSCredentialProvider object directly rather than AWSCredentials itself.
