### PR TITLE
Decoupled DC from Region

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+1.2.5
+- Decoupled definition of DC from Region in configuration and all used
+  instances. This enabled further development to support multiple C*
+  clusters (OLAP and OLTP) in one AWS region, something DSE already does.
+
+1.2 (master)
+- Support for C* 1.2
+
 1.1
 - Support for cassandra 1.1
 - Support to publish cassandra metrics (TODO)

--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -189,15 +189,26 @@ public interface IConfiguration
     public String getRestoreSnapshot();
 
     /**
-     * @return Get the Data Center name (or region for AWS)
+     * @return Get the AWS region name like us-east
+     */
+    public String getRegion();
+
+    /**
+     * @param region
+     *            Set the current AWS region
+     */
+    public void setRegion(String region);
+
+    /**
+     * @return Get the Data Center name
      */
     public String getDC();
 
     /**
-     * @param region
+     * @param dc
      *            Set the current data center
      */
-    public void setDC(String region);
+    public void setDC(String dc);
 
     /**
      * @return true if it is a multi regional cluster

--- a/priam/src/main/java/com/netflix/priam/aws/AWSMembership.java
+++ b/priam/src/main/java/com/netflix/priam/aws/AWSMembership.java
@@ -217,14 +217,14 @@ public class AWSMembership implements IMembership
     protected AmazonAutoScaling getAutoScalingClient()
     {
         AmazonAutoScaling client = new AmazonAutoScalingClient(provider.getAwsCredentialProvider());
-        client.setEndpoint("autoscaling." + config.getDC() + ".amazonaws.com");
+        client.setEndpoint("autoscaling." + config.getRegion() + ".amazonaws.com");
         return client;
     }
 
     protected AmazonEC2 getEc2Client()
     {
         AmazonEC2 client = new AmazonEC2Client(provider.getAwsCredentialProvider());
-        client.setEndpoint("ec2." + config.getDC() + ".amazonaws.com");
+        client.setEndpoint("ec2." + config.getRegion() + ".amazonaws.com");
         return client;
     }
 }

--- a/priam/src/main/java/com/netflix/priam/aws/S3BackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3BackupPath.java
@@ -55,7 +55,7 @@ public class S3BackupPath extends AbstractBackupPath
     {
         StringBuffer buff = new StringBuffer();
         buff.append(baseDir).append(S3BackupPath.PATH_SEP); // Base dir
-        buff.append(region).append(S3BackupPath.PATH_SEP);
+        buff.append(dc).append(S3BackupPath.PATH_SEP);
         buff.append(clusterName).append(S3BackupPath.PATH_SEP);// Cluster name
         buff.append(token).append(S3BackupPath.PATH_SEP);
         buff.append(formatDate(time)).append(S3BackupPath.PATH_SEP);
@@ -87,7 +87,7 @@ public class S3BackupPath extends AbstractBackupPath
         if(pieces.size() == NUM_PATH_ELEMENTS_CASS_1_0)
                 setCassandra1_0(true);
         baseDir = pieces.get(0);
-        region = pieces.get(1);
+        dc = pieces.get(1);
         clusterName = pieces.get(2);
         token = pieces.get(3);
         time = parseDate(pieces.get(4));
@@ -116,7 +116,7 @@ public class S3BackupPath extends AbstractBackupPath
         }
         assert pieces.size() >= 4 : "Too few elements in path " + remoteFilePath;
         baseDir = pieces.get(0);
-        region = pieces.get(1);
+        dc = pieces.get(1);
         clusterName = pieces.get(2);
         token = pieces.get(3);
     }
@@ -129,18 +129,18 @@ public class S3BackupPath extends AbstractBackupPath
         if (elements.length <= 1)
         {
             baseDir = config.getBackupLocation();
-            region = config.getDC();
+            dc = config.getDC();
             clusterName = config.getAppName();
         }
         else
         {
             assert elements.length >= 4 : "Too few elements in path " + location;
             baseDir = elements[1];
-            region = elements[2];
+            dc = elements[2];
             clusterName = elements[3];
         }
         buff.append(baseDir).append(S3BackupPath.PATH_SEP);
-        buff.append(region).append(S3BackupPath.PATH_SEP);
+        buff.append(dc).append(S3BackupPath.PATH_SEP);
         buff.append(clusterName).append(S3BackupPath.PATH_SEP);
 
         token = factory.getInstance().getToken();
@@ -158,18 +158,18 @@ public class S3BackupPath extends AbstractBackupPath
         if (elements.length <= 1)
         {
             baseDir = config.getBackupLocation();
-            region = config.getDC();
+            dc = config.getDC();
             clusterName = config.getAppName();
         }
         else
         {
             assert elements.length >= 4 : "Too few elements in path " + location;
             baseDir = elements[1];
-            region = elements[2];
+            dc = elements[2];
             clusterName = elements[3];
         }
         buff.append(baseDir).append(S3BackupPath.PATH_SEP);
-        buff.append(region).append(S3BackupPath.PATH_SEP);
+        buff.append(dc).append(S3BackupPath.PATH_SEP);
         buff.append(clusterName).append(S3BackupPath.PATH_SEP);
 
         return buff.toString();

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
@@ -55,7 +55,7 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
     protected String fileName;
     protected String baseDir;
     protected String token;
-    protected String region;
+    protected String dc;
     protected Date time;
     protected long size;
     protected boolean isCassandra1_0;
@@ -96,7 +96,7 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
         String[] elements = rpath.split("" + PATH_SEP);
         this.clusterName = config.getAppName();
         this.baseDir = config.getBackupLocation();
-        this.region = config.getDC();
+        this.dc = config.getDC();
         this.token = factory.getInstance().getToken();
         this.type = type;
         if (type != BackupFileType.META && type != BackupFileType.CL)
@@ -224,9 +224,9 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
         return token;
     }
 
-    public String getRegion()
+    public String getDC()
     {
-        return region;
+        return dc;
     }
 
     public Date getTime()

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -78,6 +78,8 @@ public class PriamConfiguration implements IConfiguration
     private static final String CONFIG_TARGET_KEYSPACE_NAME = PRIAM_PRE + ".target.keyspace";
     private static final String CONFIG_TARGET_COLUMN_FAMILY_NAME = PRIAM_PRE + ".target.columnfamily";
     private static final String CONFIG_CASS_MANUAL_START_ENABLE = PRIAM_PRE + ".cass.manual.start.enable";
+    private static final String CONFIG_DC_NAME = PRIAM_PRE + ".dc.name";
+    private static final String CONFIG_DC_SUFFIX = PRIAM_PRE + ".dc.suffix";
 
     // Backup and Restore
     private static final String CONFIG_BACKUP_THREADS = PRIAM_PRE + ".backup.threads";
@@ -251,7 +253,9 @@ public class PriamConfiguration implements IConfiguration
     {
         config.set(CONFIG_ASG_NAME, ASG_NAME);
         config.set(CONFIG_REGION_NAME, REGION);
+        config.set(CONFIG_DC_NAME, REGION + config.get(CONFIG_DC_SUFFIX, ""));
     }
+
 
     @Override
     public String getCassStartupScript()
@@ -383,7 +387,7 @@ public class PriamConfiguration implements IConfiguration
     @Override
     public String getRac()
     {
-        return RAC;
+        return RAC.concat(config.get(CONFIG_DC_SUFFIX,""));
     }
 
     @Override
@@ -438,11 +442,23 @@ public class PriamConfiguration implements IConfiguration
     @Override
     public String getDC()
     {
-        return config.get(CONFIG_REGION_NAME, "");
+        return config.get(CONFIG_DC_NAME, "");
     }
 
     @Override
     public void setDC(String region)
+    {
+        config.set(CONFIG_DC_NAME, region);
+    }
+
+    @Override
+    public String getRegion()
+    {
+        return config.get(CONFIG_REGION_NAME, "");
+    }
+
+    @Override
+    public void setRegion(String region)
     {
         config.set(CONFIG_REGION_NAME, region);
     }

--- a/priam/src/main/java/com/netflix/priam/resources/BackupServlet.java
+++ b/priam/src/main/java/com/netflix/priam/resources/BackupServlet.java
@@ -203,8 +203,8 @@ public class BackupServlet
      * 
      * @param token
      *            Overrides the current token with this one, if specified
-     * @param region
-     *            Override the region for searching backup
+     * @param dc
+     *            Override the dc for searching backup
      * @param startTime
      *            Start time
      * @param endTime
@@ -213,9 +213,9 @@ public class BackupServlet
      *            Comma seperated list of keyspaces to restore
      * @throws Exception
      */
