### PR TITLE
Fixing false assumption in TuneCassandra regarding setting compatibility

### DIFF
--- a/priam/src/main/java/com/netflix/priam/utils/TuneCassandra.java
+++ b/priam/src/main/java/com/netflix/priam/utils/TuneCassandra.java
@@ -78,30 +78,18 @@ public class TuneCassandra extends Task
         map.put("endpoint_snitch", config.getSnitch());
         map.put("in_memory_compaction_limit_in_mb", config.getInMemoryCompactionLimit());
         map.put("compaction_throughput_mb_per_sec", config.getCompactionThroughput());
-	    map.put("partitioner", derivePartitioner(map.get("partitioner").toString(), config.getPartitioner()));
+	map.put("partitioner", derivePartitioner(map.get("partitioner").toString(), config.getPartitioner()));
         
-        // messy but needed it for backward and forward compatibilities.
-        if (null != map.get("memtable_total_space_in_mb"))
-            map.put("memtable_total_space_in_mb", config.getMemtableTotalSpaceMB());
-        // the default for stream_throughput_outbound_megabits_per_sec is 7 ms and not in yaml.
-        // TODO fixme: currently memtable_total_space_in_mb is used to verify if it is >1.0.7.
-        if(null != map.get("memtable_total_space_in_mb"))
-            map.put("stream_throughput_outbound_megabits_per_sec", config.getStreamingThroughputMB());
-        if(null != map.get("multithreaded_compaction"))
-            map.put("multithreaded_compaction", config.getMultithreadedCompaction());
-        if (null != map.get("max_hint_window_in_ms"))
-        {
-            map.put("max_hint_window_in_ms", config.getMaxHintWindowInMS());
-            map.put("hinted_handoff_throttle_delay_in_ms", config.getHintHandoffDelay());
-        }
+	map.put("memtable_total_space_in_mb", config.getMemtableTotalSpaceMB());
+	map.put("stream_throughput_outbound_megabits_per_sec", config.getStreamingThroughputMB());
+	map.put("multithreaded_compaction", config.getMultithreadedCompaction());
 
-        // this is only for 0.8 so check before set.
-        if (null != map.get("seed_provider"))
-        {
-            List<?> seedp = (List) map.get("seed_provider");
-            Map<String, String> m = (Map<String, String>) seedp.get(0);
-            m.put("class_name", seedProvider);
-        }
+	map.put("max_hint_window_in_ms", config.getMaxHintWindowInMS());
+	map.put("hinted_handoff_throttle_delay_in_ms", config.getHintHandoffDelay());
+
+	List<?> seedp = (List) map.get("seed_provider");
+	Map<String, String> m = (Map<String, String>) seedp.get(0);
+	m.put("class_name", seedProvider);
 
         configureGlobalCaches(config, map);
 


### PR DESCRIPTION
Previously, there was logic to guard against yaml config settings that had been added or removed from different versions. This was tested by adding a null check to see if the setting existed in the yaml that was read in. Unfortunately, if a property was commented out in the yaml (yet still compltetly valid as a setting) the entry would not be present in the map that snakeyaml produced, and hence you could never write out that setting. Basically this was a poor man's way to avoid branching. Now that we branch in priam, that is no longer necessary.
