### PR TITLE
Added AWS metrics to Priam to see cassandra and instance stats, closing input stream of S3 Object, to avoid TimeoutConnections

### DIFF
--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -16,6 +16,7 @@
 package com.netflix.priam;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Interface for Priam's configuration
@@ -327,4 +328,20 @@ public interface IConfiguration
      * @return true/false, if Cassandra needs to be started manually
      */
     public boolean doesCassandraStartManually();
+    
+    /**
+     * @return the endpoint where metrics are sent to
+     */
+	public String getCloudwatchMonitoringEndpoint();
+	
+	/**
+	 * @return true/false to define if metrics are enabled or not
+	 */
+	public boolean isMetricsEnabled();
+	
+	
+	/**
+	 * @return a set of column family names to be monitored
+	 */
+	public Set<String> getMetricsForColumnFamilies();
 }

--- a/priam/src/main/java/com/netflix/priam/PriamServer.java
+++ b/priam/src/main/java/com/netflix/priam/PriamServer.java
@@ -110,7 +110,7 @@ public class PriamServer
         //Set cleanup
         scheduler.addTask(UpdateCleanupPolicy.JOBNAME, UpdateCleanupPolicy.class, UpdateCleanupPolicy.getTimer());
         
-        scheduler.addTaskWithDelay(HecubaTask.JOBNAME, HecubaTask.class, HecubaTask.getTimer(), HecubaTask.HECUBA_INITIAL_WAIT_TIME_IN_SECS);
+        scheduler.addTask(HecubaTask.JOBNAME, HecubaTask.class, HecubaTask.getTimer());
         
     }
 

--- a/priam/src/main/java/com/netflix/priam/PriamServer.java
+++ b/priam/src/main/java/com/netflix/priam/PriamServer.java
@@ -15,6 +15,10 @@
  */
 package com.netflix.priam;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.priam.aws.UpdateCleanupPolicy;
@@ -23,14 +27,12 @@ import com.netflix.priam.backup.IncrementalBackup;
 import com.netflix.priam.backup.Restore;
 import com.netflix.priam.backup.SnapshotBackup;
 import com.netflix.priam.identity.InstanceIdentity;
+import com.netflix.priam.metrics.HecubaTask;
 import com.netflix.priam.scheduler.PriamScheduler;
 import com.netflix.priam.utils.CassandraMonitor;
 import com.netflix.priam.utils.Sleeper;
 import com.netflix.priam.utils.SystemUtils;
 import com.netflix.priam.utils.TuneCassandra;
-import org.apache.commons.collections.CollectionUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Start all tasks here - Property update task - Backup task - Restore task -
@@ -107,6 +109,9 @@ public class PriamServer
         
         //Set cleanup
         scheduler.addTask(UpdateCleanupPolicy.JOBNAME, UpdateCleanupPolicy.class, UpdateCleanupPolicy.getTimer());
+        
+        scheduler.addTaskWithDelay(HecubaTask.JOBNAME, HecubaTask.class, HecubaTask.getTimer(), HecubaTask.HECUBA_INITIAL_WAIT_TIME_IN_SECS);
+        
     }
 
     public InstanceIdentity getId()

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -125,6 +125,7 @@ public class S3FileSystem implements IBackupFileSystem, S3FileSystemMBean
 //            bytesDownloaded.addAndGet(obj.getObjectMetadata().getContentLength());
 
             long contentLen = obj.getObjectMetadata().getContentLength();
+            obj.getObjectContent().close();
             path.setSize(contentLen);
             RangeReadInputStream rris = new RangeReadInputStream(client, getPrefix(), path);            
             final long bufSize = MAX_BUFFERED_IN_STREAM_SIZE > contentLen ? contentLen : MAX_BUFFERED_IN_STREAM_SIZE;