-    private void restore(String token, String region, Date startTime, Date endTime, String keyspaces) throws Exception
+    private void restore(String token, String dc, Date startTime, Date endTime, String keyspaces) throws Exception
     {
-        String origRegion = config.getDC();
+        String origDC = config.getDC();
         String origToken = priamServer.getId().getInstance().getToken();
         if (StringUtils.isNotBlank(token))
             priamServer.getId().getInstance().setToken(token);
@@ -223,11 +223,11 @@ public class BackupServlet
         if( config.isRestoreClosestToken())
             priamServer.getId().getInstance().setToken(closestToken(priamServer.getId().getInstance().getToken(), config.getDC()));
         
-        if (StringUtils.isNotBlank(region))
+        if (StringUtils.isNotBlank(dc))
         {
-            config.setDC(region);
-            logger.info("Restoring from region " + region);
-            priamServer.getId().getInstance().setToken(closestToken(priamServer.getId().getInstance().getToken(), region));
+            config.setDC(dc);
+            logger.info("Restoring from region " + dc);
+            priamServer.getId().getInstance().setToken(closestToken(priamServer.getId().getInstance().getToken(), dc));
             logger.info("Restore will use token " + priamServer.getId().getInstance().getToken());
         }
 
@@ -239,7 +239,7 @@ public class BackupServlet
         }
         finally
         {
-            config.setDC(origRegion);
+            config.setDC(origDC);
             priamServer.getId().getInstance().setToken(origToken);
         }
         tuner.updateAutoBootstrap(config.getYamlLocation(), false);
