### PR TITLE
Updating retriable count for creating new token

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.1.40-SNAPSHOT
+version=1.1.41-SNAPSHOT

--- a/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -121,7 +121,11 @@ public class InstanceIdentity
             myInstance = new GetDeadToken().call();
         // Grab a new token
         if (null == myInstance)
-            myInstance = new GetNewToken().call();
+        {
+			GetNewToken newToken = new GetNewToken();
+			newToken.set(100, 100);
+			myInstance = newToken.call();
+		}
         logger.info("My token: " + myInstance.getToken());
     }
 


### PR DESCRIPTION
Updating retriable count to 100 while creating new tokens. 
This will make sure that New nodes do not entirely consume retriable limit and successfully bootstrap.  
