### PR TITLE
Seed list is now a list of strings in public IP4 format.

### DIFF
--- a/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -217,14 +217,14 @@ public class InstanceIdentity
             if (membership.getRacMembershipSize() != locMap.get(myInstance.getRac()).size())
                 return seeds;
             // If seed node, return the next node in the list
-            if (locMap.get(myInstance.getRac()).size() > 1 && locMap.get(myInstance.getRac()).get(0).getHostName().equals(myInstance.getHostName()))
-                seeds.add(locMap.get(myInstance.getRac()).get(1).getHostName());
+            if (locMap.get(myInstance.getRac()).size() > 1 && locMap.get(myInstance.getRac()).get(0).getHostIP().equals(myInstance.getHostIP()))
+                seeds.add(locMap.get(myInstance.getRac()).get(1).getHostIP());
         }
         for (String loc : locMap.keySet())
         {
         		PriamInstance instance = Iterables.tryFind(locMap.get(loc), differentHostPredicate).orNull();
         		if (instance != null)
-        			seeds.add(instance.getHostName());
+        			seeds.add(instance.getHostIP());
         }
         return seeds;
     }
@@ -232,8 +232,8 @@ public class InstanceIdentity
     public boolean isSeed()
     {
         populateRacMap();
-        String ip = locMap.get(myInstance.getRac()).get(0).getHostName();
-        return myInstance.getHostName().equals(ip);
+        String ip = locMap.get(myInstance.getRac()).get(0).getHostIP();
+        return myInstance.getHostIP().equals(ip);
     }
     
     public boolean isReplace(){


### PR DESCRIPTION
This solves these 3 issues in a C\* process caused by the bug:
1. Every C\* JVM holds 2 connection pools (4 threads total) for each same-region seed node.
   "WRITE-/50.16.3.113" daemon prio=10 tid=0x00007f4404032000 nid=0x1e98 waiting on condition [0x00007f440aca8000]
   "WRITE-/50.16.3.113" daemon prio=10 tid=0x00007f4404096800 nid=0x1e97 waiting on condition [0x00007f440acd5000]
   "WRITE-ec2-50-16-3-113.compute-1.amazonaws.com/10.166.46.179" daemon prio=10 tid=0x00000000019d0800 nid=0x1e95 waiting on condition [0x00007f440ad02000]
   "WRITE-ec2-50-16-3-113.compute-1.amazonaws.com/10.166.46.179" daemon prio=10 tid=0x00000000015be800 nid=0x1e94 waiting on condition [0x00007f4410725000]
   
   This obviously costs us some CPU and thread resources on every C\* node. We only need one connection pool for each remote node.
2. Another problem is that when that seed node goes down, FailureDetector in C\* JVM can only help to remove one connection pool (and its threads) associated with that
   down node's Public IP endpoint. The connection pool associated with DNS names would stay. We are wasting 2 more threads on each same-region node when we replace a seed node in Ec2.
3. Avoid some intra-region gossipping between nodes to go through SSL port.  Remember that SSL traffics are only for inter-region connections and all intra-region traffics should go through
   non-SSL port.