@@ -289,7 +289,11 @@ public class BackupServlet
 				backupJSON.put("bucket", config.getBackupPrefix());
 				backupJSON.put("filename", p.getRemotePath());
 				backupJSON.put("app", p.getClusterName());
-				backupJSON.put("region", p.getRegion());
+				/* TODO: We should remove region from JSON response, but I am not sure about everyone's usage. So,
+				         keeping it for now. -Arya
+				  */
+                backupJSON.put("region", p.getDC());
+                backupJSON.put("dc", p.getDC());
 				backupJSON.put("token", p.getToken());
 				backupJSON.put("ts", new DateTime(p.getTime()).toString(FMT));
 				backupJSON.put("instance_id", p.getInstanceIdentity()

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -15,6 +15,7 @@ public class FakeConfiguration implements IConfiguration
 	public static final String FAKE_REGION = "us-east-1";
 
     public String region;
+    public String dc;
     public String appName;
     public String zone;
     public String instance_id;
@@ -23,6 +24,7 @@ public class FakeConfiguration implements IConfiguration
     public FakeConfiguration(String region, String appName, String zone, String ins_id)
     {
         this.region = region;
+        this.dc = region;
         this.appName = appName;
         this.zone = zone;
         this.instance_id = ins_id;
@@ -33,7 +35,6 @@ public class FakeConfiguration implements IConfiguration
     public void intialize()
     {
         // TODO Auto-generated method stub
-
     }
 
     @Override
@@ -169,10 +170,17 @@ public class FakeConfiguration implements IConfiguration
     }
 
     @Override
-    public String getDC()
+    public String getRegion()
     {
         // TODO Auto-generated method stub
         return this.region;
+    }
+
+    @Override
+    public String getDC()
+    {
+        // TODO Auto-generated method stub
+        return this.dc;
     }
 
     @Override
@@ -294,10 +302,15 @@ public class FakeConfiguration implements IConfiguration
     }
 
     @Override
-    public void setDC(String region)
+    public void setRegion(String region)
     {
         // TODO Auto-generated method stub
-        
+    }
+
+    @Override
+    public void setDC(String dc)
+    {
+        // TODO Auto-generated method stub
     }
 
     @Override

