### PR TITLE
upgraded jersey-multipart to 1.9.1 to match other jersey libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
         compile "commons-io:commons-io:2.0.1"
         compile "commons-cli:commons-cli:1.2"
         compile "commons-httpclient:commons-httpclient:3.1"
-        compile "com.sun.jersey.contribs:jersey-multipart:1.1.4.1"
+        compile "com.sun.jersey.contribs:jersey-multipart:1.9.1"
         compile "com.sun.jersey:jersey-json:1.9.1"
         compile "com.google.guava:guava:14.0.1"
         compile "com.google.code.findbugs:jsr305:1.3.9"


### PR DESCRIPTION
multipart is pulling in the 1.1.4.1 core.  This patch will make them match.