### PR TITLE
Add support for Eucalyptus endpoints

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/AWSMembership.java
+++ b/priam/src/main/java/com/netflix/priam/aws/AWSMembership.java
@@ -216,15 +216,13 @@ public class AWSMembership implements IMembership
 
     protected AmazonAutoScaling getAutoScalingClient()
     {
-        AmazonAutoScaling client = new AmazonAutoScalingClient(provider.getAwsCredentialProvider());
-        client.setEndpoint("autoscaling." + config.getDC() + ".amazonaws.com");
+        AmazonAutoScaling client = AwsServiceClients.autoScaling( provider.getAwsCredentialProvider(), config.getDC() );
         return client;
     }
 
     protected AmazonEC2 getEc2Client()
     {
-        AmazonEC2 client = new AmazonEC2Client(provider.getAwsCredentialProvider());
-        client.setEndpoint("ec2." + config.getDC() + ".amazonaws.com");
+        AmazonEC2 client = AwsServiceClients.ec2( provider.getAwsCredentialProvider(), config.getDC() );
         return client;
     }
 }

--- a/priam/src/main/java/com/netflix/priam/aws/AwsServiceClients.java
+++ b/priam/src/main/java/com/netflix/priam/aws/AwsServiceClients.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.priam.aws;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.autoscaling.AmazonAutoScaling;
+import com.amazonaws.services.autoscaling.AmazonAutoScalingClient;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+
+
+/**
+ * Static facade to create AWS service clients with appropriately configured endpoints.
+ * 
+ * Endpoints constructed according to: {@link http://docs.aws.amazon.com/general/latest/gr/rande.html}.
+ */
+public class AwsServiceClients {
+  
+  private static boolean isRegion(String region) {
+    try {
+      InetAddress.getByName( "ec2." + region + ".amazonaws.com" );
+      return true;
+    } catch ( UnknownHostException ex ) {
+      return false;
+    }
+  }
+  
+  
+  public static AmazonAutoScaling autoScaling(AWSCredentialsProvider provider, String region) {
+    AmazonAutoScaling client = new AmazonAutoScalingClient(provider);
+    if (isRegion( region )) {
+      client.setEndpoint("autoscaling." + region + ".amazonaws.com");
+    } else {
+      client.setEndpoint( region + ":8773/services/AutoScaling" );
+    }
+    return client;
+  }
+  
+  public static AmazonEC2 ec2(AWSCredentialsProvider provider, String region) {
+    AmazonEC2 client = new AmazonEC2Client(provider);
+    if (isRegion( region )) {
+      client.setEndpoint("ec2." + region + ".amazonaws.com");
+    } else {
+      client.setEndpoint( region + ":8773/services/Eucalyptus" );
+    }
+    return client;
+  }
+ 
+  public static AmazonS3 s3(AWSCredentialsProvider provider, String region) {
+    AmazonS3 client = new AmazonS3Client(provider);
+    if ("us-east-1".equals(region)) {
+      client.setEndpoint("s3.amazonaws.com");
+    } else if (isRegion( region )) {
+      client.setEndpoint("s3-" + region + ".amazonaws.com");
+    } else {
+      client.setEndpoint( region + ":8773/services/Walrus" );
+    }
+    return client;
+  }
+}

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -75,7 +75,7 @@ public class S3FileSystem implements IBackupFileSystem, S3FileSystemMBean
     private AtomicInteger uploadCount = new AtomicInteger();
     private AtomicInteger downloadCount = new AtomicInteger();
 
-    private final AmazonS3Client s3Client;
+    private final AmazonS3 s3Client;
 
     @Inject
     public S3FileSystem(Provider<AbstractBackupPath> pathProvider, ICompression compress, final IConfiguration config, ICredential cred)
@@ -100,28 +100,7 @@ public class S3FileSystem implements IBackupFileSystem, S3FileSystemMBean
             throw new RuntimeException(e);
         }
 
-        s3Client = new AmazonS3Client(cred.getAwsCredentialProvider());
-        s3Client.setEndpoint(getS3Endpoint());
-    }
-
-    /*
-     * S3 End point information
-     * http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
-     */
-    private String getS3Endpoint()
-    {
-        final String curRegion = config.getDC();
-        if("us-east-1".equalsIgnoreCase(curRegion))
-            return "s3.amazonaws.com";
-        if("eu-west-1".equalsIgnoreCase(curRegion))
-            return "s3-eu-west-1.amazonaws.com";
-        if("us-west-1".equalsIgnoreCase(curRegion))
-            return "s3-us-west-1.amazonaws.com";
-        if("us-west-2".equalsIgnoreCase(curRegion))
-            return "s3-us-west-2.amazonaws.com";
-        if("sa-east-1".equalsIgnoreCase(curRegion))
-            return "s3-sa-east-1.amazonaws.com";
-        throw new IllegalStateException("Unsupported region for this application: " + curRegion);
+        s3Client = AwsServiceClients.s3(cred.getAwsCredentialProvider(),config.getDC());
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -25,6 +25,7 @@ import com.google.inject.Singleton;
 import com.netflix.priam.IConfigSource;
 import com.netflix.priam.IConfiguration;
 import com.netflix.priam.ICredential;
+import com.netflix.priam.aws.AwsServiceClients;
 import com.netflix.priam.utils.SystemUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -193,8 +194,7 @@ public class PriamConfiguration implements IConfiguration
      */
     private String populateASGName(String region, String instanceId)
     {
-        AmazonEC2 client = new AmazonEC2Client(provider.getCredentials());
-        client.setEndpoint("ec2." + region + ".amazonaws.com");
+        AmazonEC2 client = AwsServiceClients.ec2( provider.getAwsCredentialProvider(), region );
         DescribeInstancesRequest desc = new DescribeInstancesRequest().withInstanceIds(instanceId);
         DescribeInstancesResult res = client.describeInstances(desc);
 
@@ -216,8 +216,7 @@ public class PriamConfiguration implements IConfiguration
      * Get the fist 3 available zones in the region
      */
     public void setDefaultRACList(String region){
-        AmazonEC2 client = new AmazonEC2Client(provider.getCredentials());
-        client.setEndpoint("ec2." + region + ".amazonaws.com");
+        AmazonEC2 client = AwsServiceClients.ec2( provider.getAwsCredentialProvider(), region);
         DescribeAvailabilityZonesResult res = client.describeAvailabilityZones();
         List<String> zone = Lists.newArrayList();
         for(AvailabilityZone reg : res.getAvailabilityZones()){


### PR DESCRIPTION
- Add facade for constructing AWS service clients w/ configured endpoints.
- Construct clients using facade in AWSMembership, PriamConfiguration, and
  S3FileSystem.
- No support for SimpleDB currently -- SimpleDBConfigSource needs
  alternative credentials.