--- a/priam/src/test/java/com/netflix/priam/backup/FakeBackupFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/FakeBackupFileSystem.java
@@ -124,9 +124,8 @@ public class FakeBackupFileSystem implements IBackupFileSystem
         List<AbstractBackupPath> tmpList = new ArrayList<AbstractBackupPath>();
         for (AbstractBackupPath path : flist)
         {
-
             if ((path.time.after(start) && path.time.before(till)) || path.time.equals(start)
-                && path.baseDir.equals(baseDir) && path.clusterName.equals(clusterName) && path.region.equals(region))
+                && path.baseDir.equals(baseDir) && path.clusterName.equals(clusterName) && path.dc.equals(region))
             {
                  tmpList.add(path);
             }

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackupFile.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackupFile.java
@@ -69,7 +69,7 @@ public class TestBackupFile
         Assert.assertEquals("Standard1", backupfile.columnFamily);
         Assert.assertEquals("1234567", backupfile.token);
         Assert.assertEquals("fake-app", backupfile.clusterName);
-        Assert.assertEquals(FakeConfiguration.FAKE_REGION, backupfile.region);
+        Assert.assertEquals(FakeConfiguration.FAKE_REGION, backupfile.dc);
         Assert.assertEquals("casstestbackup", backupfile.baseDir);
         Assert.assertEquals("casstestbackup/"+FakeConfiguration.FAKE_REGION+"/fake-app/1234567/201108082320/SNAP/Keyspace1/Standard1/Keyspace1-Standard1-ia-5-Data.db", backupfile.getRemotePath());
     }
@@ -86,7 +86,7 @@ public class TestBackupFile
         Assert.assertEquals("Standard1", backupfile.columnFamily);
         Assert.assertEquals("1234567", backupfile.token);
         Assert.assertEquals("fake-app", backupfile.clusterName);
-        Assert.assertEquals(FakeConfiguration.FAKE_REGION, backupfile.region);
+        Assert.assertEquals(FakeConfiguration.FAKE_REGION, backupfile.dc);
         Assert.assertEquals("casstestbackup", backupfile.baseDir);
         String datestr = backupfile.formatDate(new Date(bfile.lastModified()));
         Assert.assertEquals("casstestbackup/"+FakeConfiguration.FAKE_REGION+"/fake-app/1234567/" + datestr + "/SST/Keyspace1/Standard1/Keyspace1-Standard1-ia-5-Data.db", backupfile.getRemotePath());
@@ -104,7 +104,7 @@ public class TestBackupFile
         Assert.assertEquals(BackupFileType.META, backupfile.type);
         Assert.assertEquals("1234567", backupfile.token);
         Assert.assertEquals("fake-app", backupfile.clusterName);
-        Assert.assertEquals(FakeConfiguration.FAKE_REGION, backupfile.region);
+        Assert.assertEquals(FakeConfiguration.FAKE_REGION, backupfile.dc);
         Assert.assertEquals("casstestbackup", backupfile.baseDir);
         Assert.assertEquals("casstestbackup/"+FakeConfiguration.FAKE_REGION+"/fake-app/1234567/201108082320/META/1234567.meta", backupfile.getRemotePath());
     }


### PR DESCRIPTION
Priam is built based on the assumtion that C*'s notion of DC will
always be the AWS region. This limits use cases where we want to have
two Datacenters simulated in one AWS region for different purposes like
one being OLAP and another OLTP. There has been some work done on
integration of DSE. This patch can do what DSE patch does, however it
just addreses the decoupling of DC and Region by separating their
definition in the IConfiguration. You don't have to have DSE to run two
datacenters in one AWS region. Furthermore, it uses a new
configuration parameter called dc_suffix (see CASSANDRA-5155) to emulate different DC
in the same AWS region like DSE. I did not add automatic propagation of
rackdc.properties file as it conflicts with the DSE.

Add Suffix to RAC

Priam uses availability zone's full string (us-east-1) as RAC inside its
configuration. Further this information is used for token computation
and figuring out if nodes belong to the same RAC. We should namespace
this field by DC suffix as well to make it unique accross all DCs.

To properly use this feature, you need to make sure you also suffix the
zone names in your PriamProperties with the suffix you specify in the
configuration. For example if the suffix is _ssd and your zones are

us-east-1a,us-east-1b,us-east-1c

they should become

us-east-1a_ssd,us-east-1b_ssh and us-east-1c_ssd