--- a/priam/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
@@ -63,8 +63,8 @@ public class SnapshotBackup extends AbstractBackup
     @Override
     public void execute() throws Exception
     {
-        //If Cassandra is started then only start Snapshot Backup
-    		while(!CassandraMonitor.isCassadraStarted())
+        	//If Cassandra is started then only start Snapshot Backup
+    		while(!CassandraMonitor.isCassandraStarted())
     		{
         		logger.debug("Cassandra is not yet started, hence Snapshot Backup will start after ["+WAIT_TIME_MS/1000+"] secs ...");
     			sleeper.sleep(WAIT_TIME_MS);

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -40,6 +41,7 @@ import com.amazonaws.services.simpledb.model.SelectResult;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.netflix.priam.IConfiguration;
 import com.netflix.priam.ICredential;
 import com.netflix.priam.utils.SystemUtils;
@@ -101,6 +103,9 @@ public class PriamConfiguration implements IConfiguration
     private static final String CONFIG_KEYCACHE_COUNT= PRIAM_PRE + ".keyCache.count";
     private static final String CONFIG_ROWCACHE_SIZE = PRIAM_PRE + ".rowCache.size";
     private static final String CONFIG_ROWCACHE_COUNT= PRIAM_PRE + ".rowCache.count";
+    private static final String CONFIG_METRICS_ENABLED = PRIAM_PRE + ".metrics.enabled";
+    private static final String CONFIG_METRICS_FOR_COLUMN_FAMILES = PRIAM_PRE + ".metrics.for.column.families";
+    private static final String CONFIG_METRICS_CLOUDWATCH_MONITORING_ENDPOINT = PRIAM_PRE + ".metrics.cloudwatch.monitoring.endpoint";
 
 
     // Amazon specific
@@ -145,7 +150,10 @@ public class PriamConfiguration implements IConfiguration
     private final int DEFAULT_RESTORE_THREADS = 8;
     private final int DEFAULT_BACKUP_CHUNK_SIZE = 10;
     private final int DEFAULT_BACKUP_RETENTION = 0;
+    private final String DEFAULT_METRICS_CLOUDWATCH_MONITORING_ENDPOINT = "monitoring.us-east-1.amazonaws.com";
+    private final boolean DEFAULT_METRICS_ENABLED = false;
 
+    
     private PriamProperties config;
     private static final Logger logger = LoggerFactory.getLogger(PriamConfiguration.class);
 
@@ -673,5 +681,26 @@ public class PriamConfiguration implements IConfiguration
 	@Override
 	public boolean doesCassandraStartManually() {
 		return config.getBoolean(CONFIG_CASS_MANUAL_START_ENABLE, false);
+	}
+	
+	
+	@Override
+	public String getCloudwatchMonitoringEndpoint() {
+		return config.getProperty(CONFIG_METRICS_CLOUDWATCH_MONITORING_ENDPOINT, DEFAULT_METRICS_CLOUDWATCH_MONITORING_ENDPOINT);
+	}
+
+	@Override
+	public boolean isMetricsEnabled() {
+		return config.getBoolean(CONFIG_METRICS_ENABLED, DEFAULT_METRICS_ENABLED);
+	}
+
+	@Override
+	public Set<String> getMetricsForColumnFamilies() {
+		Set<String> observedCfs = Sets.newHashSet();
+		List<String> cfs = config.getList(CONFIG_METRICS_FOR_COLUMN_FAMILES, "");
+		if (!cfs.isEmpty()) {
+			observedCfs.addAll(cfs); 
+		}
+		return observedCfs;
 	}
 }

--- a/priam/src/main/java/com/netflix/priam/metrics/CfMetric.java
+++ b/priam/src/main/java/com/netflix/priam/metrics/CfMetric.java
@@ -1,0 +1,91 @@
+package com.netflix.priam.metrics;
+
+
+/**
+ * Helper class for DTOing CF metadata
+ * 
+ */
+public class CfMetric {
+	
+	private String keyspace;
+	private String columnFamilyName;
+	private long pendingTasks;
+	private long estimatedKeys;
+	private long totalReadLatencyMicros;
+	private long totalWriteLatencyMicros;
+	private long totalDiskSpaceUsed;
+	
+	public CfMetric(String keyspace, String columnFamilyName, int pendingTasks, long estimateKeys, 
+			long totalWriteLatencyMicros, long totalReadLatencyMicros, long totalDiskSpaceUsed) {
+		
+		this.keyspace = keyspace;
+		this.columnFamilyName = columnFamilyName;
+		this.pendingTasks = pendingTasks;
+		this.estimatedKeys = estimateKeys;
+		this.totalWriteLatencyMicros = totalWriteLatencyMicros;
+		this.totalReadLatencyMicros = totalReadLatencyMicros;
+		this.totalDiskSpaceUsed = totalDiskSpaceUsed;
+		
+	}
+
+
+	public long getTotalDiskSpaceUsed() {
+		return totalDiskSpaceUsed;
+	}
+	public long getTotalReadLatencyMicros() {
+		return totalReadLatencyMicros;
+	}
+	public long getTotalWriteLatencyMicros() {
+		return totalWriteLatencyMicros;
+	}
+	public long getEstimatedKeys() {
+		return estimatedKeys;
+	}
+	public long getPendingTasks() {
+		return pendingTasks;
+	}
+	public String getColumnFamilyName() {
+		return columnFamilyName;
+	}
+	public String getKeyspace() {
+		return keyspace;
+	}
+
+
+
+	@Override
+	public int hashCode() {
+		return columnFamilyName.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		CfMetric other = (CfMetric) obj;
+		if (columnFamilyName == null) {
+			if (other.columnFamilyName != null)
+				return false;
+		} else if (!columnFamilyName.equals(other.columnFamilyName))
+			return false;
+		return true;
+	}
+
+
+	@Override
+	public String toString() {
+		return "CfMetric [keyspace=" + keyspace + ", columnFamilyName="
+				+ columnFamilyName + ", pendingTasks=" + pendingTasks
+				+ ", estimatedKeys=" + estimatedKeys
+				+ ", totalReadLatencyMicros=" + totalReadLatencyMicros
+				+ ", totalWriteLatencyMicros=" + totalWriteLatencyMicros
+				+ ", totalDiskSpaceUsed=" + totalDiskSpaceUsed + "]";
+	}
+
+	
+
+}

--- a/priam/src/main/java/com/netflix/priam/metrics/CfMetric.java
+++ b/priam/src/main/java/com/netflix/priam/metrics/CfMetric.java
@@ -2,7 +2,7 @@ package com.netflix.priam.metrics;
 
 
 /**
- * Helper class for DTOing CF metadata
+ * Helper class for DTOing a single CF metadata
  * 
  */
 public class CfMetric {
@@ -11,19 +11,19 @@ public class CfMetric {
 	private String columnFamilyName;
 	private long pendingTasks;
 	private long estimatedKeys;
-	private long totalReadLatencyMicros;
-	private long totalWriteLatencyMicros;
+	private long avgReadLatencyMicros;
+	private long avgWriteLatencyMicros;
 	private long totalDiskSpaceUsed;
 	
 	public CfMetric(String keyspace, String columnFamilyName, int pendingTasks, long estimateKeys, 
-			long totalWriteLatencyMicros, long totalReadLatencyMicros, long totalDiskSpaceUsed) {
+			long avgWriteLatencyMicros, long avgReadLatencyMicros, long totalDiskSpaceUsed) {
 		
 		this.keyspace = keyspace;
 		this.columnFamilyName = columnFamilyName;
 		this.pendingTasks = pendingTasks;
 		this.estimatedKeys = estimateKeys;
-		this.totalWriteLatencyMicros = totalWriteLatencyMicros;
-		this.totalReadLatencyMicros = totalReadLatencyMicros;
+		this.avgWriteLatencyMicros = avgWriteLatencyMicros;
+		this.avgReadLatencyMicros = avgReadLatencyMicros;
 		this.totalDiskSpaceUsed = totalDiskSpaceUsed;
 		
 	}
@@ -32,11 +32,11 @@ public class CfMetric {
 	public long getTotalDiskSpaceUsed() {
 		return totalDiskSpaceUsed;
 	}
-	public long getTotalReadLatencyMicros() {
-		return totalReadLatencyMicros;
+	public long getAvgReadLatencyMicros() {
+		return avgReadLatencyMicros;
 	}
-	public long getTotalWriteLatencyMicros() {
-		return totalWriteLatencyMicros;
+	public long getAvgWriteLatencyMicros() {
+		return avgWriteLatencyMicros;
 	}
 	public long getEstimatedKeys() {
 		return estimatedKeys;
@@ -81,8 +81,8 @@ public class CfMetric {
 		return "CfMetric [keyspace=" + keyspace + ", columnFamilyName="
 				+ columnFamilyName + ", pendingTasks=" + pendingTasks
 				+ ", estimatedKeys=" + estimatedKeys
-				+ ", totalReadLatencyMicros=" + totalReadLatencyMicros
-				+ ", totalWriteLatencyMicros=" + totalWriteLatencyMicros
+				+ ", avgReadLatencyMicros=" + avgReadLatencyMicros
+				+ ", avgWriteLatencyMicros=" + avgWriteLatencyMicros
 				+ ", totalDiskSpaceUsed=" + totalDiskSpaceUsed + "]";
 	}
 

--- a/priam/src/main/java/com/netflix/priam/metrics/HecubaTask.java
+++ b/priam/src/main/java/com/netflix/priam/metrics/HecubaTask.java
@@ -1,0 +1,75 @@
+package com.netflix.priam.metrics;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.netflix.priam.IConfiguration;
+import com.netflix.priam.scheduler.SimpleTimer;
+import com.netflix.priam.scheduler.Task;
+import com.netflix.priam.scheduler.TaskTimer;
+import com.netflix.priam.utils.JMXConnectionException;
+/**
+ * In greek mythology Hecuba is the Priam's wife and the mother of cassandra. 
+ * Therefore monitoring/taking care of cassandra is Hecuba's task!
+ *
+ */
+@Singleton
+public class HecubaTask extends Task {
+
+	public static final String JOBNAME = "HECUBA_THREAD";
+	public static final long INTERVAL = 60L*1000;
+	public static final int HECUBA_INITIAL_WAIT_TIME_IN_SECS = 30; 
+    private static final Logger logger = LoggerFactory.getLogger(HecubaTask.class);
+    
+    private MetricsSender sender;
+    private MetricsCollector collector;
+	
+    // used to disable/enable metrics via REST call
+    private boolean metricsEnabled;
+    
+	
+	@Inject
+    public HecubaTask(IConfiguration config, MetricsSender sender) throws JMXConnectionException {
+		super(config);
+		this.collector = new MetricsCollector(config);
+		this.sender = sender;
+		this.metricsEnabled = config.isMetricsEnabled();
+		logger.info("HecubaTask was instantiated");
+	}
+	
+	
+	@Override
+	public void execute() throws Exception {
+		if (!metricsEnabled) {
+			logger.debug("Collecting metrics is disabled!");
+			return;
+		}
+		List<MetricDatum> datums = collector.collectMetrics();
+		sender.sendMetrics(datums);
+		logger.debug("Executed Hecuba task ...");
+	}
+
+	@Override
+	public String getName() {
+		return JOBNAME;
+	}
+	
+	public static TaskTimer getTimer() {
+		return new SimpleTimer(JOBNAME, INTERVAL);
+	}
+	
+	
+	public void setMetricsEnabled(boolean metricsEnabled) {
+		this.metricsEnabled = metricsEnabled;
+	}
+	
+	public boolean isMetricsEnabled() {
+		return metricsEnabled;
+	}
+
+}

--- a/priam/src/main/java/com/netflix/priam/metrics/HecubaTask.java
+++ b/priam/src/main/java/com/netflix/priam/metrics/HecubaTask.java
@@ -9,6 +9,7 @@ import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.priam.IConfiguration;
+import com.netflix.priam.scheduler.CronTimer;
 import com.netflix.priam.scheduler.SimpleTimer;
 import com.netflix.priam.scheduler.Task;
 import com.netflix.priam.scheduler.TaskTimer;
@@ -60,7 +61,7 @@ public class HecubaTask extends Task {
 	}
 	
 	public static TaskTimer getTimer() {
-		return new SimpleTimer(JOBNAME, INTERVAL);
+		return new CronTimer(JOBNAME, "0 * * * * ?");
 	}
 	
 	

--- a/priam/src/main/java/com/netflix/priam/metrics/HecubaTask.java
+++ b/priam/src/main/java/com/netflix/priam/metrics/HecubaTask.java
@@ -10,7 +10,6 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.priam.IConfiguration;
 import com.netflix.priam.scheduler.CronTimer;
-import com.netflix.priam.scheduler.SimpleTimer;
 import com.netflix.priam.scheduler.Task;
 import com.netflix.priam.scheduler.TaskTimer;
 import com.netflix.priam.utils.JMXConnectionException;

--- a/priam/src/main/java/com/netflix/priam/metrics/MetricsCollector.java
+++ b/priam/src/main/java/com/netflix/priam/metrics/MetricsCollector.java
@@ -1,0 +1,353 @@
+package com.netflix.priam.metrics;
+
+import java.io.File;
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.management.ThreadMXBean;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.cassandra.db.ColumnFamilyStoreMBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.services.cloudwatch.model.Dimension;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import com.amazonaws.services.cloudwatch.model.StandardUnit;
+import com.amazonaws.services.cloudwatch.model.StatisticSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.netflix.priam.IConfiguration;
+import com.netflix.priam.utils.JMXConnectionException;
+import com.netflix.priam.utils.JMXNodeTool;
+/**
+ * Collector to gather cassandra metrics by using {@link JMXNodeTool} calls that may be useful for monitoring 
+ * and analyzing bottlenecks. These comprise only metrics that are not available from AWS by default 
+ * (e.g. system space available, etc.)
+ * <br/><br/>
+ * 
+ * Cassandra cluster metrics: amount of nodes alive, keys per CF (estimated), used heap, pending tasks
+ * <br/><br/>
+ * 
+ * Cassandra instance metrics: file load, used system diskspace, current thread count
+ * <br/><br/>
+ * 
+ * OS metrics: used disk space on data partition (in %), used memory (in %), system load
+ */
+
+@Singleton
+public class MetricsCollector {
+	
+	private static final Logger logger = LoggerFactory.getLogger(MetricsCollector.class);
+	
+	private OperatingSystemMXBean osMxBean;
+	private ThreadMXBean threadMxBean;
+	public JMXNodeTool nodetool;
+	private IConfiguration config;
+	private Set<String> observedColumnFamilies = Collections.emptySet();
+    
+	
+	public static final double KB = 1024d;
+	public static final double MB = 1024*1024d;
+	public static final double GB = 1024*1024*1024d;
+	public static final double TB = 1024*1024*1024*1024d;
+
+	// cluster metrics
+	public static final String CLUSTER = "cluster";
+	public static final String CLUSTER_LIVE_NODES = CLUSTER+"_live_nodes";
+	public static final String CLUSTER_UNREACHABLE_NODES = CLUSTER+"_unreachable_nodes";
+	public static final String CLUSTER_ESTIMATED_KEYS = CLUSTER+"_estimated_keys";
+	public static final String CLUSTER_PENDING_TASKS = CLUSTER+"_pending_tasks";
+	
+	// instance metrics
+	private static final String INSTANCE = "instance";
+	public static final String INSTANCE_FILE_LOAD = "file_load";
+	public static final String INSTANCE_USED_HEAP = "used_heap";
+	public static final String INSTANCE_USED_SYSTEM_DISKSPACE = "used_system_diskspace";
+	public static final String INSTANCE_SYSTEM_LOAD = "system_load";
+	public static final String INSTANCE_FREE_RUNTIME_MEMORY = "free_runtime_memory";
+	public static final String INSTANCE_CURRENT_THREAD_COUNT = "current_thread_count";
+	
+	// cf metrics
+	public static final String CF_NAME = "cf_name";
+	public static final String CF_PENDING_TASKS = "pending_tasks";
+	public static final String CF_ESTIMATED_KEYS = "estimated_keys";
+	public static final String CF_WRITE_LATENCY_MICROS = "write_latency_micros";
+	public static final String CF_READ_LATENCY_MICROS = "read_latency_micros";
+	public static final String CF_USED_DISKSPACE = "used_diskspace";
+
+	
+
+	
+	@Inject
+	public MetricsCollector(IConfiguration config) throws JMXConnectionException {
+		this.config = config;
+		this.observedColumnFamilies = config.getMetricsForColumnFamilies();
+		osMxBean = JMXNodeTool.getRemoteBean(OperatingSystemMXBean.class, 
+				ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME, config, true);
+		threadMxBean = JMXNodeTool.getRemoteBean(ThreadMXBean.class, 
+				ManagementFactory.THREAD_MXBEAN_NAME, config, true);
+		setNodeTool(JMXNodeTool.connect(config));
+		logger.info("Metricscollector instantiated!");
+	}
+	
+	
+	// constructor only for testing
+	protected MetricsCollector(IConfiguration config2,
+			OperatingSystemMXBean osMxBean2, ThreadMXBean threadMxBean2, JMXNodeTool nodetool2) throws JMXConnectionException {
+		this.nodetool = nodetool2;
+		this.config = config2;
+		this.osMxBean = osMxBean2;
+		this.threadMxBean = threadMxBean2;
+	}
+
+	/**
+	 * Wraps statistical info into a DTO
+	 * @param entry jmx information from cassandra or the vm
+	 * @return a metric DTO
+	 */
+	private CfMetric createHecubaCfMetric(Entry<String, ColumnFamilyStoreMBean> entry) {
+		
+		CfMetric metric = new CfMetric(
+				entry.getKey(),
+				entry.getValue().getColumnFamilyName(), 
+				entry.getValue().getPendingTasks(),
+				entry.getValue().estimateKeys(),
+				entry.getValue().getTotalWriteLatencyMicros(),
+				entry.getValue().getTotalReadLatencyMicros(),
+				entry.getValue().getTotalDiskSpaceUsed()
+				);
+		
+		return metric;
+	}
+	
+	/**
+	 * Iterates over column family mbeans and extracts info if column family should be observed
+	 * 
+	 * @param observedColumnFamilies (defined in priam's properties)
+	 * @return a set of column family metrics
+	 */
+	public Set<CfMetric> getCfStats(Set<String> observedColumnFamilies) {
+		
+		Iterator<Entry<String, ColumnFamilyStoreMBean>> it = nodetool.getColumnFamilyStoreMBeanProxies();
+        Set<CfMetric> cfMetrics = Sets.newHashSet();
+        if (observedColumnFamilies == null || observedColumnFamilies.isEmpty()) {
+        	logger.info("No column family names given ... returning empty metric set.");
+        	return cfMetrics;
+        }
+        logger.debug("Fetching metadata for ["+observedColumnFamilies+"]");
+        while (it.hasNext())
+        {	
+        	Entry<String, ColumnFamilyStoreMBean> entry = it.next();
+        	String keyspace = entry.getKey();
+        	String cfName = entry.getValue().getColumnFamilyName();
+        	logger.debug("Fetching data for ["+keyspace+"||"+cfName+"]");
+        	if (observedColumnFamilies.contains(cfName)) {
+        		cfMetrics.add(createHecubaCfMetric(entry));
+        	} else {
+        		logger.debug("Skipping column family ["+cfName+"]");
+        		continue;
+        	}
+        	
+        }
+        logger.debug("Column family stats: " + cfMetrics.toString());
+        return cfMetrics;
+	}
+
+	
+	/**
+	 * Collects cassandra colum family metrics
+	 * 
+	 * @return a list of {@link MetricDatum} to be fired into cloudwatch
+	 */
+	private List<MetricDatum> collectCassandraCfMetrics() {
+		
+		Set<CfMetric> cfMetrics = getCfStats(observedColumnFamilies);
+		List<MetricDatum> mDatums = Lists.newArrayList();
+		for (CfMetric cfMetric : cfMetrics) {
+			Dimension dimension = new Dimension().withName(config.getAppName()).withValue(cfMetric.getColumnFamilyName());
+			mDatums.add(createMetricDatum(CF_ESTIMATED_KEYS, Arrays.asList(dimension), 
+					StandardUnit.Count, new Double(cfMetric.getEstimatedKeys())));
+			mDatums.add(createMetricDatum(CF_PENDING_TASKS, Arrays.asList(dimension), 
+					StandardUnit.Count, new Double(cfMetric.getPendingTasks())));
+			mDatums.add(createMetricDatum(CF_USED_DISKSPACE, Arrays.asList(dimension), 
+					StandardUnit.Bytes, new Double(cfMetric.getTotalDiskSpaceUsed())));
+// 	TODO: calculate latest metrics, not total
+//			mDatums.add(createMetricDatum(CF_READ_LATENCY_MICROS, Arrays.asList(dimension), 
+//					StandardUnit.Microseconds, new Double(cfMetric.getTotalReadLatencyMicros())));
+//			mDatums.add(createMetricDatum(CF_WRITE_LATENCY_MICROS, Arrays.asList(dimension), 
+//					StandardUnit.Microseconds, new Double(cfMetric.getTotalWriteLatencyMicros())));
+			
+		}
+		return mDatums;
+	}
+	
+	/**
+	 * Collects cassandra cluster metrics
+	 * 
+	 * @return a list of {@link MetricDatum} to be fired into AWS cloudwatch
+	 */
+	private List<MetricDatum> collectCassandraClusterMetrics() {
+		
+		List<MetricDatum> mDatums = Lists.newArrayList();
+		Dimension dimension = new Dimension().withName(config.getAppName()).withValue(CLUSTER);
+		mDatums.add(createMetricDatum(CLUSTER_LIVE_NODES, Arrays.asList(dimension), 
+				StandardUnit.Count, new Double(nodetool.getLiveNodes().size())));
+		mDatums.add(createMetricDatum(CLUSTER_UNREACHABLE_NODES, Arrays.asList(dimension), 
+				StandardUnit.Count, new Double(nodetool.getUnreachableNodes().size())));
+		// gets the space used for files of each node		
+		Map<String, String> loadMap = nodetool.getLoadMap();
+		for (Entry<String, String> entry : loadMap.entrySet()) {
+			// e.g. 10.0.0.1 = 116,16 KB
+			String node = entry.getKey();
+			String amount = entry.getValue().split(" ")[0].replace(",", ".");
+			String unit = entry.getValue().split(" ")[1];
+			mDatums.add(createMetricDatum(INSTANCE_FILE_LOAD+":"+node, Arrays.asList(dimension), 
+					computeUnit(unit), new Double(amount)));
+		}
+		return mDatums;
+	}
+	
+	/**
+	 * Collects instance metrics
+	 * 
+	 * @return a list of {@link MetricDatum} to be fired into cloudwatch
+	 */
+	private List<MetricDatum> collectCassandraInstanceMetrics() {
+		List<MetricDatum> mDatums = Lists.newArrayList();
+		Dimension dimension = new Dimension().withName(config.getAppName()).withValue(INSTANCE);
+		mDatums.add(createMetricDatum(INSTANCE_USED_HEAP+":"+config.getInstanceName(), Arrays.asList(dimension), 
+				StandardUnit.Bytes, new Double(nodetool.getHeapMemoryUsage().getUsed())));
+		
+		String dataFileLocation = config.getDataFileLocation();
+		if (dataFileLocation != null) {
+			File file = new File(dataFileLocation);
+			Double usedSpacePercent = 1D - (new Double(file.getUsableSpace())/new Double(file.getTotalSpace()));
+			mDatums.add(createMetricDatum(INSTANCE_USED_SYSTEM_DISKSPACE+":"+config.getInstanceName(), Arrays.asList(dimension), 
+					StandardUnit.Percent, usedSpacePercent*100));
+		}
+		mDatums.add(createMetricDatum(INSTANCE_SYSTEM_LOAD+":"+config.getInstanceName(), Arrays.asList(dimension), 
+				StandardUnit.None, new Double(osMxBean.getSystemLoadAverage())));
+		mDatums.add(createMetricDatum(INSTANCE_FREE_RUNTIME_MEMORY+":"+config.getInstanceName(), Arrays.asList(dimension), 
+				StandardUnit.Bytes, new Double(Runtime.getRuntime().freeMemory())));
+		mDatums.add(createMetricDatum(INSTANCE_CURRENT_THREAD_COUNT+":"+config.getInstanceName(), Arrays.asList(dimension), 
+				StandardUnit.Count, new Double(threadMxBean.getThreadCount())));
+		
+		return mDatums;
+	}
+	
+	
+	/**
+	 * Collects cassandra related metrics
+	 * 
+	 * @return a list of {@link MetricDatum}
+	 */
+	public @Nonnull List<MetricDatum> collectMetrics() {
+		
+		long start = System.currentTimeMillis();
+		List<MetricDatum> mDatums = Lists.newArrayList();
+		mDatums.addAll(collectCassandraInstanceMetrics());
+		mDatums.addAll(collectCassandraCfMetrics());
+		mDatums.addAll(collectCassandraClusterMetrics());
+		long end = System.currentTimeMillis();
+		logger.info("Collecting Hecuba data took " + ((end-start)/1000) + " seconds.");
+		return mDatums;
+	}
+	
+
+	public static MetricDatum createMetricDatum(String metricName, Collection<Dimension> dimensions, StandardUnit unit, Double value) {
+		return createMetricDatum(metricName, dimensions, unit, value, null);
+	}
+	
+	public static MetricDatum createMetricDatum(String metricName, Collection<Dimension> dimensions, StandardUnit unit, StatisticSet statisticSet) {
+		return createMetricDatum(metricName, dimensions, unit, null, statisticSet);
+	}
+	
+	/**
+	 * Private helper method for creating metric datums with a statisticSet
+	 * 
+	 * @return a {@link MetricDatum} to be inserted in AWS cloudwatch
+	 */
+	private static MetricDatum createMetricDatum(String metricName, @Nullable Collection<Dimension> dimensions, 
+			StandardUnit unit, Double value, @Nullable StatisticSet statisticSet) {
+		
+		MetricDatum datum = new MetricDatum().withMetricName(metricName).withDimensions(dimensions)
+					.withUnit(unit).withValue(value).withStatisticValues(statisticSet);
+		return datum;
+	}
+
+	
+
+	// Helper methods
+	public static Double createBytesAmountFromStringifiedValue(String unit, String stringifiedValue) {
+		stringifiedValue = stringifiedValue.replace(" "+unit, "").trim();
+		return new Double(stringifiedValue);
+	}
+	
+	
+	public static Double unstringifyFileSize(String stringifiedValue) {
+        
+		if (stringifiedValue.contains("TB")) {
+        	stringifiedValue = stringifiedValue.replace(" TB", "").trim();
+        	return new Double(stringifiedValue)*TB;
+        } else if (stringifiedValue.contains("GB")) {
+        	stringifiedValue = stringifiedValue.replace(" GB", "").trim();
+        	return new Double(stringifiedValue)*GB;
+        } else if (stringifiedValue.contains("MB")) {
+        	stringifiedValue = stringifiedValue.replace(" MB", "").trim();
+        	return new Double(stringifiedValue)*MB;
+        } else if (stringifiedValue.contains("KB")) {
+        	stringifiedValue = stringifiedValue.replace(" KB", "").trim();
+        	return new Double(stringifiedValue)*KB;
+        } else {
+        	stringifiedValue = stringifiedValue.replace(" bytes", "").trim();
+        	return new Double(stringifiedValue);
+        }
+    }
+	
+	/**
+	 * Helper for wrapping textual representation of units into AWS {@link StandardUnit}
+	 
+	 * @param unit as a string
+	 * @return calculated {@link StandardUnit}
+	 */
+	public static StandardUnit computeUnit(String unit) {
+		
+		if (unit.contains("TB")) {
+        	return StandardUnit.Terabytes;
+        } else if (unit.contains("GB")) {
+        	return StandardUnit.Gigabytes;
+        } else if (unit.contains("MB")) {
+        	return StandardUnit.Megabytes;
+        } else if (unit.contains("KB")) {
+        	return StandardUnit.Kilobytes;
+        } else if (unit.contains("ytes")) {
+        	return StandardUnit.Bytes;
+        } else {
+        	throw new IllegalArgumentException("Unit ["+unit+"] not supported.");
+        }
+	}
+	
+	// setter only for mocking
+	public void setNodeTool(JMXNodeTool nodeTool) {
+		this.nodetool = nodeTool;
+	}
+	public void setOsMxBean(OperatingSystemMXBean osMxBean) {
+		this.osMxBean = osMxBean;
+	}
+	public void setThreadMxBean(ThreadMXBean threadMxBean) {
+		this.threadMxBean = threadMxBean;
+	}
+
+}

--- a/priam/src/main/java/com/netflix/priam/metrics/MetricsCollector.java
+++ b/priam/src/main/java/com/netflix/priam/metrics/MetricsCollector.java
@@ -191,7 +191,7 @@ public class MetricsCollector {
 			mDatums.add(createMetricDatum(CF_PENDING_TASKS, Arrays.asList(dimension), 
 					StandardUnit.Count, new Double(cfMetric.getPendingTasks())));
 			mDatums.add(createMetricDatum(CF_USED_DISKSPACE, Arrays.asList(dimension), 
-					StandardUnit.Gigabytes, new Double(cfMetric.getTotalDiskSpaceUsed()/BYTES_TO_GIGABYTES)));
+					StandardUnit.Megabytes, new Double(cfMetric.getTotalDiskSpaceUsed()/BYTES_TO_MEGABYTES)));
 			mDatums.add(createMetricDatum(CF_READ_LATENCY_MICROS, Arrays.asList(dimension), 
 					StandardUnit.Microseconds, new Double(cfMetric.getAvgReadLatencyMicros())));
 			mDatums.add(createMetricDatum(CF_WRITE_LATENCY_MICROS, Arrays.asList(dimension), 

--- a/priam/src/main/java/com/netflix/priam/metrics/MetricsCollector.java
+++ b/priam/src/main/java/com/netflix/priam/metrics/MetricsCollector.java
@@ -71,7 +71,7 @@ public class MetricsCollector {
 	public static final String CLUSTER_PENDING_TASKS = CLUSTER+"_pending_tasks";
 	
 	// instance metrics
-	private static final String INSTANCE = "instance";
+	public static final String INSTANCE = "instance";
 	public static final String INSTANCE_FILE_LOAD = "file_load";
 	public static final String INSTANCE_USED_HEAP = "used_heap";
 	public static final String INSTANCE_USED_SYSTEM_DISKSPACE = "used_system_diskspace";
@@ -88,6 +88,7 @@ public class MetricsCollector {
 	public static final String CF_USED_DISKSPACE = "used_diskspace";
 	
 	private static final long BYTES_TO_MEGABYTES = 1024*1024;
+	private static final long BYTES_TO_GIGABYTES = BYTES_TO_MEGABYTES*1024;
 	
 	@Inject
 	public MetricsCollector(IConfiguration config) throws JMXConnectionException {
@@ -190,7 +191,7 @@ public class MetricsCollector {
 			mDatums.add(createMetricDatum(CF_PENDING_TASKS, Arrays.asList(dimension), 
 					StandardUnit.Count, new Double(cfMetric.getPendingTasks())));
 			mDatums.add(createMetricDatum(CF_USED_DISKSPACE, Arrays.asList(dimension), 
-					StandardUnit.Bytes, new Double(cfMetric.getTotalDiskSpaceUsed())));
+					StandardUnit.Gigabytes, new Double(cfMetric.getTotalDiskSpaceUsed()/BYTES_TO_GIGABYTES)));
 			mDatums.add(createMetricDatum(CF_READ_LATENCY_MICROS, Arrays.asList(dimension), 
 					StandardUnit.Microseconds, new Double(cfMetric.getAvgReadLatencyMicros())));
 			mDatums.add(createMetricDatum(CF_WRITE_LATENCY_MICROS, Arrays.asList(dimension), 

--- a/priam/src/main/java/com/netflix/priam/metrics/MetricsCollector.java
+++ b/priam/src/main/java/com/netflix/priam/metrics/MetricsCollector.java
@@ -88,7 +88,6 @@ public class MetricsCollector {
 	public static final String CF_USED_DISKSPACE = "used_diskspace";
 	
 	private static final long BYTES_TO_MEGABYTES = 1024*1024;
-	private static final long BYTES_TO_GIGABYTES = BYTES_TO_MEGABYTES*1024;
 	
 	@Inject
 	public MetricsCollector(IConfiguration config) throws JMXConnectionException {

--- a/priam/src/main/java/com/netflix/priam/metrics/MetricsSender.java
+++ b/priam/src/main/java/com/netflix/priam/metrics/MetricsSender.java
@@ -1,0 +1,75 @@
+package com.netflix.priam.metrics;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.netflix.priam.IConfiguration;
+import com.netflix.priam.ICredential;
+
+/**
+ * connects to AWS cloudwatch and puts monitoring data
+ */
+@Singleton
+public class MetricsSender {
+	
+	private static final Logger logger = LoggerFactory.getLogger(MetricsSender.class);
+	
+	// default value
+	private String namespace = "CASSANDRA-METRICS";
+	private final ICredential provider;
+	private final IConfiguration config;
+	private AmazonCloudWatchClient cloudWatchClient;
+
+	@Inject
+	public MetricsSender(IConfiguration config, ICredential provider) {
+		getNamespace(config);
+		this.provider = provider;
+		this.config = config;
+		cloudWatchClient = new AmazonCloudWatchClient(provider.getAwsCredentialProvider());
+		cloudWatchClient.setEndpoint(config.getCloudwatchMonitoringEndpoint());
+		logger.info("Cloudwatch client with endpoint ["+ config.getCloudwatchMonitoringEndpoint() +"] successfully instantiated");
+	} 
+	
+	
+	// for testing
+	protected MetricsSender(IConfiguration config, AmazonCloudWatchClient cloudWatchClient, ICredential provider) {
+		getNamespace(config);
+		this.provider = provider;
+		this.config = config;
+		this.cloudWatchClient = cloudWatchClient;
+	}
+
+
+	private void getNamespace(IConfiguration config) {
+		String ns = config.getAppName();
+		if (ns == null || "".equals(ns.trim())) {
+			logger.warn("Using default namespace [" +namespace + "] as there's no app name configured.");
+		} else {
+			this.namespace  = ns;
+		}
+	} 
+	
+	/**
+	 * Finally inserts metric data into cloudwatch
+	 * 
+	 * @param datums
+	 */
+	public void sendMetrics(List<MetricDatum> datums) {
+		
+		for (MetricDatum datum : datums) {
+			logger.debug("Putting metric: [" + datum.toString()+"]");
+			PutMetricDataRequest request = new PutMetricDataRequest().withMetricData(datum).withNamespace(namespace);
+			cloudWatchClient.putMetricData(request);
+		}
+		logger.info("Put [" + datums.size() + "] metrics into cloudwatch!");
+	}
+	
+
+}

--- a/priam/src/main/java/com/netflix/priam/metrics/MetricsSender.java
+++ b/priam/src/main/java/com/netflix/priam/metrics/MetricsSender.java
@@ -68,7 +68,7 @@ public class MetricsSender {
 			PutMetricDataRequest request = new PutMetricDataRequest().withMetricData(datum).withNamespace(namespace);
 			cloudWatchClient.putMetricData(request);
 		}
-		logger.info("Put [" + datums.size() + "] metrics into cloudwatch!");
+		logger.debug("Put [" + datums.size() + "] metrics into cloudwatch!");
 	}
 	
 

--- a/priam/src/main/java/com/netflix/priam/metrics/MetricsSender.java
+++ b/priam/src/main/java/com/netflix/priam/metrics/MetricsSender.java
@@ -23,15 +23,11 @@ public class MetricsSender {
 	
 	// default value
 	private String namespace = "CASSANDRA-METRICS";
-	private final ICredential provider;
-	private final IConfiguration config;
 	private AmazonCloudWatchClient cloudWatchClient;
 
 	@Inject
 	public MetricsSender(IConfiguration config, ICredential provider) {
 		getNamespace(config);
-		this.provider = provider;
-		this.config = config;
 		cloudWatchClient = new AmazonCloudWatchClient(provider.getAwsCredentialProvider());
 		cloudWatchClient.setEndpoint(config.getCloudwatchMonitoringEndpoint());
 		logger.info("Cloudwatch client with endpoint ["+ config.getCloudwatchMonitoringEndpoint() +"] successfully instantiated");
@@ -41,8 +37,6 @@ public class MetricsSender {
 	// for testing
 	protected MetricsSender(IConfiguration config, AmazonCloudWatchClient cloudWatchClient, ICredential provider) {
 		getNamespace(config);
-		this.provider = provider;
-		this.config = config;
 		this.cloudWatchClient = cloudWatchClient;
 	}
 

--- a/priam/src/main/java/com/netflix/priam/resources/HecubaServlet.java
+++ b/priam/src/main/java/com/netflix/priam/resources/HecubaServlet.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.priam.resources;
+
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.httpclient.HttpStatus;
+import org.codehaus.jettison.json.JSONObject;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import com.google.inject.Inject;
+import com.netflix.priam.IConfiguration;
+import com.netflix.priam.PriamServer;
+import com.netflix.priam.metrics.MetricsCollector;
+import com.netflix.priam.metrics.HecubaTask;
+import com.netflix.priam.scheduler.PriamScheduler;
+
+@Path("/v1/metrics")
+@Produces(MediaType.APPLICATION_JSON)
+public class HecubaServlet
+{
+    private static final Logger logger = LoggerFactory.getLogger(HecubaServlet.class);
+	public static final String WAS_NOT_SCHEDULED = "was not scheduled";
+    
+    private final HecubaTask task;
+	private final MetricsCollector collector;
+	private final PriamScheduler scheduler;
+
+	
+    @Inject
+    public HecubaServlet(PriamServer priamServer, IConfiguration config, MetricsCollector collector, 
+    						PriamScheduler scheduler, HecubaTask task) {
+        this.collector = collector;
+        this.scheduler = scheduler;
+        this.task = task;
+    }
+
+    
+    @GET
+    @Path("/status")
+    public Response getStatus() throws Exception {
+        
+        JSONObject response = new JSONObject();
+        response.put("metrics", stringifyMetricsState());
+        response.put("successful executions", task.getExecutionCount());
+        response.put("non-successful executions", task.getErrorCount());
+        response.put("repeat", "every " + HecubaTask.INTERVAL +" ms");
+        return Response.ok(response.toString(), MediaType.APPLICATION_JSON).build();
+        
+    }
+
+    
+    @GET
+    @Path("/enable")
+    public Response enableMetrics() throws Exception {
+        
+    	task.setMetricsEnabled(true);
+    	JSONObject response = new JSONObject().put("metrics", stringifyMetricsState());
+//    	if (isJobScheduled()) {
+//    		scheduler.getScheduler().resumeJob(HecubaTask.JOBNAME, Scheduler.DEFAULT_GROUP);
+//    		logger.info("Resumed hecuba job");
+//    		response.put("job", "resumed");
+//    	} else {
+//    		response.put("job", WAS_NOT_SCHEDULED);
+//    	}
+    										  
+        return Response.ok(response.toString(), MediaType.APPLICATION_JSON).build();
+        
+    }
+
+	@GET
+    @Path("/disable")
+    public Response disableMetrics() throws Exception {
+        
+    	task.setMetricsEnabled(false);
+    	JSONObject response = new JSONObject().put("metrics", stringifyMetricsState());
+//    	if (isJobScheduled()) {
+//    		scheduler.getScheduler().pauseJob(HecubaTask.JOBNAME, Scheduler.DEFAULT_GROUP);
+//    		logger.info("Paused hecuba job");
+//    		response.put("job", "paused");
+//    	} else {
+//    		response.put("job", WAS_NOT_SCHEDULED);
+//    	}
+    		
+        return Response.ok(response.toString(), MediaType.APPLICATION_JSON).build();
+        
+    }
+
+    
+    @GET
+    @Path("/get")
+    public Response getMetrics() throws Exception {
+        
+        JSONObject response = new JSONObject();
+        List<MetricDatum> res = collector.collectMetrics();
+        response.put("hecuba metrics", res);
+        return Response.ok(response.toString(), MediaType.APPLICATION_JSON).build();
+        
+    }
+    
+    @GET
+    @Path("/send")
+    public Response sendMetrics() throws Exception {
+        
+        JSONObject response = new JSONObject();
+        task.execute();
+        response.put("sent metrics", HttpStatus.SC_OK);
+        return Response.ok(response.toString(), MediaType.APPLICATION_JSON).build();
+        
+    }
+	
+	private String stringifyMetricsState() {
+		return task.isMetricsEnabled() == true ? "enabled" : "disabled";
+	}
+	
+	public boolean isJobScheduled() throws SchedulerException {
+    	String[] jobNames = scheduler.getScheduler().getJobNames(Scheduler.DEFAULT_GROUP);
+    	if (jobNames != null) {
+    		for (String name : jobNames) {
+				if (name.equals(HecubaTask.JOBNAME))
+					return true;
+			}
+    	}
+    	return false;
+	}
+}

--- a/priam/src/main/java/com/netflix/priam/resources/HecubaServlet.java
+++ b/priam/src/main/java/com/netflix/priam/resources/HecubaServlet.java
@@ -34,8 +34,8 @@ import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import com.google.inject.Inject;
 import com.netflix.priam.IConfiguration;
 import com.netflix.priam.PriamServer;
-import com.netflix.priam.metrics.MetricsCollector;
 import com.netflix.priam.metrics.HecubaTask;
+import com.netflix.priam.metrics.MetricsCollector;
 import com.netflix.priam.scheduler.PriamScheduler;
 
 @Path("/v1/metrics")
@@ -79,14 +79,6 @@ public class HecubaServlet
         
     	task.setMetricsEnabled(true);
     	JSONObject response = new JSONObject().put("metrics", stringifyMetricsState());
-//    	if (isJobScheduled()) {
-//    		scheduler.getScheduler().resumeJob(HecubaTask.JOBNAME, Scheduler.DEFAULT_GROUP);
-//    		logger.info("Resumed hecuba job");
-//    		response.put("job", "resumed");
-//    	} else {
-//    		response.put("job", WAS_NOT_SCHEDULED);
-//    	}
-    										  
         return Response.ok(response.toString(), MediaType.APPLICATION_JSON).build();
         
     }
@@ -97,14 +89,6 @@ public class HecubaServlet
         
     	task.setMetricsEnabled(false);
     	JSONObject response = new JSONObject().put("metrics", stringifyMetricsState());
-//    	if (isJobScheduled()) {
-//    		scheduler.getScheduler().pauseJob(HecubaTask.JOBNAME, Scheduler.DEFAULT_GROUP);
-//    		logger.info("Paused hecuba job");
-//    		response.put("job", "paused");
-//    	} else {
-//    		response.put("job", WAS_NOT_SCHEDULED);
-//    	}
-    		
         return Response.ok(response.toString(), MediaType.APPLICATION_JSON).build();
         
     }
@@ -135,15 +119,5 @@ public class HecubaServlet
 	private String stringifyMetricsState() {
 		return task.isMetricsEnabled() == true ? "enabled" : "disabled";
 	}
-	
-	public boolean isJobScheduled() throws SchedulerException {
-    	String[] jobNames = scheduler.getScheduler().getJobNames(Scheduler.DEFAULT_GROUP);
-    	if (jobNames != null) {
-    		for (String name : jobNames) {
-				if (name.equals(HecubaTask.JOBNAME))
-					return true;
-			}
-    	}
-    	return false;
-	}
+
 }

--- a/priam/src/main/java/com/netflix/priam/scheduler/CronTimer.java
+++ b/priam/src/main/java/com/netflix/priam/scheduler/CronTimer.java
@@ -27,6 +27,7 @@ import org.quartz.Trigger;
 public class CronTimer implements TaskTimer
 {
     private String cronExpression;
+	private static String crontrigger = "CronTrigger";
 
     public enum DayOfWeek
     {
@@ -62,11 +63,17 @@ public class CronTimer implements TaskTimer
      */
     public CronTimer(String expression)
     {
+        this(crontrigger, expression);
+    }
+    
+    public CronTimer(String name, String expression)
+    {
         this.cronExpression = expression;
+        crontrigger = name;
     }
 
     public Trigger getTrigger() throws ParseException
     {
-        return new CronTrigger("CronTrigger", Scheduler.DEFAULT_GROUP, cronExpression);
+        return new CronTrigger(crontrigger , Scheduler.DEFAULT_GROUP, cronExpression);
     }
 }

--- a/priam/src/main/java/com/netflix/priam/scheduler/PriamScheduler.java
+++ b/priam/src/main/java/com/netflix/priam/scheduler/PriamScheduler.java
@@ -21,6 +21,8 @@ import org.quartz.JobDetail;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.SchedulerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -33,6 +35,7 @@ public class PriamScheduler
 {
     private final Scheduler scheduler;
     private final GuiceJobFactory jobFactory;
+    private static final Logger logger = LoggerFactory.getLogger(PriamScheduler.class);
 
     @Inject
     public PriamScheduler(SchedulerFactory factory, GuiceJobFactory jobFactory)
@@ -57,6 +60,8 @@ public class PriamScheduler
         assert timer != null : "Cannot add scheduler task " + name + " as no timer is set";
         JobDetail job = new JobDetail(name, Scheduler.DEFAULT_GROUP, taskclass);
         scheduler.scheduleJob(job, timer.getTrigger());
+        logger.info("Added job to scheduler: ["+job+"]");
+        
     }
 
     /**
@@ -79,6 +84,7 @@ public class PriamScheduler
             		catch (ParseException e) {}
             }
         }).start();
+        logger.info("Added delayed job to scheduler: ["+job+"]");
     }
     
     public void runTaskNow(Class<? extends Task> taskclass) throws Exception

--- a/priam/src/main/java/com/netflix/priam/utils/CassandraMonitor.java
+++ b/priam/src/main/java/com/netflix/priam/utils/CassandraMonitor.java
@@ -53,12 +53,12 @@ public class CassandraMonitor extends Task{
         		Process p = Runtime.getRuntime().exec("pgrep -f " + config.getCassProcessName());
         		BufferedReader input = new BufferedReader(new InputStreamReader(p.getInputStream()));
             String line = input.readLine();
-        		if (line != null&& !isCassadraStarted())
+        		if (line != null&& !isCassandraStarted())
         		{
         			//Setting cassandra flag to true
         			isCassandraStarted.set(true);
         		}
-        		else if(line  == null&& isCassadraStarted())
+        		else if(line  == null&& isCassandraStarted())
         		{
         			//Setting cassandra flag to false
         			isCassandraStarted.set(false);
@@ -84,13 +84,13 @@ public class CassandraMonitor extends Task{
         return JOBNAME;
     }
 
-    public static Boolean isCassadraStarted()
+    public static Boolean isCassandraStarted()
     {
         return isCassandraStarted.get();
     }
 
     //Added for testing only
-    public static void setIsCassadraStarted()
+    public static void setIsCassandraStarted()
     {
 		//Setting cassandra flag to true
 		isCassandraStarted.set(true);

--- a/priam/src/main/java/com/netflix/priam/utils/JMXNodeTool.java
+++ b/priam/src/main/java/com/netflix/priam/utils/JMXNodeTool.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import javax.management.JMX;
@@ -47,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.priam.IConfiguration;
+import com.netflix.priam.metrics.CfMetric;
 
 /**
  * Class to get data out of Cassandra JMX
@@ -132,7 +134,7 @@ public class JMXNodeTool extends NodeProbe
     		JMXNodeTool jmxNodeTool = null;
     		
 		// If Cassandra is started then only start the monitoring
-		if (!CassandraMonitor.isCassadraStarted()) {
+		if (!CassandraMonitor.isCassandraStarted()) {
 			String exceptionMsg = "Cassandra is not yet started, check back again later";
 			logger.debug(exceptionMsg);
 			throw new JMXConnectionException(exceptionMsg);
@@ -170,7 +172,7 @@ public class JMXNodeTool extends NodeProbe
     @SuppressWarnings("unchecked")
     public JSONObject estimateKeys() throws JSONException
     {
-        Iterator<Entry<String, ColumnFamilyStoreMBean>> it = super.getColumnFamilyStoreMBeanProxies();
+        Iterator<Entry<String, ColumnFamilyStoreMBean>> it = getCfMBeanProxies();
         JSONObject object = new JSONObject();
         while (it.hasNext())
         {
@@ -181,7 +183,13 @@ public class JMXNodeTool extends NodeProbe
         }
         return object;
     }
+    
+    
+    public Iterator<Entry<String, ColumnFamilyStoreMBean>> getCfMBeanProxies() {
+    	return super.getColumnFamilyStoreMBeanProxies();
+    }
 
+    
     @SuppressWarnings("unchecked")
     public JSONObject info() throws JSONException
     {
@@ -338,4 +346,6 @@ public class JMXNodeTool extends NodeProbe
             super.close();
         }
     }
+
+	
 }

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -2,10 +2,11 @@ package com.netflix.priam;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.inject.Singleton;
-import com.netflix.priam.IConfiguration;
 
 @Singleton
 public class FakeConfiguration implements IConfiguration
@@ -406,5 +407,20 @@ public class FakeConfiguration implements IConfiguration
 	@Override
 	public boolean doesCassandraStartManually() {
 		return false;
+	}
+
+	@Override
+	public String getCloudwatchMonitoringEndpoint() {
+		return null;
+	}
+
+	@Override
+	public boolean isMetricsEnabled() {
+		return false;
+	}
+
+	@Override
+	public Set<String> getMetricsForColumnFamilies() {
+		return null;
 	}
 }

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackup.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackup.java
@@ -62,7 +62,7 @@ public class TestBackup
         filesystem.setupTest();
         SnapshotBackup backup = injector.getInstance(SnapshotBackup.class);
         CassandraMonitor cassMon = injector.getInstance(CassandraMonitor.class);
-        cassMon.setIsCassadraStarted();
+        cassMon.setIsCassandraStarted();
         backup.execute();
         Assert.assertEquals(3, filesystem.uploadedFiles.size());
         System.out.println(filesystem.uploadedFiles.size());

--- a/priam/src/test/java/com/netflix/priam/metrics/HecubaServletTest.java
+++ b/priam/src/test/java/com/netflix/priam/metrics/HecubaServletTest.java
@@ -64,14 +64,6 @@ public class HecubaServletTest {
 		
 	}
 	
-	@Test
-	public void testIsJobEnabled() throws Exception {
-		
-		createExpectations(HecubaTask.JOBNAME, true);
-		Assert.assertTrue(servlet.isJobScheduled());
-		createExpectations("bliblablupp", true);
-		Assert.assertFalse(servlet.isJobScheduled());
-	}
 	
 	@Test
 	public void testEnableDisable() throws Exception {

--- a/priam/src/test/java/com/netflix/priam/metrics/HecubaServletTest.java
+++ b/priam/src/test/java/com/netflix/priam/metrics/HecubaServletTest.java
@@ -1,0 +1,135 @@
+package com.netflix.priam.metrics;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.ws.rs.core.Response;
+
+import mockit.Mocked;
+import mockit.NonStrict;
+import mockit.NonStrictExpectations;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+
+import com.amazonaws.services.cloudwatch.model.Dimension;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import com.amazonaws.services.cloudwatch.model.StandardUnit;
+import com.google.common.collect.Lists;
+import com.netflix.priam.IConfiguration;
+import com.netflix.priam.PriamServer;
+import com.netflix.priam.resources.HecubaServlet;
+import com.netflix.priam.scheduler.PriamScheduler;
+import com.netflix.priam.utils.CassandraMonitor;
+
+public class HecubaServletTest {
+
+	private @Mocked @NonStrict PriamServer priamServer;
+    private @Mocked @NonStrict IConfiguration config;
+    private @Mocked @NonStrict HecubaTask task;
+    private @Mocked @NonStrict PriamScheduler scheduler;
+	private HecubaServlet servlet;
+	
+	
+	@Test
+	public void testGetMetrics() throws Exception {
+		
+		CassandraMonitor.setIsCassandraStarted();
+		final List<MetricDatum> mDatums = Lists.newArrayList();
+		
+		Dimension dimension = new Dimension().withName("testapp").withValue("myinstance");
+		MetricDatum datum1 = MetricsCollector.createMetricDatum(MetricsCollector.INSTANCE_FREE_RUNTIME_MEMORY+":myinstance", Arrays.asList(dimension), 
+				StandardUnit.Bytes, new Double(13));
+		mDatums.add(datum1);
+		mDatums.add(MetricsCollector.createMetricDatum(MetricsCollector.INSTANCE_CURRENT_THREAD_COUNT+":myinstance", Arrays.asList(dimension), 
+				StandardUnit.Count, new Double(12)));
+		
+		
+		new NonStrictExpectations() {
+			MetricsCollector hcm;
+            {	
+            	servlet = new HecubaServlet(priamServer, config, hcm, scheduler, task);
+            	hcm.collectMetrics(); result = mDatums;
+            }
+            
+		};
+		
+		Response res = servlet.getMetrics();
+		Object entity = res.getEntity();
+		Assert.assertTrue(entity.toString().contains("hecuba metrics"));
+		Assert.assertTrue(entity.toString().contains("testapp"));
+		Assert.assertTrue(entity.toString().contains(MetricsCollector.INSTANCE_FREE_RUNTIME_MEMORY));
+		
+	}
+	
+	@Test
+	public void testIsJobEnabled() throws Exception {
+		
+		createExpectations(HecubaTask.JOBNAME, true);
+		Assert.assertTrue(servlet.isJobScheduled());
+		createExpectations("bliblablupp", true);
+		Assert.assertFalse(servlet.isJobScheduled());
+	}
+	
+	@Test
+	public void testEnableDisable() throws Exception {
+		
+		createExpectations(null, true);
+		Assert.assertTrue(servlet.enableMetrics().getEntity().toString().contains("enabled"));
+		createExpectations(null, false);
+		Assert.assertTrue(servlet.disableMetrics().getEntity().toString().contains("disabled"));
+	}
+	
+	@Test
+	public void testSend() throws Exception {
+		new NonStrictExpectations() {
+			PriamScheduler scheduler;
+			MetricsCollector hcm;
+			HecubaTask task;
+			{
+				servlet = new HecubaServlet(priamServer, config, hcm, scheduler, task);
+				task.execute(); times = 1;
+			}
+		};
+		servlet.sendMetrics();
+	}
+
+	
+	@Test
+	public void testStatus() throws Exception {
+		
+		new NonStrictExpectations() {
+			MetricsCollector hcm;
+			{
+				servlet = new HecubaServlet(priamServer, config, hcm, scheduler, task);
+			}
+		};
+		Response res = servlet.getStatus();
+		Assert.assertTrue(res.getEntity().toString().contains("non-successful executions"));
+	}
+
+	
+	
+	
+	
+	private void createExpectations(final String jobName, final boolean metricsEnabled) throws SchedulerException {
+		
+		new NonStrictExpectations() {
+			
+			PriamScheduler scheduler;
+			Scheduler qScheduler;
+			MetricsCollector hcm;
+			HecubaTask task;
+			{
+				servlet = new HecubaServlet(priamServer, config, hcm, scheduler, task);
+				scheduler.getScheduler(); result = qScheduler;
+				qScheduler.getJobNames(anyString); result = Arrays.asList(jobName, "someOtherJob").toArray();
+				task.isMetricsEnabled(); result = metricsEnabled;
+				
+			}
+		};
+	}
+
+}

--- a/priam/src/test/java/com/netflix/priam/metrics/MetricsCollectorTest.java
+++ b/priam/src/test/java/com/netflix/priam/metrics/MetricsCollectorTest.java
@@ -1,0 +1,170 @@
+package com.netflix.priam.metrics;
+
+import java.lang.management.MemoryUsage;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.management.ThreadMXBean;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import junit.framework.Assert;
+import mockit.NonStrictExpectations;
+
+import org.apache.cassandra.db.ColumnFamilyStoreMBean;
+import org.codehaus.jettison.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.services.cloudwatch.model.Dimension;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import com.amazonaws.services.cloudwatch.model.StandardUnit;
+import com.amazonaws.services.cloudwatch.model.StatisticSet;
+import com.amazonaws.util.json.JSONException;
+import com.google.common.collect.Lists;
+import com.netflix.priam.IConfiguration;
+import com.netflix.priam.utils.CassandraMonitor;
+import com.netflix.priam.utils.JMXConnectionException;
+import com.netflix.priam.utils.JMXNodeTool;
+
+public class MetricsCollectorTest {
+	
+	private MetricsCollector mCollector;
+    private static final Logger logger = LoggerFactory.getLogger(MetricsCollectorTest.class);
+	
+    @Before
+    public void setUp() throws JMXConnectionException
+    {
+    	CassandraMonitor.setIsCassandraStarted();
+    }
+    
+    @Test
+	public void testMetricsCollection() throws JSONException, org.codehaus.jettison.json.JSONException, JMXConnectionException {
+		
+		final List<CfMetric> someHcfMetrics = Lists.newArrayList();
+		CfMetric m1 = new CfMetric("keyspace1", "columnFamilyName1", 1, 42, 123456789, 987654321, 100000);
+		CfMetric m2 = new CfMetric("keyspace2", "columnFamilyName2", 1, 42, 23456789, 98765432, 200000);
+		someHcfMetrics.add(m1);
+		someHcfMetrics.add(m2);
+		
+		
+		final List<MetricDatum> mDatums = Lists.newArrayList();
+		Dimension dimension = new Dimension().withName("testapp").withValue("myinstance");
+		MetricDatum datum1 = MetricsCollector.createMetricDatum(MetricsCollector.INSTANCE_FREE_RUNTIME_MEMORY+":myinstance", Arrays.asList(dimension), 
+				StandardUnit.Bytes, new Double(13));
+		mDatums.add(datum1);
+		mDatums.add(MetricsCollector.createMetricDatum(MetricsCollector.INSTANCE_CURRENT_THREAD_COUNT+":myinstance", Arrays.asList(dimension), 
+				StandardUnit.Count, new Double(12)));
+		
+		final Map<String, String> someMap = new HashMap<String, String>();
+		someMap.put("127.0.0.1", "45.8 bytes");
+		someMap.put("127.0.0.2", "15.8 TB");
+		
+		final JSONObject object = new JSONObject();
+		object.put("keyspace", "k1");
+        object.put("column_family", "ode-to-my-family");
+        object.put("estimated_size", "1234567");
+        
+        final Iterator<Entry<String, ColumnFamilyStoreMBean>> someIter = new ArrayList<Entry<String, ColumnFamilyStoreMBean>>().iterator();
+		
+		new NonStrictExpectations() {
+			
+			MemoryUsage memUsage;
+			JMXNodeTool nodetool;
+			ThreadMXBean threadMxBean;
+			OperatingSystemMXBean osMxBean;
+			IConfiguration config;
+
+			{
+				
+				mCollector = new MetricsCollector(config, osMxBean, threadMxBean, nodetool);
+				config.getDataFileLocation(); result = null;
+				config.getAppName(); result = "testApp";
+				config.getInstanceName(); result = "myInstanceName";
+				osMxBean.getSystemLoadAverage(); result = 1.23D;
+				threadMxBean.getThreadCount(); result = 42;
+				
+				nodetool.getColumnFamilyStoreMBeanProxies(); result = someIter;
+				nodetool.getLiveNodes(); result = Arrays.asList("1");
+				nodetool.getUnreachableNodes(); result = Arrays.asList("0");
+				nodetool.getLoadMap(); result = someMap;
+				nodetool.estimateKeys(); result = object;
+				nodetool.getHeapMemoryUsage(); result = memUsage;
+				memUsage.getUsed(); result = 123456l;
+				nodetool.getLoadMap(); result = someMap;
+				
+			}
+		};
+		
+		List<MetricDatum> res = mCollector.collectMetrics();
+		Map<String, MetricDatum> m = new HashMap<String, MetricDatum>();
+		for (MetricDatum metricDatum : res) {
+			m.put(metricDatum.getMetricName(), metricDatum);
+			logger.info(metricDatum.toString());
+		}
+		Assert.assertEquals(8, res.size());
+		Assert.assertEquals(m.get(MetricsCollector.INSTANCE_USED_HEAP+":myInstanceName").getValue().longValue(), 123456l);
+		Assert.assertNotNull(m.get(MetricsCollector.INSTANCE_FREE_RUNTIME_MEMORY+":myInstanceName").getValue());
+		Assert.assertNotNull(m.get(MetricsCollector.INSTANCE_FREE_RUNTIME_MEMORY+":myInstanceName").getValue());
+		Assert.assertNotNull(m.get(MetricsCollector.INSTANCE_CURRENT_THREAD_COUNT+":myInstanceName").getValue());
+		Assert.assertNotNull(m.get(MetricsCollector.CLUSTER_LIVE_NODES).getValue());
+		Assert.assertNotNull(m.get(MetricsCollector.INSTANCE_FILE_LOAD+":127.0.0.2").getValue());
+		
+	}
+    
+	@Test
+	public void testCreatingDatums() {
+		
+		MetricDatum res1; 
+		
+		res1 = MetricsCollector.createMetricDatum(MetricsCollector.INSTANCE_FREE_RUNTIME_MEMORY, null, 
+				StandardUnit.Bytes, 1.2D);
+		
+		Assert.assertEquals(1.2D, res1.getValue());
+		Assert.assertEquals(MetricsCollector.INSTANCE_FREE_RUNTIME_MEMORY, res1.getMetricName());
+		Assert.assertEquals(Collections.EMPTY_LIST, res1.getDimensions());
+		
+		
+		res1 = MetricsCollector.createMetricDatum(MetricsCollector.INSTANCE_FREE_RUNTIME_MEMORY, 
+				Arrays.asList(new Dimension().withName("dim1").withValue("none")), 
+				StandardUnit.Bytes, 1.2D);
+		
+		Assert.assertEquals(1.2D, res1.getValue());
+		Assert.assertEquals(MetricsCollector.INSTANCE_FREE_RUNTIME_MEMORY, res1.getMetricName());
+		Assert.assertEquals("dim1", res1.getDimensions().get(0).getName());
+		
+		res1 = MetricsCollector.createMetricDatum(MetricsCollector.INSTANCE_FREE_RUNTIME_MEMORY, 
+				Arrays.asList(new Dimension().withName("dim1").withValue("none")), 
+				StandardUnit.Bytes, new StatisticSet().withMaximum(10D).withMinimum(2D).withSampleCount(2D).withSum(12D));
+		
+		Assert.assertEquals(2D, res1.getStatisticValues().getMinimum());
+		Assert.assertEquals(MetricsCollector.INSTANCE_FREE_RUNTIME_MEMORY, res1.getMetricName());
+		Assert.assertEquals("dim1", res1.getDimensions().get(0).getName());
+		Assert.assertEquals(StandardUnit.Bytes.name(), res1.getUnit().toString());
+		
+	}
+	
+	@Test
+	public void testComputeUnits() {
+		
+		Assert.assertEquals(MetricsCollector.computeUnit("bytes"), StandardUnit.Bytes);
+		Assert.assertEquals(MetricsCollector.computeUnit("KB  "), StandardUnit.Kilobytes);
+		Assert.assertEquals(MetricsCollector.computeUnit("   MB"), StandardUnit.Megabytes);
+		Assert.assertEquals(MetricsCollector.computeUnit("GB"), StandardUnit.Gigabytes);
+		Assert.assertEquals(MetricsCollector.computeUnit("TB"), StandardUnit.Terabytes);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testComputeUnitsEx() {
+
+		MetricsCollector.computeUnit("xB");
+	}
+	
+	
+}

--- a/priam/src/test/java/com/netflix/priam/metrics/MetricsSenderTest.java
+++ b/priam/src/test/java/com/netflix/priam/metrics/MetricsSenderTest.java
@@ -1,0 +1,36 @@
+package com.netflix.priam.metrics;
+
+import java.util.List;
+
+import mockit.Mocked;
+import mockit.NonStrict;
+import mockit.NonStrictExpectations;
+
+import org.junit.Test;
+
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import com.amazonaws.util.json.JSONException;
+import com.google.common.collect.Lists;
+import com.netflix.priam.utils.JMXConnectionException;
+
+public class MetricsSenderTest {
+	
+	private @NonStrict @Mocked MetricsSender mSender;
+	
+    
+    @Test
+	public void testSendMetrics() throws JSONException, org.codehaus.jettison.json.JSONException, JMXConnectionException {
+    	
+    	final List<MetricDatum> metrics = Lists.newArrayList();
+		new NonStrictExpectations() {
+
+			{	
+				mSender.sendMetrics(metrics); times = 2;				
+			}
+		};
+		
+		mSender.sendMetrics(metrics);
+		mSender.sendMetrics(metrics);
+	}
+    
+}


### PR DESCRIPTION
Documentation for the addition is only inline yet but will follow as soon as I know where it should go. 
In general there's another job running who send metrics to AWS cloudwatch based on priam config values. Also a servlet for maintaining the job is included.
Where does documentation go?