### PR TITLE
Extend script execute timeout

### DIFF
--- a/priam/src/main/java/com/netflix/priam/defaultimpl/CassandraProcessManager.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/CassandraProcessManager.java
@@ -24,7 +24,7 @@ public class CassandraProcessManager implements ICassandraProcess
 {
     private static final Logger logger = LoggerFactory.getLogger(CassandraProcessManager.class);
     private static final String SUDO_STRING = "/usr/bin/sudo";
-    private static final int SCRIPT_EXECUTE_WAIT_TIME_MS = 1000;
+    private static final int SCRIPT_EXECUTE_WAIT_TIME_MS = 5000;
     private final IConfiguration config;
     private final Sleeper sleeper;
 


### PR DESCRIPTION
Default value (1s) is too short to work on default init.rd script on smaller ec2 instances with sudo overhead. Extending to 5s.
