### PR TITLE
Fix a bug in double ring case where the newly added nodes think that it ...

### DIFF
--- a/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -159,7 +159,8 @@ public class InstanceIdentity
                         dead.getToken());
                 // remove it as we marked it down...
                 factory.delete(dead);
-                isReplace = true;
+                if (!"new_slot".equals(dead.getInstanceId()))
+                	isReplace = true;
                 replacedIp = markAsDead.getHostIP();
                 String payLoad = markAsDead.getToken();
                 logger.info("Trying to grab slot {} with availability zone {}", markAsDead.getId(), markAsDead.getRac());


### PR DESCRIPTION
...should replace and invalid IP.

For this case, those nodes just have to overwrite the tokens table with its information and should not set the replace_address for C*
