### PR TITLE
fix duplicate row keys for nodes on us-west-1 and us-west-2

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/SDBInstanceData.java
+++ b/priam/src/main/java/com/netflix/priam/aws/SDBInstanceData.java
@@ -58,7 +58,7 @@ public class SDBInstanceData
     }
     public static final String DOMAIN = "InstanceIdentity";
     public static final String ALL_QUERY = "select * from " + DOMAIN + " where " + Attributes.APP_ID + "='%s'";
-    public static final String INSTANCE_QUERY = "select * from " + DOMAIN + " where " + Attributes.APP_ID + "='%s' and " + Attributes.ID + "='%d'";
+    public static final String INSTANCE_QUERY = "select * from " + DOMAIN + " where " + Attributes.APP_ID + "='%s ' and " + Attributes.LOCATION + "='%s ' and " + Attributes.ID + "='%d'";
 
     private final ICredential provider;
     
@@ -75,10 +75,10 @@ public class SDBInstanceData
      * @param id Node ID
      * @return the node with the given {@code id}, or {@code null} if no such node exists
      */
-    public PriamInstance getInstance(String app, int id)
+    public PriamInstance getInstance(String app, String dc, int id)
     {
         AmazonSimpleDBClient simpleDBClient = getSimpleDBClient();
-        SelectRequest request = new SelectRequest(String.format(INSTANCE_QUERY, app, id));
+        SelectRequest request = new SelectRequest(String.format(INSTANCE_QUERY, app, dc, id));
         SelectResult result = simpleDBClient.select(request);
         if (result.getItems().size() == 0)
             return null;
@@ -223,7 +223,7 @@ public class SDBInstanceData
 
     private String getKey(PriamInstance instance)
     {
-        return instance.getApp() + instance.getId();
+        return instance.getApp() + "_" + instance.getDC() + "_" + instance.getId();
     }
     
     private AmazonSimpleDBClient getSimpleDBClient(){

--- a/priam/src/main/java/com/netflix/priam/aws/SDBInstanceFactory.java
+++ b/priam/src/main/java/com/netflix/priam/aws/SDBInstanceFactory.java
@@ -64,9 +64,9 @@ public class SDBInstanceFactory implements IPriamInstanceFactory
     }
 
     @Override
-    public PriamInstance getInstance(String appName, int id)
+    public PriamInstance getInstance(String appName, String dc, int id)
     {
-      return dao.getInstance(appName, id);
+      return dao.getInstance(appName, dc, id);
     }
 
     @Override
@@ -80,7 +80,7 @@ public class SDBInstanceFactory implements IPriamInstanceFactory
             {
                 try
                 {
-                    PriamInstance oldData = dao.getInstance(app, id);
+                    PriamInstance oldData = dao.getInstance(app, config.getDC(), id);
                     // clean up a very old data...
                     if (null != oldData && oldData.getUpdatetime() < (System.currentTimeMillis() - (3 * 60 * 1000)))
                         dao.deregisterInstance(oldData);

--- a/priam/src/main/java/com/netflix/priam/identity/IPriamInstanceFactory.java
+++ b/priam/src/main/java/com/netflix/priam/identity/IPriamInstanceFactory.java
@@ -41,7 +41,7 @@ public interface IPriamInstanceFactory
      * @param id the node id
      * @return the node with the given {@code id}, or {@code null} if none found
      */
-    public PriamInstance getInstance(String appName, int id);
+    public PriamInstance getInstance(String appName, String dc, int id);
 
     /**
      * Create/Register an instance of the server with its info.

--- a/priam/src/main/java/com/netflix/priam/resources/PriamInstanceResource.java
+++ b/priam/src/main/java/com/netflix/priam/resources/PriamInstanceResource.java
@@ -132,7 +132,7 @@ public class PriamInstanceResource
      */
     private PriamInstance getByIdIfFound(int id)
     {
-        PriamInstance instance = factory.getInstance(config.getAppName(), id);
+        PriamInstance instance = factory.getInstance(config.getAppName(), config.getDC(), id);
         if (instance == null) {
             throw notFound(String.format("No priam instance with id %s found", id));
         }

--- a/priam/src/test/java/com/netflix/priam/FakePriamInstanceFactory.java
+++ b/priam/src/test/java/com/netflix/priam/FakePriamInstanceFactory.java
@@ -30,7 +30,7 @@ public class FakePriamInstanceFactory implements IPriamInstanceFactory
     }
     
     @Override
-    public PriamInstance getInstance(String appName, int id) {
+    public PriamInstance getInstance(String appName, String dc, int id) {
       return instances.get(id);
     }
 

--- a/priam/src/test/java/com/netflix/priam/resources/PriamInstanceResourceTest.java
+++ b/priam/src/test/java/com/netflix/priam/resources/PriamInstanceResourceTest.java
@@ -62,7 +62,7 @@ public class PriamInstanceResourceTest
 
             {
                 config.getAppName(); result = APP_NAME;
-                factory.getInstance(APP_NAME, NODE_ID); result = instance;
+                factory.getInstance(APP_NAME, config.getDC(), NODE_ID); result = instance;
                 instance.toString(); result = expected;
             }
         };
@@ -75,7 +75,7 @@ public class PriamInstanceResourceTest
     {
         new Expectations() {{
             config.getAppName(); result = APP_NAME;
-            factory.getInstance(APP_NAME, NODE_ID); result = null;
+            factory.getInstance(APP_NAME, config.getDC(), NODE_ID); result = null;
         }};
 
         try
@@ -121,7 +121,7 @@ public class PriamInstanceResourceTest
 
           {
               config.getAppName(); result = APP_NAME;
-              factory.getInstance(APP_NAME, NODE_ID); result = instance;
+              factory.getInstance(APP_NAME, config.getDC(), NODE_ID); result = instance;
               factory.delete(instance);
           }
         };
@@ -135,7 +135,7 @@ public class PriamInstanceResourceTest
     {
         new Expectations() {{
             config.getAppName(); result = APP_NAME;
-            factory.getInstance(APP_NAME, NODE_ID); result = null;
+            factory.getInstance(APP_NAME, config.getDC(), NODE_ID); result = null;
         }};
 
         try


### PR DESCRIPTION
Fix duplicate row keys for nodes on us-west-1 and us-west-2 due the usage of Java's hashcode to compute the keys.
