### PR TITLE
Fix for issue 260

### DIFF
--- a/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -218,13 +218,23 @@ public class InstanceIdentity
                 return seeds;
             // If seed node, return the next node in the list
             if (locMap.get(myInstance.getRac()).size() > 1 && locMap.get(myInstance.getRac()).get(0).getHostIP().equals(myInstance.getHostIP()))
-                seeds.add(locMap.get(myInstance.getRac()).get(1).getHostIP());
+            {	
+            	if (config.isMultiDC())
+            		seeds.add(locMap.get(myInstance.getRac()).get(1).getHostIP());
+            	else 
+            		seeds.add(locMap.get(myInstance.getRac()).get(1).getHostName());
+            }
         }
         for (String loc : locMap.keySet())
         {
         		PriamInstance instance = Iterables.tryFind(locMap.get(loc), differentHostPredicate).orNull();
         		if (instance != null)
-        			seeds.add(instance.getHostIP());
+        		{
+        			if (config.isMultiDC())
+        			   seeds.add(instance.getHostIP());
+        			else
+        			   seeds.add(instance.getHostName());
+        		}
         }
         return seeds;
     }


### PR DESCRIPTION
If not multi-dc cluster, get_seeds will return list of public ec2 names to let DNS server to resolve to private IPs.  As in this case, C\* use the normal Ec2Snitch and it does not translate public names to private IPs nicely. C\* nodes do connect through Private IPs and non-ssl port eventually but they still hold around the undesired Public IP's OutboundTCPConnection. Also, without this change, Cassandra's handshake connections initially have to go through Public IPs and SSL port before being able to settle down on the private IPs and non-ssl port.
