### PR TITLE
make priam retry getting the asg name

### DIFF
--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -226,11 +226,14 @@ public class PriamConfiguration implements IConfiguration
     
     private class GetASGName extends RetryableCallable<String>
     {
+        private static final int NUMBER_OF_RETRIES = 15;
+        private static final long WAIT_TIME = 30000;
         private final String region;
         private final String instanceId;
         private final AmazonEC2 client;
         
         public GetASGName(String region, String instanceId) {
+            super(NUMBER_OF_RETRIES, WAIT_TIME);
             this.region = region;
             this.instanceId = instanceId;
             client = new AmazonEC2Client(provider.getCredentials());


### PR DESCRIPTION
it sometimes comes out as null because the instance tags have not propagated yet. This adds retrying to ensure we are able to retrieve the ASG name.

(Diff is a little weird, but I basically wrapped the call in RetryableCallable)
