### PR TITLE
make compatible with cassandra 2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ subprojects {
         compile "com.googlecode.json-simple:json-simple:1.1"
         compile "org.xerial.snappy:snappy-java:1.0.5-M3"
         compile "org.yaml:snakeyaml:1.10"
-        compile "org.apache.cassandra:cassandra-all:[1.2.0,1.2.8["
+        compile "org.apache.cassandra:cassandra-all:2.0.7"
         compile "javax.ws.rs:jsr311-api:1.1.1"
         compile "joda-time:joda-time:2.0"
         compile "commons-configuration:commons-configuration:1.5"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.2.29
+version=1.2.30

--- a/gradle/convention.gradle
+++ b/gradle/convention.gradle
@@ -4,7 +4,7 @@ status = project.hasProperty('preferredStatus')?project.preferredStatus:(version
 subprojects { project ->
     apply plugin: 'java' // Plugin as major conventions
 
-    sourceCompatibility = 1.6
+    sourceCompatibility = 1.7
 
     // Restore status after Java plugin
     status = rootProject.status

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
@@ -64,7 +64,7 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
     protected final IConfiguration config;
     protected File backupFile;
     protected Date uploadedTs;
-    
+
     public AbstractBackupPath(IConfiguration config, InstanceIdentity factory)
     {
         this.factory = factory;
@@ -84,7 +84,7 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
     public InputStream localReader() throws IOException
     {
         assert backupFile != null;
-        return new RafInputStream(RandomAccessReader.open(backupFile, true));
+        return new RafInputStream(RandomAccessReader.open(backupFile));
     }
 
     public void parseLocal(File file, BackupFileType type) throws ParseException
@@ -136,9 +136,9 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
         if (type == BackupFileType.CL)
         {
         	buff.append(config.getBackupCommitLogLocation()).append(PATH_SEP);
-        } else 
+        } else
         {
-        
+
         	buff.append(config.getDataFileLocation()).append(PATH_SEP);
         	if (type != BackupFileType.META)
         	{
@@ -148,9 +148,9 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
         			buff.append(keyspace).append(PATH_SEP).append(columnFamily).append(PATH_SEP);
         	}
         }
-        	
+
         buff.append(fileName);
-        
+
         File return_ = new File(buff.toString());
         File parent = new File(return_.getParent());
         if (!parent.exists())
@@ -163,7 +163,7 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
     {
         return getRemotePath().compareTo(o.getRemotePath());
     }
-    
+
     @Override
     public boolean equals(Object obj)
     {
@@ -183,16 +183,16 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
     public abstract void parseRemote(String remoteFilePath);
 
     /**
-     *  Parses paths with just token prefixes 
+     *  Parses paths with just token prefixes
      */
     public abstract void parsePartialPrefix(String remoteFilePath);
 
     /**
-     * Provides a common prefix that matches all objects that fall between 
-     * the start and end time 
+     * Provides a common prefix that matches all objects that fall between
+     * the start and end time
      */
     public abstract String remotePrefix(Date start, Date end, String location);
-    
+
     /**
      * Provides the cluster prefix
      */
@@ -265,7 +265,7 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
 	public void setCassandra1_0(boolean isCassandra1_0) {
 		this.isCassandra1_0 = isCassandra1_0;
 	}
-	
+
     public void setFileName(String fileName)
     {
         this.fileName = fileName;
@@ -275,7 +275,7 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
     {
     		return this.factory;
     }
-    
+
     public void setUploadedTs(Date uploadedTs)
     {
     		this.uploadedTs = uploadedTs;

--- a/priam/src/main/java/com/netflix/priam/utils/JMXNodeTool.java
+++ b/priam/src/main/java/com/netflix/priam/utils/JMXNodeTool.java
@@ -59,9 +59,9 @@ public class JMXNodeTool extends NodeProbe
     /**
      * Hostname and Port to talk to will be same server for now optionally we
      * might want the ip to poll.
-     * 
+     *
      * NOTE: This class shouldn't be a singleton and this shouldn't be cached.
-     * 
+     *
      * This will work only if cassandra runs.
      */
     public JMXNodeTool(String host, int port) throws IOException, InterruptedException
@@ -77,7 +77,7 @@ public class JMXNodeTool extends NodeProbe
 
     /**
      * try to create if it is null.
-     * @throws IOException 
+     * @throws IOException
      */
     public static JMXNodeTool instance(IConfiguration config) throws JMXConnectionException
     {
@@ -112,7 +112,7 @@ public class JMXNodeTool extends NodeProbe
         // connecting first time hence return false.
         if (tool == null)
             return false;
-        
+
         try
         {
             tool.isInitialized();
@@ -128,14 +128,14 @@ public class JMXNodeTool extends NodeProbe
     public static synchronized JMXNodeTool connect(final IConfiguration config) throws JMXConnectionException
     {
     		JMXNodeTool jmxNodeTool = null;
-    		
+
 		// If Cassandra is started then only start the monitoring
 		if (!CassandraMonitor.isCassadraStarted()) {
 			String exceptionMsg = "Cassandra is not yet started, check back again later";
 			logger.debug(exceptionMsg);
 			throw new JMXConnectionException(exceptionMsg);
-		}        		
-    		
+		}
+
     		try {
     				jmxNodeTool = new BoundedExponentialRetryCallable<JMXNodeTool>()
 						{
@@ -288,7 +288,7 @@ public class JMXNodeTool extends NodeProbe
     public void compact() throws IOException, ExecutionException, InterruptedException
     {
         for (String keyspace : getKeyspaces())
-            forceTableCompaction(keyspace, new String[0]);
+            forceKeyspaceCompaction(keyspace, new String[0]);
     }
 
     public void repair(boolean isSequential, boolean localDataCenterOnly) throws IOException, ExecutionException, InterruptedException
@@ -299,21 +299,21 @@ public class JMXNodeTool extends NodeProbe
     {
         for (String keyspace : getKeyspaces())
             if (primaryRange)
-                forceTableRepairPrimaryRange(keyspace, isSequential, localDataCenterOnly, new String[0]);
+                forceKeyspaceRepairPrimaryRange(keyspace, isSequential, localDataCenterOnly, new String[0]);
             else
-                forceTableRepair(keyspace, isSequential, localDataCenterOnly, new String[0]);
+                forceKeyspaceRepair(keyspace, isSequential, localDataCenterOnly, new String[0]);
     }
 
     public void cleanup() throws IOException, ExecutionException, InterruptedException
     {
         for (String keyspace : getKeyspaces())
-            forceTableCleanup(keyspace, new String[0]);
+            forceKeyspaceCleanup(keyspace, new String[0]);
     }
 
     public void flush() throws IOException, ExecutionException, InterruptedException
     {
         for (String keyspace : getKeyspaces())
-            forceTableFlush(keyspace, new String[0]);
+            forceKeyspaceFlush(keyspace, new String[0]);
     }
 
     public void refresh(List<String> keyspaces) throws IOException, ExecutionException, InterruptedException

--- a/priam/src/main/java/org/apache/cassandra/io/sstable/SSTableLoaderWrapper.java
+++ b/priam/src/main/java/org/apache/cassandra/io/sstable/SSTableLoaderWrapper.java
@@ -20,22 +20,49 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.cassandra.auth.IAuthenticator;
+import org.apache.cassandra.config.CFMetaData;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.SystemKeyspace;
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.SSTableLoader.Client;
 import org.apache.cassandra.io.util.FileUtils;
-import org.apache.cassandra.streaming.FileStreamTask;
-import org.apache.cassandra.streaming.OperationType;
-import org.apache.cassandra.streaming.PendingFile;
-import org.apache.cassandra.streaming.StreamHeader;
+import org.apache.cassandra.streaming.ProgressInfo;
+import org.apache.cassandra.streaming.StreamEvent;
+import org.apache.cassandra.streaming.StreamEventHandler;
+import org.apache.cassandra.streaming.StreamResultFuture;
+import org.apache.cassandra.streaming.StreamState;
+import org.apache.cassandra.thrift.AuthenticationRequest;
+import org.apache.cassandra.thrift.Cassandra;
+import org.apache.cassandra.thrift.Compression;
+import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.CqlResult;
+import org.apache.cassandra.thrift.CqlRow;
+import org.apache.cassandra.thrift.ITransportFactory;
+import org.apache.cassandra.thrift.TFramedTransportFactory;
+import org.apache.cassandra.thrift.TokenRange;
+import org.apache.cassandra.tools.BulkLoader;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.OutputHandler;
 import org.apache.cassandra.utils.Pair;
 import org.apache.commons.lang.StringUtils;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.transport.TTransport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
@@ -50,27 +77,27 @@ public class SSTableLoaderWrapper
     private static final Logger logger = LoggerFactory.getLogger(SSTableLoaderWrapper.class);
     private static Set<Component> allComponents = Sets.newHashSet(Component.COMPRESSION_INFO, Component.DATA, Component.FILTER, Component.PRIMARY_INDEX, Component.STATS, Component.DIGEST);
     private final IConfiguration config;
-    
+
     @Inject
     public SSTableLoaderWrapper(IConfiguration config, CassandraTuner tuner) throws IOException
-    {        
+    {
         this.config = config;
         String srcCassYamlFile =  config.getCassHome() + "/conf/cassandra.yaml";
         String targetYamlLocation = "/tmp/";
-        
+
         File sourceFile = new File(srcCassYamlFile);
         File targetFile = new File(targetYamlLocation+"incr-restore-cassandra.yaml");
         logger.info("Copying file : " + sourceFile.getName() +" to --> "+targetFile.getName());
-      
+
         //copy file from one location to another
         Files.copy(sourceFile, targetFile);
-        
+
         logger.info("Trying to load the yaml file from: " + targetFile);
         tuner.writeAllProperties(targetFile.getPath(), "localhost", "org.apache.cassandra.locator.SimpleSeedProvider");
         System.setProperty("cassandra.config", "file:"+ targetFile.getPath());
     }
 
-    private final OutputHandler options = new OutputHandler()
+    private final OutputHandler outputHandler = new OutputHandler()
     {
         public void output(String msg)
         {
@@ -94,52 +121,175 @@ public class SSTableLoaderWrapper
     };
 
     /**
-     * Not multi-threaded intentionally.
-     * @return 
+     * @return
      */
-    public Collection<PendingFile> stream(File directory) throws IOException, InterruptedException
+    public Collection<String> stream(File directory, int throttleMb) throws IOException, InterruptedException
     {
-        Client client = new Client()
-        {
-            public boolean validateColumnFamily(String keyspace, String cfName)
-            {
-                return true;
-            }
+    	InetAddress host = InetAddress.getLocalHost();
+        Client client = new ExternalClient(
+        	ImmutableSet.of(host),
+        	config.getThriftPort(),
+        	null,
+        	null,
+        	new TFramedTransportFactory()
+        );
 
-            public void init(String keyspace)
-            {
-            }
-        };
-        try {
-	    client.setPartitioner(config.getPartitioner());
-	} catch (Exception e) {
-	    logger.error("Configuration Exception while setting partitioner", e);
-	}
-        
-        
-        SSTableLoader loader = new SSTableLoader(directory, client, options);       
-        
-        Collection<PendingFile> pendingFiles = Lists.newArrayList();
-        for (SSTableReader sstable : loader.openSSTables())
+        SSTableLoader loader = new SSTableLoader(directory, client, outputHandler);
+        DatabaseDescriptor.setStreamThroughputOutboundMegabitsPerSec(throttleMb);	// TODO: make configurable
+
+        FileCompletedListener listener = new FileCompletedListener(host);
+        StreamResultFuture future = loader.stream(Collections.<InetAddress>emptySet(), listener);
+
+        try
         {
-            Descriptor desc = sstable.descriptor;
-            List<Pair<Long, Long>> sections = Lists.newArrayList(Pair.create(0L, sstable.onDiskLength()));
-            PendingFile pending = new PendingFile(sstable, desc, SSTable.COMPONENT_DATA, sections, OperationType.BULK_LOAD);
-            StreamHeader header = new StreamHeader(directory.getName(), UUID.randomUUID(), pending, Collections.singleton(pending));
-            logger.info("Streaming to {}", InetAddress.getLocalHost());
-            new FileStreamTask(header, InetAddress.getLocalHost()).run();
-            logger.info("Done Streaming: " + pending.toString());
-            sstable.releaseReference();
-            pendingFiles.add(pending);
+            future.get();
         }
-        return pendingFiles;
+        catch (Exception e) {
+        	logger.error("Failed streaming to the following hosts: " + loader.getFailedHosts(), e);
+        }
+
+        return listener.getCompletedFiles();
     }
 
-    public void deleteCompleted(Collection<PendingFile> sstables) throws IOException
+    public void deleteCompleted(Collection<String> filenames) throws IOException
     {
-        logger.info("Restored SST's Now Deleting: " + StringUtils.join(sstables, ","));
-        for (PendingFile file : sstables)
+        logger.info("Restored SST's Now Deleting: " + StringUtils.join(filenames, ","));
+        for (String filename : filenames)
+        {
+        	Descriptor desc = Descriptor.fromFilename(filename);
+
             for (Component component : allComponents)
-                FileUtils.delete(file.sstable.descriptor.filenameFor(component));
+                FileUtils.delete(desc.filenameFor(component));
+        }
     }
+
+    static class FileCompletedListener implements StreamEventHandler
+    {
+    	private Set<String> completedFiles = Sets.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+    	private final InetAddress host;
+
+    	public FileCompletedListener(InetAddress host)
+    	{
+    		this.host = host;
+    	}
+
+    	public Collection<String> getCompletedFiles()
+    	{
+    		return completedFiles;
+    	}
+
+		@Override
+		public void onSuccess(StreamState result) { }
+
+		@Override
+		public void onFailure(Throwable t) { }
+
+		@Override
+		public void handleStreamEvent(StreamEvent event)
+		{
+			if (event.eventType == StreamEvent.Type.FILE_PROGRESS)
+			{
+				ProgressInfo progress = ((StreamEvent.ProgressEvent) event).progress;
+
+				if (progress.peer != host)
+				{
+					logger.warn("Ignoring progress about unexpected host " + progress.peer);
+					return;
+				}
+
+				if (progress.currentBytes == progress.totalBytes)
+				{
+					logger.info("Completed streaming of file: " + progress.fileName);
+					completedFiles.add(progress.fileName);
+				}
+			}
+		}
+    }
+
+
+    // Cloned from Cassandra's BulkLoader.java because it's protected.
+    static class ExternalClient extends SSTableLoader.Client
+    {
+        private final Map<String, CFMetaData> knownCfs = new HashMap<>();
+        private final Set<InetAddress> hosts;
+        private final int rpcPort;
+        private final String user;
+        private final String passwd;
+        private final ITransportFactory transportFactory;
+
+        public ExternalClient(Set<InetAddress> hosts, int port, String user, String passwd, ITransportFactory transportFactory)
+        {
+            super();
+            this.hosts = hosts;
+            this.rpcPort = port;
+            this.user = user;
+            this.passwd = passwd;
+            this.transportFactory = transportFactory;
+        }
+
+        public void init(String keyspace)
+        {
+            Iterator<InetAddress> hostiter = hosts.iterator();
+            while (hostiter.hasNext())
+            {
+                try
+                {
+                    // Query endpoint to ranges map and schemas from thrift
+                    InetAddress host = hostiter.next();
+                    Cassandra.Client client = createThriftClient(host.getHostAddress(), rpcPort, this.user, this.passwd, this.transportFactory);
+
+                    setPartitioner(client.describe_partitioner());
+                    Token.TokenFactory tkFactory = getPartitioner().getTokenFactory();
+
+                    for (TokenRange tr : client.describe_ring(keyspace))
+                    {
+                        Range<Token> range = new Range<>(tkFactory.fromString(tr.start_token), tkFactory.fromString(tr.end_token));
+                        for (String ep : tr.endpoints)
+                        {
+                            addRangeForEndpoint(range, InetAddress.getByName(ep));
+                        }
+                    }
+
+                    String query = String.format("SELECT * FROM %s.%s WHERE keyspace_name = '%s'",
+                                                 Keyspace.SYSTEM_KS,
+                                                 SystemKeyspace.SCHEMA_COLUMNFAMILIES_CF,
+                                                 keyspace);
+                    CqlResult result = client.execute_cql3_query(ByteBufferUtil.bytes(query), Compression.NONE, ConsistencyLevel.ONE);
+                    for (CqlRow row : result.rows)
+                    {
+                        CFMetaData metadata = CFMetaData.fromThriftCqlRow(row);
+                        knownCfs.put(metadata.cfName, metadata);
+                    }
+                    break;
+                }
+                catch (Exception e)
+                {
+                    if (!hostiter.hasNext())
+                        throw new RuntimeException("Could not retrieve endpoint ranges: ", e);
+                }
+            }
+        }
+
+        public CFMetaData getCFMetaData(String keyspace, String cfName)
+        {
+            return knownCfs.get(cfName);
+        }
+
+        private static Cassandra.Client createThriftClient(String host, int port, String user, String passwd, ITransportFactory transportFactory) throws Exception
+        {
+            TTransport trans = transportFactory.openTransport(host, port);
+            TProtocol protocol = new TBinaryProtocol(trans);
+            Cassandra.Client client = new Cassandra.Client(protocol);
+            if (user != null && passwd != null)
+            {
+                Map<String, String> credentials = new HashMap<String, String>();
+                credentials.put(IAuthenticator.USERNAME_KEY, user);
+                credentials.put(IAuthenticator.PASSWORD_KEY, passwd);
+                AuthenticationRequest authenticationRequest = new AuthenticationRequest(credentials);
+                client.login(authenticationRequest);
+            }
+            return client;
+        }
+    }
+
 }

--- a/priam/src/test/java/com/netflix/priam/stream/StreamingTest.java
+++ b/priam/src/test/java/com/netflix/priam/stream/StreamingTest.java
@@ -8,7 +8,6 @@ import com.netflix.priam.defaultimpl.StandardTuner;
 import junit.framework.Assert;
 
 import org.apache.cassandra.io.sstable.SSTableLoaderWrapper;
-import org.apache.cassandra.streaming.PendingFile;
 import org.junit.Test;
 
 import com.google.inject.Guice;
@@ -28,7 +27,7 @@ public class StreamingTest
     {
         IConfiguration config = new FakeConfiguration("test", "cass_upg107_ccs", "test", "ins_id");
         SSTableLoaderWrapper loader = new SSTableLoaderWrapper(config, new StandardTuner(config));
-        Collection<PendingFile> ssts = loader.stream(new File("/tmp/Keyspace2/"));
+        Collection<String> ssts = loader.stream(new File("/tmp/Keyspace2/"), 0);
         loader.deleteCompleted(ssts);
     }
 


### PR DESCRIPTION
Supposedly the master branch of Priam is 2.0 compatible. While this is true for most things, a couple of auxiliary functions are broken (due to Streaming 2.0 as well as some JMX bean renames).

This PR attempts to fix errors I know about, although they're not necessarily battle tested.