### PR TITLE
Handling the new replaced_address required by cassandra starting from ve...

### DIFF
--- a/priam-cass-extensions/src/main/java/com/netflix/priam/cassandra/extensions/PriamStartupAgent.java
+++ b/priam-cass-extensions/src/main/java/com/netflix/priam/cassandra/extensions/PriamStartupAgent.java
@@ -17,6 +17,9 @@ package com.netflix.priam.cassandra.extensions;
 
 import java.lang.instrument.Instrumentation;
 
+
+import org.apache.cassandra.utils.FBUtilities;
+
 /**
  * A <a href="http://docs.oracle.com/javase/6/docs/api/java/lang/instrument/package-summary.html">PreMain</a> class
  * to run inside of the cassandra process. Contacts Priam for essential cassandra startup information
@@ -24,6 +27,7 @@ import java.lang.instrument.Instrumentation;
  */
 public class PriamStartupAgent
 {
+	public static String REPLACED_ADDRESS_MIN_VER = "1.2.11";
     public static void premain(String agentArgs, Instrumentation inst)
     {
         PriamStartupAgent agent = new PriamStartupAgent();
@@ -35,6 +39,8 @@ public class PriamStartupAgent
         String token = null;
         String seeds = null;
         boolean isReplace = false;
+        String replacedIp = "";
+        
         while (true)
         {
             try
@@ -42,6 +48,7 @@ public class PriamStartupAgent
                 token = DataFetcher.fetchData("http://127.0.0.1:8080/Priam/REST/v1/cassconfig/get_token");
                 seeds = DataFetcher.fetchData("http://127.0.0.1:8080/Priam/REST/v1/cassconfig/get_seeds");
                 isReplace = Boolean.parseBoolean(DataFetcher.fetchData("http://127.0.0.1:8080/Priam/REST/v1/cassconfig/is_replace_token"));
+                replacedIp = DataFetcher.fetchData("http://127.0.0.1:8080/Priam/REST/v1/cassconfig/get_realaced_ip");
             }
             catch (Exception e)
             {
@@ -64,7 +71,17 @@ public class PriamStartupAgent
         System.setProperty("cassandra.initial_token", token);
   
         if (isReplace)
-            System.setProperty("cassandra.replace_token", token);
+        {	
+        	System.out.println("Detect cassandra version : " + FBUtilities.getReleaseVersionString());
+        	if (FBUtilities.getReleaseVersionString().compareTo(REPLACED_ADDRESS_MIN_VER) < 0)
+        	{
+        		System.setProperty("cassandra.replace_token", token);
+        	} else 
+        	{	
+               System.setProperty("cassandra.replace_address", replacedIp);
+        	}
+        }
+
     }
 
 }

--- a/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -71,6 +71,7 @@ public class InstanceIdentity
    
     private PriamInstance myInstance;
     private boolean isReplace = false;
+    private String replacedIp = "";
 
     @Inject
     public InstanceIdentity(IPriamInstanceFactory factory, IMembership membership, IConfiguration config,
@@ -127,6 +128,7 @@ public class InstanceIdentity
 			myInstance = newToken.call();
 		}
         logger.info("My token: " + myInstance.getToken());
+        
     }
 
     private void populateRacMap()
@@ -158,6 +160,7 @@ public class InstanceIdentity
                 // remove it as we marked it down...
                 factory.delete(dead);
                 isReplace = true;
+                replacedIp = markAsDead.getHostIP();
                 String payLoad = markAsDead.getToken();
                 logger.info("Trying to grab slot {} with availability zone {}", markAsDead.getId(), markAsDead.getRac());
                 return factory.create(config.getAppName(), markAsDead.getId(), config.getInstanceName(), config.getHostname(), config.getHostIP(), config.getRac(), markAsDead.getVolumes(), payLoad);
@@ -238,7 +241,7 @@ public class InstanceIdentity
         }
         return seeds;
     }
-
+    
     public boolean isSeed()
     {
         populateRacMap();
@@ -246,7 +249,13 @@ public class InstanceIdentity
         return myInstance.getHostIP().equals(ip);
     }
     
-    public boolean isReplace(){
+    public boolean isReplace() 
+    {
         return isReplace;
+    }
+    
+    public String getReplacedIp()
+    {
+    	return replacedIp;
     }
 }

--- a/priam/src/main/java/com/netflix/priam/resources/CassandraConfig.java
+++ b/priam/src/main/java/com/netflix/priam/resources/CassandraConfig.java
@@ -105,6 +105,24 @@ public class CassandraConfig
         }
     }
 
+    
+    @GET
+    @Path("/get_replaced_ip")
+    public Response getReplacedIp()
+    {
+        try
+        {
+            return Response.ok(String.valueOf(priamServer.getId().getReplacedIp())).build();
+        }
+        catch (Exception e)
+        {
+            // TODO: can this ever happen? if so, what conditions would cause an exception here?
+            logger.error("Error while executing get_replaced_ip", e);
+            return Response.serverError().build();
+        }
+    }
+    
+    
     @GET
     @Path("/double_ring")
     public Response doubleRing() throws IOException, ClassNotFoundException

--- a/priam/src/test/java/com/netflix/priam/resources/CassandraConfigTest.java
+++ b/priam/src/test/java/com/netflix/priam/resources/CassandraConfigTest.java
@@ -176,6 +176,24 @@ public class CassandraConfigTest
     }
 
     @Test
+    public void getReplacedAddress()
+    {
+    	final String replacedIp = "127.0.0.1";
+        new Expectations() {
+            InstanceIdentity identity;
+
+            {
+                priamServer.getId(); result = identity;
+                identity.getReplacedIp(); result = replacedIp;
+            }
+        };
+
+        Response response = resource.getReplacedIp();
+        assertEquals(200, response.getStatus());
+        assertEquals(replacedIp, response.getEntity());
+    }
+    
+    @Test
     public void doubleRing() throws Exception
     {
         new NonStrictExpectations() {{


### PR DESCRIPTION
...rsion 1.2.11.

However, the old replaced_token is still backward compatible if we use cassandra older than 1.2.11.
