### PR TITLE
Change replacedIP to return external hostname 

### DIFF
--- a/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -167,7 +167,7 @@ public class InstanceIdentity
                 // remove it as we marked it down...
                 factory.delete(dead);
                 isReplace = true;
-                replacedIp = markAsDead.getHostIP();
+                replacedIp = markAsDead.getHostName();
                 String payLoad = markAsDead.getToken();
                 logger.info("Trying to grab slot {} with availability zone {}", markAsDead.getId(), markAsDead.getRac());
                 return factory.create(config.getAppName(), markAsDead.getId(), config.getInstanceName(), config.getHostname(), config.getHostIP(), config.getRac(), markAsDead.getVolumes(), payLoad);


### PR DESCRIPTION
instead of external IP. This resolves to the internal hostname if queried from inside AWS.

When using Ec2Snitch, replace node fails due to Priam sending the external IP of the replaced node as the casasndra.replace_address= option.

With this patch, Priam returns the external DNS for the replaced node, which resolves to the private IP if queried from within AWS. 

I've checked this , and it solved the problem on my setup and replaced nodes now work automatically.
