### PR TITLE
Close uploading streams in all cases. 

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
+import org.apache.commons.io.IOUtils;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.RateLimiter;
 import org.apache.commons.io.IOUtils;
@@ -184,6 +185,8 @@ public class S3FileSystem implements IBackupFileSystem, S3FileSystemMBean
         {
             new S3PartUploader(s3Client, part, partETags).abortUpload();
             throw new BackupRestoreException("Error uploading file " + path.getFileName(), e);
+        } finally {
+            IOUtils.closeQuietly(in);
         }
     }
 


### PR DESCRIPTION
...ening files" when there is an S3 issue blocking the uploading and Priam just keeps the filedescriptor around.
