### PR TITLE
Avoid recursively calling self; instead call outer class's getCredentials

### DIFF
--- a/priam/src/main/java/com/netflix/priam/defaultimpl/ClearCredential.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/ClearCredential.java
@@ -88,7 +88,7 @@ public class ClearCredential implements ICredential
 	public AWSCredentialsProvider getAwsCredentialProvider() {
 		return new AWSCredentialsProvider(){
 			public AWSCredentials getCredentials(){
-				return getCredentials();				
+				return ClearCredential.this.getCredentials();
 			}
 
 			@Override


### PR DESCRIPTION
Avoid recursively calling self; instead call outer class's getCredentials
