### PR TITLE
making the switch to using AWSCredntialsProvider when instantiating aws clients

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-ext.releaseVersion = '0.0.5.9'
+ext.releaseVersion = '0.0.5.10'
 ext.githubProjectName = 'Priam'
 
 buildscript {

--- a/priam/src/main/java/com/netflix/priam/aws/AWSMembership.java
+++ b/priam/src/main/java/com/netflix/priam/aws/AWSMembership.java
@@ -193,16 +193,14 @@ public class AWSMembership implements IMembership
 
     protected AmazonAutoScaling getAutoScalingClient()
     {
-        BasicAWSCredentials cred = new BasicAWSCredentials(provider.getAccessKeyId(), provider.getSecretAccessKey());
-        AmazonAutoScaling client = new AmazonAutoScalingClient(cred);
+        AmazonAutoScaling client = new AmazonAutoScalingClient(provider.getAwsCredentialProvider());
         client.setEndpoint("autoscaling." + config.getDC() + ".amazonaws.com");
         return client;
     }
 
     protected AmazonEC2 getEc2Client()
     {
-        BasicAWSCredentials cred = new BasicAWSCredentials(provider.getAccessKeyId(), provider.getSecretAccessKey());
-        AmazonEC2 client = new AmazonEC2Client(cred);
+        AmazonEC2 client = new AmazonEC2Client(provider.getAwsCredentialProvider());
         client.setEndpoint("ec2." + config.getDC() + ".amazonaws.com");
         return client;
     }

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -241,7 +241,7 @@ public class S3FileSystem implements IBackupFileSystem, S3FileSystemMBean
 
     private AmazonS3 getS3Client()
     {
-        return new AmazonS3Client(new BasicAWSCredentials(cred.getAccessKeyId(), cred.getSecretAccessKey()));
+        return new AmazonS3Client(cred.getAwsCredentialProvider());
     }
 
     /**

--- a/priam/src/main/java/com/netflix/priam/aws/SDBInstanceData.java
+++ b/priam/src/main/java/com/netflix/priam/aws/SDBInstanceData.java
@@ -216,6 +216,6 @@ public class SDBInstanceData
     
     private AmazonSimpleDBClient getSimpleDBClient(){
         //Create per request
-        return new AmazonSimpleDBClient(new BasicAWSCredentials(provider.getAccessKeyId(), provider.getSecretAccessKey()));
+        return new AmazonSimpleDBClient(provider.getAwsCredentialProvider());
     }
 }

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/ClearCredential.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/ClearCredential.java
@@ -67,7 +67,7 @@ public class ClearCredential implements ICredential
 	public AWSCredentialsProvider getAwsCredentialProvider() {
 		return new AWSCredentialsProvider(){
 			public AWSCredentials getCredentials(){
-				return getCredentials();				
+				return ClearCredential.this.getCredentials();
 			}
 
 			@Override


### PR DESCRIPTION
Looks like this was missed in the backport :)
