### PR TITLE
Incremental restore throws an exception if it is started before full restore

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backup/IncrementalRestore.java
+++ b/priam/src/main/java/com/netflix/priam/backup/IncrementalRestore.java
@@ -78,11 +78,16 @@ public class IncrementalRestore extends AbstractRestore
     @Override
     public void execute() throws Exception
     {
-    		String prefix = config.getRestorePrefix();
+        String prefix = config.getRestorePrefix();
         if (Strings.isNullOrEmpty(prefix))
         {
             logger.error("Restore prefix is not set, skipping incremental restore to avoid looping over the incremental backups. Plz check the configurations");
             return; // No point in restoring the files which was just backedup.
+        }
+
+        if (tracker.isEmpty()) {
+            logger.error("You should perform full restore before incremental restore, skipping incremental restore.");
+            return;
         }
 
         if (config.isRestoreClosestToken())


### PR DESCRIPTION
Incremental restore throws NoSuchElementException if it is started before full restore:
```
java.util.NoSuchElementException
        at java.util.TreeMap.key(TreeMap.java:1223)
        at java.util.TreeMap.firstKey(TreeMap.java:284)
        at java.util.TreeSet.first(TreeSet.java:394)
        at com.netflix.priam.backup.IncrementalRestore.execute(IncrementalRestore.java:93)
        at com.netflix.priam.scheduler.Task.execute(Task.java:93)
        at org.quartz.core.JobRunShell.run(JobRunShell.java:199)
        at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:546)
```
Currently there is a AbstractRestore.tracker which aim is to track which files have been already restored and  which are not. But if full restore has not been performed it has empty queue and throws an exception during incremental restoring. As a fix of this issue I decided to add a special check and appropriate error message. Please, review it and let me know if I should change something.