### PR TITLE
Remove num_tokens from priam configuration.

### DIFF
--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -328,11 +328,6 @@ public interface IConfiguration
     public String getCassProcessName();
 
     /**
-     * Get the number of tokens node uses; used as part of vnodes support
-     */
-    public int getNumTokens();
-
-    /**
     * Defaults to 'allow all'.
      */
     public String getAuthenticator();

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/StandardTuner.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/StandardTuner.java
@@ -69,7 +69,8 @@ public class StandardTuner implements CassandraTuner
         m.put("class_name", seedProvider);
 
         configureGlobalCaches(config, map);
-	map.put("num_tokens", config.getNumTokens());
+        //force to 1 until vnodes are properly supported
+	    map.put("num_tokens", 1);
 
         logger.info(yaml.dump(map));
         yaml.dump(map, new FileWriter(yamlFile));


### PR DESCRIPTION
Priam doesn't support vnodes yet, and the interaction of a non-vnode priam and a vnode c\* are not well understood (and I'm not sure if it's desirable). Best to wait until priam fully supports vnodes to support the yaml config for it.
