### PR TITLE
Dan decouple region dc

### DIFF
--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -37,6 +37,11 @@ public interface IConfiguration
     public String getYamlLocation();
 
     /**
+     * @return Path to cassandra-rackdc.properties directory.
+     */
+    public String getRackDcPropertiesLocation();
+
+    /**
      * @return Path to Cassandra startup script
      */
     public String getCassStartupScript();

--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -194,9 +194,19 @@ public interface IConfiguration
     public String getRestoreSnapshot();
 
     /**
-     * @return Get the Data Center name (or region for AWS)
+     * @return Get the Data Center name
      */
     public String getDC();
+
+    /*
+     * @return Get the Data Center name suffix
+     */
+    public String getDCSuffix();
+
+    /**
+     * @return Get the AWS region
+     */
+    public String getRegion();
 
     /**
      * @param region

--- a/priam/src/main/java/com/netflix/priam/aws/AWSMembership.java
+++ b/priam/src/main/java/com/netflix/priam/aws/AWSMembership.java
@@ -217,14 +217,14 @@ public class AWSMembership implements IMembership
     protected AmazonAutoScaling getAutoScalingClient()
     {
         AmazonAutoScaling client = new AmazonAutoScalingClient(provider.getAwsCredentialProvider());
-        client.setEndpoint("autoscaling." + config.getDC() + ".amazonaws.com");
+        client.setEndpoint("autoscaling." + config.getRegion() + ".amazonaws.com");
         return client;
     }
 
     protected AmazonEC2 getEc2Client()
     {
         AmazonEC2 client = new AmazonEC2Client(provider.getAwsCredentialProvider());
-        client.setEndpoint("ec2." + config.getDC() + ".amazonaws.com");
+        client.setEndpoint("ec2." + config.getRegion() + ".amazonaws.com");
         return client;
     }
 }

--- a/priam/src/main/java/com/netflix/priam/aws/S3BackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3BackupPath.java
@@ -46,16 +46,16 @@ public class S3BackupPath extends AbstractBackupPath
     /**
      * Format of backup path:
      * Cassandra 1.0
-     * BASE/REGION/CLUSTER/TOKEN/[SNAPSHOTTIME]/[SST|SNP|META]/KEYSPACE/FILE
+     * BASE/DC/CLUSTER/TOKEN/[SNAPSHOTTIME]/[SST|SNP|META]/KEYSPACE/FILE
      * Cassandra 1.1
-     * BASE/REGION/CLUSTER/TOKEN/[SNAPSHOTTIME]/[SST|SNP|META]/KEYSPACE/COLUMNFAMILY/FILE
+     * BASE/DC/CLUSTER/TOKEN/[SNAPSHOTTIME]/[SST|SNP|META]/KEYSPACE/COLUMNFAMILY/FILE
      */
     @Override
     public String getRemotePath()
     {
         StringBuffer buff = new StringBuffer();
         buff.append(baseDir).append(S3BackupPath.PATH_SEP); // Base dir
-        buff.append(region).append(S3BackupPath.PATH_SEP);
+        buff.append(dc).append(S3BackupPath.PATH_SEP);
         buff.append(clusterName).append(S3BackupPath.PATH_SEP);// Cluster name
         buff.append(token).append(S3BackupPath.PATH_SEP);
         buff.append(formatDate(time)).append(S3BackupPath.PATH_SEP);
@@ -87,7 +87,7 @@ public class S3BackupPath extends AbstractBackupPath
         if(pieces.size() == NUM_PATH_ELEMENTS_CASS_1_0)
                 setCassandra1_0(true);
         baseDir = pieces.get(0);
-        region = pieces.get(1);
+        dc = pieces.get(1);
         clusterName = pieces.get(2);
         token = pieces.get(3);
         time = parseDate(pieces.get(4));
@@ -116,7 +116,7 @@ public class S3BackupPath extends AbstractBackupPath
         }
         assert pieces.size() >= 4 : "Too few elements in path " + remoteFilePath;
         baseDir = pieces.get(0);
-        region = pieces.get(1);
+        dc = pieces.get(1);
         clusterName = pieces.get(2);
         token = pieces.get(3);
     }
@@ -129,18 +129,18 @@ public class S3BackupPath extends AbstractBackupPath
         if (elements.length <= 1)
         {
             baseDir = config.getBackupLocation();
-            region = config.getDC();
+            dc = config.getDC();
             clusterName = config.getAppName();
         }
         else
         {
             assert elements.length >= 4 : "Too few elements in path " + location;
             baseDir = elements[1];
-            region = elements[2];
+            dc = elements[2];
             clusterName = elements[3];
         }
         buff.append(baseDir).append(S3BackupPath.PATH_SEP);
-        buff.append(region).append(S3BackupPath.PATH_SEP);
+        buff.append(dc).append(S3BackupPath.PATH_SEP);
         buff.append(clusterName).append(S3BackupPath.PATH_SEP);
 
         token = factory.getInstance().getToken();
@@ -158,18 +158,18 @@ public class S3BackupPath extends AbstractBackupPath
         if (elements.length <= 1)
         {
             baseDir = config.getBackupLocation();
-            region = config.getDC();
+            dc = config.getDC();
             clusterName = config.getAppName();
         }
         else
         {
             assert elements.length >= 4 : "Too few elements in path " + location;
             baseDir = elements[1];
-            region = elements[2];
+            dc = elements[2];
             clusterName = elements[3];
         }
         buff.append(baseDir).append(S3BackupPath.PATH_SEP);
-        buff.append(region).append(S3BackupPath.PATH_SEP);
+        buff.append(dc).append(S3BackupPath.PATH_SEP);
         buff.append(clusterName).append(S3BackupPath.PATH_SEP);
 
         return buff.toString();

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -116,7 +116,7 @@ public class S3FileSystem implements IBackupFileSystem, S3FileSystemMBean
      */
     private String getS3Endpoint()
     {
-    	 final String curRegion = config.getDC();
+    	 final String curRegion = config.getRegion();
          if("us-east-1".equalsIgnoreCase(curRegion) ||
             "us-west-1".equalsIgnoreCase(curRegion) ||
             "us-west-2".equalsIgnoreCase(curRegion)	|| 

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
@@ -55,7 +55,7 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
     protected String fileName;
     protected String baseDir;
     protected String token;
-    protected String region;
+    protected String dc;
     protected Date time;
     protected long size;
     protected boolean isCassandra1_0;
@@ -96,7 +96,7 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
         String[] elements = rpath.split("" + PATH_SEP);
         this.clusterName = config.getAppName();
         this.baseDir = config.getBackupLocation();
-        this.region = config.getDC();
+        this.dc = config.getDC();
         this.token = factory.getInstance().getToken();
         this.type = type;
         if (type != BackupFileType.META && type != BackupFileType.CL)
@@ -233,9 +233,9 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
         return token;
     }
 
-    public String getRegion()
+    public String getDC()
     {
-        return region;
+        return dc;
     }
 
     public Date getTime()

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -73,6 +73,7 @@ public class PriamConfiguration implements IConfiguration
     private static final String CONFIG_CASS_PROCESS_NAME = PRIAM_PRE + ".cass.process";
     private static final String CONFIG_VNODE_NUM_TOKENS = PRIAM_PRE + ".vnodes.numTokens";
     private static final String CONFIG_YAML_LOCATION = PRIAM_PRE + ".yamlLocation";
+    private static final String CONFIG_RACK_DC_PROPERTIES_LOCATION = PRIAM_PRE + ".rackDcPropertiesLocation";
     private static final String CONFIG_AUTHENTICATOR = PRIAM_PRE + ".authenticator";
     private static final String CONFIG_AUTHORIZER = PRIAM_PRE + ".authorizer";
     private static final String CONFIG_TARGET_KEYSPACE_NAME = PRIAM_PRE + ".target.keyspace";
@@ -715,6 +716,12 @@ public class PriamConfiguration implements IConfiguration
         return config.get(CONFIG_YAML_LOCATION, getCassHome() + "/conf/cassandra.yaml");
     }
 
+    @Override
+    public String getRackDcPropertiesLocation()
+    {
+        return config.get(CONFIG_RACK_DC_PROPERTIES_LOCATION, "");
+    }
+
     public String getAuthenticator()
     {
         return config.get(CONFIG_AUTHENTICATOR, DEFAULT_AUTHENTICATOR);
@@ -836,7 +843,7 @@ public class PriamConfiguration implements IConfiguration
     
     
     public String getS3EndPoint() {
-    	String region = getDC();
+    	String region = getRegion();
     	
     	String s3Url = null;
     	

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -27,6 +27,7 @@ import com.google.inject.Singleton;
 import com.netflix.priam.IConfigSource;
 import com.netflix.priam.IConfiguration;
 import com.netflix.priam.ICredential;
+import com.netflix.priam.utils.AsgNameParser;
 import com.netflix.priam.utils.RetryableCallable;
 import com.netflix.priam.utils.SystemUtils;
 
@@ -139,6 +140,7 @@ public class PriamConfiguration implements IConfiguration
     // Amazon specific
     private static final String CONFIG_ASG_NAME = PRIAM_PRE + ".az.asgname";
     private static final String CONFIG_REGION_NAME = PRIAM_PRE + ".az.region";
+    private static final String CONFIG_DC_SUFFIX = PRIAM_PRE + ".az.dcSuffix";
     private static final String CONFIG_ACL_GROUP_NAME = PRIAM_PRE + ".acl.groupname";
     private final String RAC = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/placement/availability-zone");
     private final String PUBLIC_HOSTNAME;
@@ -149,6 +151,7 @@ public class PriamConfiguration implements IConfiguration
     private final String INSTANCE_TYPE = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/instance-type").trim();
     private static String ASG_NAME = System.getenv("ASG_NAME");
     private static String REGION = System.getenv("EC2_REGION");
+    private static String DC_SUFFIX;
     private static final String CONFIG_VPC_RING = PRIAM_PRE + ".vpc";
 
 
@@ -334,6 +337,7 @@ public class PriamConfiguration implements IConfiguration
     {
         config.set(CONFIG_ASG_NAME, ASG_NAME);
         config.set(CONFIG_REGION_NAME, REGION);
+        config.set(CONFIG_DC_SUFFIX, AsgNameParser.parseAsgName(ASG_NAME).getDcSuffix());
     }
 
     @Override
@@ -525,6 +529,19 @@ public class PriamConfiguration implements IConfiguration
 
     @Override
     public String getDC()
+    {
+        return config.get(CONFIG_REGION_NAME, "") + getDCSuffix();
+    }
+
+    @Override
+    public String getDCSuffix()
+    {
+        return config.get(CONFIG_DC_SUFFIX, "");
+    }
+
+
+    @Override
+    public String getRegion()
     {
         return config.get(CONFIG_REGION_NAME, "");
     }

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/StandardTuner.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/StandardTuner.java
@@ -109,19 +109,28 @@ public class StandardTuner implements CassandraTuner
     private void writeCassandraSnitchProperties()
     {
         Reader reader = null;
+        String filePath = config.getRackDcPropertiesLocation();
+
+        if (filePath.trim().isEmpty()) {
+            // skip tuning if not specified
+            logger.info("cassandra-rackdc.properties location not specified, skipping tuning");
+            return;
+        }
+
         try
         {
-            String filePath = config.getCassHome() + "/conf/" + RACKDC_PROPERTY_FILENAME;
             reader = new FileReader(filePath);
             Properties properties = new Properties();
             properties.load(reader);
             String suffix = config.getDCSuffix();
             properties.put("dc_suffix", suffix);
             properties.store(new FileWriter(filePath), "");
+
+            logger.info("Tuned cassandra-rackdc.properties with dc suffix {}", config.getDCSuffix());
         }
         catch (Exception e)
         {
-            throw new RuntimeException("Unable to read " + RACKDC_PROPERTY_FILENAME, e);
+            throw new RuntimeException("Unable to read " + filePath, e);
         }
         finally
         {

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/StandardTuner.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/StandardTuner.java
@@ -8,9 +8,9 @@ import java.util.Properties;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 
+import org.apache.cassandra.io.util.FileUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,6 +20,8 @@ import com.netflix.priam.utils.CassandraTuner;
 
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
+
+import static org.apache.cassandra.locator.SnitchProperties.RACKDC_PROPERTY_FILENAME;
 
 public class StandardTuner implements CassandraTuner
 {
@@ -88,7 +90,7 @@ public class StandardTuner implements CassandraTuner
         Map<String, String> m = (Map<String, String>) seedp.get(0);
         m.put("class_name", seedProvider);
 
-        configfureSecurity(map);
+        configureSecurity(map);
         configureGlobalCaches(config, map);
         //force to 1 until vnodes are properly supported
 	    map.put("num_tokens", 1);
@@ -100,6 +102,31 @@ public class StandardTuner implements CassandraTuner
         yaml.dump(map, new FileWriter(yamlFile));
 
         configureCommitLogBackups();
+
+        writeCassandraSnitchProperties();
+    }
+
+    private void writeCassandraSnitchProperties()
+    {
+        Reader reader = null;
+        try
+        {
+            String filePath = config.getCassHome() + "/conf/" + RACKDC_PROPERTY_FILENAME;
+            reader = new FileReader(filePath);
+            Properties properties = new Properties();
+            properties.load(reader);
+            String suffix = config.getDCSuffix();
+            properties.put("dc_suffix", suffix);
+            properties.store(new FileWriter(filePath), "");
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Unable to read " + RACKDC_PROPERTY_FILENAME, e);
+        }
+        finally
+        {
+            FileUtils.closeQuietly(reader);
+        }
     }
 
     /**
@@ -151,7 +178,7 @@ public class StandardTuner implements CassandraTuner
         return fromYaml;
     }
 
-    protected void configfureSecurity(Map map)
+    protected void configureSecurity(Map map)
     {
         //the client-side ssl settings
         Map clientEnc = (Map) map.get("client_encryption_options");

--- a/priam/src/main/java/com/netflix/priam/identity/DoubleRing.java
+++ b/priam/src/main/java/com/netflix/priam/identity/DoubleRing.java
@@ -65,7 +65,7 @@ public class DoubleRing
         for (PriamInstance data : local)
             factory.delete(data);
 
-        int hash = tokenManager.regionOffset(config.getDC());
+        int hash = tokenManager.dcOffset(config.getDC());
         // move existing slots.
         for (PriamInstance data : local)
         {

--- a/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -49,7 +49,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
-import java.util.Set;
 
 import javax.ws.rs.core.MediaType;
 
@@ -330,7 +329,7 @@ public class InstanceIdentity
         	logger.info("Generating my own and new token");
             // Sleep random interval - upto 15 sec
             sleeper.sleep(new Random().nextInt(15000));
-            int hash = tokenManager.regionOffset(config.getDC());
+            int hash = tokenManager.dcOffset(config.getDC());
             // use this hash so that the nodes are spred far away from the other
             // regions.
 

--- a/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -173,7 +173,7 @@ public class InstanceIdentity
             for (PriamInstance dead : allIds)
             {
                 // test same zone and is it is alive.
-                if (!dead.getRac().equals(config.getRac()) || asgInstances.contains(dead.getInstanceId()) || isInstanceDummy(dead))
+                if (!dead.getDC().equals(config.getDC()) || !dead.getRac().equals(config.getRac()) || asgInstances.contains(dead.getInstanceId()) || isInstanceDummy(dead))
                     continue;
                 logger.info("Found dead instances: " + dead.getInstanceId());
                 PriamInstance markAsDead = factory.create(dead.getApp() + "-dead", dead.getId(), dead.getInstanceId(), dead.getHostName(), dead.getHostIP(), dead.getRac(), dead.getVolumes(),
@@ -298,7 +298,7 @@ public class InstanceIdentity
             for (PriamInstance dead : allIds)
             {
                 // test same zone and is it is alive.
-                if (!dead.getRac().equals(config.getRac()) || asgInstances.contains(dead.getInstanceId()) || !isInstanceDummy(dead))
+                if (!dead.getDC().equals(config.getDC()) || !dead.getRac().equals(config.getRac()) || asgInstances.contains(dead.getInstanceId()) || !isInstanceDummy(dead))
                     continue;
                 logger.info("Found pre-generated token: " + dead.getToken());
                 PriamInstance markAsDead = factory.create(dead.getApp() + "-dead", dead.getId(), dead.getInstanceId(), dead.getHostName(), dead.getHostIP(), dead.getRac(), dead.getVolumes(),
@@ -335,7 +335,7 @@ public class InstanceIdentity
 
             int max = hash;
             for (PriamInstance data : factory.getAllIds(config.getAppName()))
-                max = (data.getRac().equals(config.getRac()) && (data.getId() > max)) ? data.getId() : max;
+                max = (data.getDC().equals(config.getDC()) && data.getRac().equals(config.getRac()) && (data.getId() > max)) ? data.getId() : max;
             int maxSlot = max - hash;
             int my_slot = 0;
             if (hash == max && locMap.get(new DcAndRac(config.getDC(), config.getRac())).size() == 0) {

--- a/priam/src/main/java/com/netflix/priam/utils/AsgNameParser.java
+++ b/priam/src/main/java/com/netflix/priam/utils/AsgNameParser.java
@@ -1,0 +1,47 @@
+package com.netflix.priam.utils;
+
+public class AsgNameParser
+{
+    public static class AsgNameParts
+    {
+        private String clusterName;
+        private String dcSuffix;
+        private String zone;
+
+        AsgNameParts(String clusterName, String dcSuffix, String zone)
+        {
+            this.clusterName = clusterName;
+            this.dcSuffix = dcSuffix;
+            this.zone = zone;
+        }
+
+        public String getClusterName()
+        {
+            return clusterName;
+        }
+
+        public String getDcSuffix()
+        {
+            return dcSuffix;
+        }
+
+        public String getZone()
+        {
+            return zone;
+        }
+    }
+
+    public static AsgNameParts parseAsgName(String asgName)
+    {
+        String[] nameParts = asgName.split("-");
+
+        if (nameParts.length == 2) {
+            return new AsgNameParts(nameParts[0], "", nameParts[1]);
+
+        } else if (nameParts.length == 3) {
+            return new AsgNameParts(nameParts[0], nameParts[1], nameParts[2]);
+        } else {
+            throw new IllegalArgumentException("Couldn't parse ASG name into it's parts");
+        }
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/utils/ITokenManager.java
+++ b/priam/src/main/java/com/netflix/priam/utils/ITokenManager.java
@@ -23,11 +23,11 @@ import java.util.List;
 @ImplementedBy(TokenManager.class)
 public interface ITokenManager
 {
-    String createToken(int mySlot, int racCount, int racSize, String region);
+    String createToken(int mySlot, int racCount, int racSize, String dc);
 
-    String createToken(int mySlot, int totalCount, String region);
+    String createToken(int mySlot, int totalCount, String dc);
 
     BigInteger findClosestToken(BigInteger tokenToSearch, List<BigInteger> tokenList);
 
-    int regionOffset(String region);
+    int dcOffset(String dc);
 }

--- a/priam/src/main/java/com/netflix/priam/utils/TokenManager.java
+++ b/priam/src/main/java/com/netflix/priam/utils/TokenManager.java
@@ -59,20 +59,20 @@ public class TokenManager implements ITokenManager
      *            -- Rac count is the numeber of RAC's
      * @param rac_size
      *            -- number of memberships in the rac
-     * @param region
+     * @param dc
      *            -- name of the DC where it this token is created.
      */
     @Override
-    public String createToken(int my_slot, int rac_count, int rac_size, String region)
+    public String createToken(int my_slot, int rac_count, int rac_size, String dc)
     {
         int regionCount = rac_count * rac_size;
-        return initialToken(regionCount, my_slot, regionOffset(region)).toString();
+        return initialToken(regionCount, my_slot, dcOffset(dc)).toString();
     }
     
     @Override
-    public String createToken(int my_slot, int totalCount, String region)
+    public String createToken(int my_slot, int totalCount, String dc)
     {
-        return initialToken(totalCount, my_slot, regionOffset(region)).toString();
+        return initialToken(totalCount, my_slot, dcOffset(dc)).toString();
     }
     
     @Override
@@ -96,8 +96,8 @@ public class TokenManager implements ITokenManager
      * Create an offset to add to token values by hashing the region name.
      */
     @Override
-    public int regionOffset(String region)
+    public int dcOffset(String dc)
     {
-        return Math.abs(region.hashCode());
+        return Math.abs(dc.hashCode());
     }
 }

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -441,6 +441,12 @@ public class FakeConfiguration implements IConfiguration
         return "conf/cassandra.yaml";
     }
 
+    @Override
+    public String getRackDcPropertiesLocation()
+    {
+        return "/tmp/priam/conf/cassandra-rackdc.properties";
+    }
+
     public String getAuthenticator()
     {
         return PriamConfiguration.DEFAULT_AUTHENTICATOR;

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -15,6 +15,7 @@ public class FakeConfiguration implements IConfiguration
 	public static final String FAKE_REGION = "us-east-1";
 
     public String region;
+    public String dcSuffix;
     public String appName;
     public String zone;
     public String instance_id;
@@ -22,12 +23,13 @@ public class FakeConfiguration implements IConfiguration
 
     public FakeConfiguration()
     {
-        this(FAKE_REGION, "my_fake_cluster", "my_zone", "i-01234567");
+        this(FAKE_REGION, "_dcSuffix", "my_fake_cluster", "my_zone", "i-01234567");
     }
 
-    public FakeConfiguration(String region, String appName, String zone, String ins_id)
+    public FakeConfiguration(String region, String dcSuffix, String appName, String zone, String ins_id)
     {
         this.region = region;
+        this.dcSuffix = dcSuffix;
         this.appName = appName;
         this.zone = zone;
         this.instance_id = ins_id;
@@ -183,6 +185,18 @@ public class FakeConfiguration implements IConfiguration
     public String getDC()
     {
         // TODO Auto-generated method stub
+        return this.region + this.dcSuffix;
+    }
+
+    @Override
+    public String getDCSuffix()
+    {
+        return this.dcSuffix;
+    }
+
+    @Override
+    public String getRegion()
+    {
         return this.region;
     }
 

--- a/priam/src/test/java/com/netflix/priam/TestModule.java
+++ b/priam/src/test/java/com/netflix/priam/TestModule.java
@@ -26,7 +26,7 @@ public class TestModule extends AbstractModule
     protected void configure()
     {
         bind(IConfiguration.class).toInstance(
-                new FakeConfiguration(FakeConfiguration.FAKE_REGION, "fake-app", "az1", "fakeInstance1"));
+                new FakeConfiguration(FakeConfiguration.FAKE_REGION, "_suffix", "fake-app", "az1", "fakeInstance1"));
         bind(IPriamInstanceFactory.class).to(FakePriamInstanceFactory.class);
         bind(SchedulerFactory.class).to(StdSchedulerFactory.class).in(Scopes.SINGLETON);
         bind(IMembership.class).toInstance(new FakeMembership(

--- a/priam/src/test/java/com/netflix/priam/backup/BRTestModule.java
+++ b/priam/src/test/java/com/netflix/priam/backup/BRTestModule.java
@@ -33,7 +33,7 @@ public class BRTestModule extends AbstractModule
     @Override
     protected void configure()
     {
-        bind(IConfiguration.class).toInstance(new FakeConfiguration(FakeConfiguration.FAKE_REGION, "fake-app", "az1", "fakeInstance1"));
+        bind(IConfiguration.class).toInstance(new FakeConfiguration(FakeConfiguration.FAKE_REGION, "_suffix", "fake-app", "az1", "fakeInstance1"));
         bind(IPriamInstanceFactory.class).to(FakePriamInstanceFactory.class);
         bind(SchedulerFactory.class).to(StdSchedulerFactory.class).in(Scopes.SINGLETON);
         bind(IMembership.class).toInstance(new FakeMembership(Arrays.asList("fakeInstance1")));

--- a/priam/src/test/java/com/netflix/priam/backup/FakeBackupFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/FakeBackupFileSystem.java
@@ -28,7 +28,7 @@ public class FakeBackupFileSystem implements IBackupFileSystem
     private List<AbstractBackupPath> flist;
     public Set<String> downloadedFiles;
     public Set<String> uploadedFiles;
-    public String baseDir, region, clusterName;
+    public String baseDir, dc, clusterName;
 
     @Inject
     Provider<S3BackupPath> pathProvider;
@@ -117,7 +117,7 @@ public class FakeBackupFileSystem implements IBackupFileSystem
         
         if( paths.length > 1){
             baseDir = paths[1];
-            region = paths[2];
+            dc = paths[2];
             clusterName = paths[3];
         }
         
@@ -126,7 +126,7 @@ public class FakeBackupFileSystem implements IBackupFileSystem
         {
 
             if ((path.time.after(start) && path.time.before(till)) || path.time.equals(start)
-                && path.baseDir.equals(baseDir) && path.clusterName.equals(clusterName) && path.region.equals(region))
+                && path.baseDir.equals(baseDir) && path.clusterName.equals(clusterName) && path.dc.equals(dc))
             {
                  tmpList.add(path);
             }

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackupFile.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackupFile.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.sql.Date;
 import java.text.ParseException;
 
+import com.netflix.priam.IConfiguration;
 import junit.framework.Assert;
 
 import org.apache.commons.io.FileUtils;
@@ -24,6 +25,7 @@ import com.netflix.priam.identity.InstanceIdentity;
 public class TestBackupFile
 {
     private static Injector injector;
+    private static IConfiguration configuration;
 
     @BeforeClass
     public static void setup() throws IOException
@@ -48,6 +50,8 @@ public class TestBackupFile
         }
         InstanceIdentity factory = injector.getInstance(InstanceIdentity.class);
         factory.getInstance().setToken("1234567");//Token
+
+        configuration = injector.getInstance(IConfiguration.class);
     }
 
     @AfterClass
@@ -69,9 +73,9 @@ public class TestBackupFile
         Assert.assertEquals("Standard1", backupfile.columnFamily);
         Assert.assertEquals("1234567", backupfile.token);
         Assert.assertEquals("fake-app", backupfile.clusterName);
-        Assert.assertEquals(FakeConfiguration.FAKE_REGION, backupfile.region);
+        Assert.assertEquals(configuration.getDC(), backupfile.dc);
         Assert.assertEquals("casstestbackup", backupfile.baseDir);
-        Assert.assertEquals("casstestbackup/"+FakeConfiguration.FAKE_REGION+"/fake-app/1234567/201108082320/SNAP/Keyspace1/Standard1/Keyspace1-Standard1-ia-5-Data.db", backupfile.getRemotePath());
+        Assert.assertEquals("casstestbackup/"+configuration.getDC()+"/fake-app/1234567/201108082320/SNAP/Keyspace1/Standard1/Keyspace1-Standard1-ia-5-Data.db", backupfile.getRemotePath());
     }
 
     @Test
@@ -86,10 +90,10 @@ public class TestBackupFile
         Assert.assertEquals("Standard1", backupfile.columnFamily);
         Assert.assertEquals("1234567", backupfile.token);
         Assert.assertEquals("fake-app", backupfile.clusterName);
-        Assert.assertEquals(FakeConfiguration.FAKE_REGION, backupfile.region);
+        Assert.assertEquals(configuration.getDC(), backupfile.dc);
         Assert.assertEquals("casstestbackup", backupfile.baseDir);
         String datestr = backupfile.formatDate(new Date(bfile.lastModified()));
-        Assert.assertEquals("casstestbackup/"+FakeConfiguration.FAKE_REGION+"/fake-app/1234567/" + datestr + "/SST/Keyspace1/Standard1/Keyspace1-Standard1-ia-5-Data.db", backupfile.getRemotePath());
+        Assert.assertEquals("casstestbackup/"+configuration.getDC()+"/fake-app/1234567/" + datestr + "/SST/Keyspace1/Standard1/Keyspace1-Standard1-ia-5-Data.db", backupfile.getRemotePath());
     }
 
     @Test
@@ -104,8 +108,8 @@ public class TestBackupFile
         Assert.assertEquals(BackupFileType.META, backupfile.type);
         Assert.assertEquals("1234567", backupfile.token);
         Assert.assertEquals("fake-app", backupfile.clusterName);
-        Assert.assertEquals(FakeConfiguration.FAKE_REGION, backupfile.region);
+        Assert.assertEquals(configuration.getDC(), backupfile.dc);
         Assert.assertEquals("casstestbackup", backupfile.baseDir);
-        Assert.assertEquals("casstestbackup/"+FakeConfiguration.FAKE_REGION+"/fake-app/1234567/201108082320/META/1234567.meta", backupfile.getRemotePath());
+        Assert.assertEquals("casstestbackup/"+configuration.getDC()+"/fake-app/1234567/201108082320/META/1234567.meta", backupfile.getRemotePath());
     }
 }

--- a/priam/src/test/java/com/netflix/priam/backup/TestRestore.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestRestore.java
@@ -49,14 +49,14 @@ public class TestRestore
 
     public static void populateBackupFileSystem(String baseDir){
         fileList.clear();
-        fileList.add(baseDir + "/"+FakeConfiguration.FAKE_REGION+"/fakecluster/123456/201108110030/META/meta.json");
-        fileList.add(baseDir + "/"+FakeConfiguration.FAKE_REGION+"/fakecluster/123456/201108110030/SNAP/ks1/cf1/f1.db");
-        fileList.add(baseDir + "/"+FakeConfiguration.FAKE_REGION+"/fakecluster/123456/201108110030/SNAP/ks1/cf1/f2.db");
-        fileList.add(baseDir + "/"+FakeConfiguration.FAKE_REGION+"/fakecluster/123456/201108110030/SNAP/ks2/cf1/f2.db");
-        fileList.add(baseDir + "/"+FakeConfiguration.FAKE_REGION+"/fakecluster/123456/201108110530/SST/ks2/cf1/f3.db");
-        fileList.add(baseDir + "/"+FakeConfiguration.FAKE_REGION+"/fakecluster/123456/201108110600/SST/ks2/cf1/f4.db");
+        fileList.add(baseDir + "/"+conf.getDC()+"/fakecluster/123456/201108110030/META/meta.json");
+        fileList.add(baseDir + "/"+conf.getDC()+"/fakecluster/123456/201108110030/SNAP/ks1/cf1/f1.db");
+        fileList.add(baseDir + "/"+conf.getDC()+"/fakecluster/123456/201108110030/SNAP/ks1/cf1/f2.db");
+        fileList.add(baseDir + "/"+conf.getDC()+"/fakecluster/123456/201108110030/SNAP/ks2/cf1/f2.db");
+        fileList.add(baseDir + "/"+conf.getDC()+"/fakecluster/123456/201108110530/SST/ks2/cf1/f3.db");
+        fileList.add(baseDir + "/"+conf.getDC()+"/fakecluster/123456/201108110600/SST/ks2/cf1/f4.db");
         filesystem.baseDir = baseDir;
-        filesystem.region = FakeConfiguration.FAKE_REGION;
+        filesystem.dc = conf.getDC();
         filesystem.clusterName = "fakecluster";
         filesystem.setupTest(fileList);
     }
@@ -89,7 +89,7 @@ public class TestRestore
     public void testRestoreLatest() throws Exception
     {
         populateBackupFileSystem("test_backup");
-        String metafile = "test_backup/"+FakeConfiguration.FAKE_REGION+"/fakecluster/123456/201108110130/META/meta.json";
+        String metafile = "test_backup/"+conf.getDC()+"/fakecluster/123456/201108110130/META/meta.json";
         filesystem.addFile(metafile);
         Restore restore = injector.getInstance(Restore.class);
         cal.set(2011, Calendar.AUGUST, 11, 0, 30, 0);
@@ -134,7 +134,7 @@ public class TestRestore
     {
         populateBackupFileSystem("test_backup_new");
         FakeConfiguration conf = (FakeConfiguration)injector.getInstance(IConfiguration.class);
-        conf.setRestorePrefix("RESTOREBUCKET/test_backup_new/"+FakeConfiguration.FAKE_REGION+"/fakecluster");
+        conf.setRestorePrefix("RESTOREBUCKET/test_backup_new/"+conf.getDC()+"/fakecluster");
         Restore restore = injector.getInstance(Restore.class);
         cal.set(2011, Calendar.AUGUST, 11, 0, 30, 0);
         cal.set(Calendar.MILLISECOND, 0);

--- a/priam/src/test/java/com/netflix/priam/backup/TestS3FileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestS3FileSystem.java
@@ -6,6 +6,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.List;
 
+import com.netflix.priam.IConfiguration;
 import junit.framework.Assert;
 import mockit.Mock;
 import mockit.Mockit;
@@ -41,6 +42,7 @@ public class TestS3FileSystem
     private static Injector injector;
     private static final Logger logger = LoggerFactory.getLogger(TestS3FileSystem.class);
     private static String FILE_PATH = "target/data/Keyspace1/Standard1/backups/201108082320/Keyspace1-Standard1-ia-1-Data.db";
+    private static IConfiguration configuration;
 
     @BeforeClass
     public static void setup() throws InterruptedException, IOException
@@ -61,6 +63,8 @@ public class TestS3FileSystem
             bos1.write(b);
         }
         bos1.close();
+
+        configuration = injector.getInstance(IConfiguration.class);
     }
 
     @AfterClass
@@ -134,7 +138,7 @@ public class TestS3FileSystem
         Assert.assertEquals(1, MockAmazonS3Client.bconf.getRules().size());
         BucketLifecycleConfiguration.Rule rule = MockAmazonS3Client.bconf.getRules().get(0);
         logger.info(rule.getPrefix());
-        Assert.assertEquals("casstestbackup/"+FakeConfiguration.FAKE_REGION+"/fake-app/", rule.getPrefix());
+        Assert.assertEquals("casstestbackup/"+configuration.getDC()+"/fake-app/", rule.getPrefix());
         Assert.assertEquals(5, rule.getExpirationInDays());
     }
 
@@ -147,7 +151,7 @@ public class TestS3FileSystem
         Assert.assertEquals(1, MockAmazonS3Client.bconf.getRules().size());
         BucketLifecycleConfiguration.Rule rule = MockAmazonS3Client.bconf.getRules().get(0);
         logger.info(rule.getPrefix());
-        Assert.assertEquals("casstestbackup/"+FakeConfiguration.FAKE_REGION+"/fake-app/", rule.getPrefix());
+        Assert.assertEquals("casstestbackup/"+configuration.getDC()+"/fake-app/", rule.getPrefix());
         Assert.assertEquals(5, rule.getExpirationInDays());
     }
 
@@ -230,7 +234,7 @@ public class TestS3FileSystem
             List<BucketLifecycleConfiguration.Rule> rules = Lists.newArrayList();
             if( ruleAvailable )
             {
-                String clusterPath = "casstestbackup/"+FakeConfiguration.FAKE_REGION+"/fake-app/";                
+                String clusterPath = "casstestbackup/"+configuration.getDC()+"/fake-app/";
                 BucketLifecycleConfiguration.Rule rule = new BucketLifecycleConfiguration.Rule().withExpirationInDays(5).withPrefix(clusterPath);
                 rule.setStatus(BucketLifecycleConfiguration.ENABLED);
                 rule.setId(clusterPath);

--- a/priam/src/test/java/com/netflix/priam/backup/identity/DoubleRingTest.java
+++ b/priam/src/test/java/com/netflix/priam/backup/identity/DoubleRingTest.java
@@ -44,7 +44,7 @@ public class DoubleRingTest extends InstanceTestUtils
         {
             PriamInstance ins = doubled.get(i);
             assertEquals(validator.get(i), ins.getToken());
-            int id = ins.getId() - tokenManager.regionOffset(config.getDC());
+            int id = ins.getId() - tokenManager.dcOffset(config.getDC());
             System.out.println(ins);
             if (0 != id % 2)
                 assertEquals(ins.getInstanceId(), InstanceIdentity.DUMMY_INSTANCE_ID);

--- a/priam/src/test/java/com/netflix/priam/backup/identity/InstanceIdentityTest.java
+++ b/priam/src/test/java/com/netflix/priam/backup/identity/InstanceIdentityTest.java
@@ -21,7 +21,7 @@ public class InstanceIdentityTest extends InstanceTestUtils
     {
 
         identity = createInstanceIdentity("az1", "fakeinstance1");
-        int hash = tokenManager.regionOffset(config.getDC());
+        int hash = tokenManager.dcOffset(config.getDC());
         assertEquals(0, identity.getInstance().getId() - hash);
 
         identity = createInstanceIdentity("az1", "fakeinstance2");
@@ -85,7 +85,7 @@ public class InstanceIdentityTest extends InstanceTestUtils
         new DoubleRing(config, factory, tokenManager).doubleSlots();
         config.zone = "az1";
         config.instance_id = "fakeinstancex";
-        int hash = tokenManager.regionOffset(config.getDC());
+        int hash = tokenManager.dcOffset(config.getDC());
         identity = createInstanceIdentity("az1", "fakeinstancex");
         printInstance(identity.getInstance(), hash);
     }

--- a/priam/src/test/java/com/netflix/priam/backup/identity/InstanceTestUtils.java
+++ b/priam/src/test/java/com/netflix/priam/backup/identity/InstanceTestUtils.java
@@ -40,7 +40,7 @@ public abstract class InstanceTestUtils
         instances.add("fakeinstance9");
 
         membership = new FakeMembership(instances);
-        config = new FakeConfiguration("fake", "fake-app", "az1", "fakeinstance1");
+        config = new FakeConfiguration("fake", "_suffix", "fake-app", "az1", "fakeinstance1");
         factory = new FakePriamInstanceFactory(config);
         sleeper = new FakeSleeper();
     }

--- a/priam/src/test/java/com/netflix/priam/defaultimpl/CassandraProcessManagerTest.java
+++ b/priam/src/test/java/com/netflix/priam/defaultimpl/CassandraProcessManagerTest.java
@@ -17,7 +17,7 @@ public class CassandraProcessManagerTest
     @Before
     public void setup()
     {
-        IConfiguration config = new FakeConfiguration("us-east-1", "test_cluster", "us-east-1a", "i-2378afd3");
+        IConfiguration config = new FakeConfiguration("us-east-1", "_suffix", "test_cluster", "us-east-1a", "i-2378afd3");
         cpm = new CassandraProcessManager(config, new FakeSleeper());
     }
 

--- a/priam/src/test/java/com/netflix/priam/defaultimpl/StandardTunerTest.java
+++ b/priam/src/test/java/com/netflix/priam/defaultimpl/StandardTunerTest.java
@@ -8,6 +8,8 @@ import com.netflix.priam.FakeConfiguration;
 import com.netflix.priam.IConfiguration;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.apache.cassandra.locator.SnitchProperties.RACKDC_PROPERTY_FILENAME;
 import static org.junit.Assert.assertEquals;
 
 public class StandardTunerTest
@@ -75,7 +77,11 @@ public class StandardTunerTest
     public void dump() throws IOException
     {
         String target = "/tmp/priam_test.yaml";
+        String rackPropertiesPath = config.getCassHome() + "/conf/" + RACKDC_PROPERTY_FILENAME;
+
         Files.copy(new File("src/main/resources/incr-restore-cassandra.yaml"), new File("/tmp/priam_test.yaml"));
+        Files.copy(new File("src/test/resources/cassandra-rackdc.properties"), new File(rackPropertiesPath));
+
         tuner.writeAllProperties(target, "your_host", "YourSeedProvider");
     }
 }

--- a/priam/src/test/java/com/netflix/priam/defaultimpl/StandardTunerTest.java
+++ b/priam/src/test/java/com/netflix/priam/defaultimpl/StandardTunerTest.java
@@ -9,7 +9,6 @@ import com.netflix.priam.IConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.apache.cassandra.locator.SnitchProperties.RACKDC_PROPERTY_FILENAME;
 import static org.junit.Assert.assertEquals;
 
 public class StandardTunerTest
@@ -77,7 +76,7 @@ public class StandardTunerTest
     public void dump() throws IOException
     {
         String target = "/tmp/priam_test.yaml";
-        String rackPropertiesPath = config.getCassHome() + "/conf/" + RACKDC_PROPERTY_FILENAME;
+        String rackPropertiesPath = config.getRackDcPropertiesLocation();
 
         Files.copy(new File("src/main/resources/incr-restore-cassandra.yaml"), new File("/tmp/priam_test.yaml"));
         Files.copy(new File("src/test/resources/cassandra-rackdc.properties"), new File(rackPropertiesPath));

--- a/priam/src/test/java/com/netflix/priam/stream/StreamingTest.java
+++ b/priam/src/test/java/com/netflix/priam/stream/StreamingTest.java
@@ -26,7 +26,7 @@ public class StreamingTest
 {
     public void teststream() throws IOException, InterruptedException
     {
-        IConfiguration config = new FakeConfiguration("test", "cass_upg107_ccs", "test", "ins_id");
+        IConfiguration config = new FakeConfiguration("test", "_suffix", "cass_upg107_ccs", "test", "ins_id");
         SSTableLoaderWrapper loader = new SSTableLoaderWrapper(config, new StandardTuner(config));
         Collection<PendingFile> ssts = loader.stream(new File("/tmp/Keyspace2/"));
         loader.deleteCompleted(ssts);

--- a/priam/src/test/java/com/netflix/priam/utils/AsgNameParserTest.java
+++ b/priam/src/test/java/com/netflix/priam/utils/AsgNameParserTest.java
@@ -1,0 +1,25 @@
+package com.netflix.priam.utils;
+
+import junit.framework.Assert;
+import org.junit.Test;
+
+public class AsgNameParserTest
+{
+    @Test
+    public void withDcSuffix()
+    {
+        AsgNameParser.AsgNameParts parts = AsgNameParser.parseAsgName("cass_1-_solr-useast1a");
+        Assert.assertEquals(parts.getClusterName(), "cass_1");
+        Assert.assertEquals(parts.getDcSuffix(), "_solr");
+        Assert.assertEquals(parts.getZone(), "useast1a");
+    }
+
+    @Test
+    public void withoutDcSuffix()
+    {
+        AsgNameParser.AsgNameParts parts = AsgNameParser.parseAsgName("cass_1-useast1a");
+        Assert.assertEquals(parts.getClusterName(), "cass_1");
+        Assert.assertEquals(parts.getDcSuffix(), "");
+        Assert.assertEquals(parts.getZone(), "useast1a");
+    }
+}

--- a/priam/src/test/java/com/netflix/priam/utils/TokenManagerTest.java
+++ b/priam/src/test/java/com/netflix/priam/utils/TokenManagerTest.java
@@ -64,7 +64,7 @@ public class TokenManagerTest
     {
         assertEquals(MAXIMUM_TOKEN.divide(BigInteger.valueOf(8 * 32))
                 .multiply(BigInteger.TEN)
-                .add(BigInteger.valueOf(tokenManager.regionOffset("region")))
+                .add(BigInteger.valueOf(tokenManager.dcOffset("region")))
                 .toString(),
                 tokenManager.createToken(10, 8, 32, "region"));
     }
@@ -142,15 +142,15 @@ public class TokenManagerTest
                 if (region1.equals(region2))
                     continue;
                 assertFalse("Diffrence seems to be low",
-                        Math.abs(tokenManager.regionOffset(region1) - tokenManager.regionOffset(region2)) < 100);
+                        Math.abs(tokenManager.dcOffset(region1) - tokenManager.dcOffset(region2)) < 100);
             }
     }
 
     @Test
     public void testMultiToken()
     {
-        int h1 = tokenManager.regionOffset("vijay");
-        int h2 = tokenManager.regionOffset("vijay2");
+        int h1 = tokenManager.dcOffset("vijay");
+        int h2 = tokenManager.dcOffset("vijay2");
         BigInteger t1 = tokenManager.initialToken(100, 10, h1);
         BigInteger t2 = tokenManager.initialToken(100, 10, h2);
 

--- a/priam/src/test/resources/cassandra-rackdc.properties
+++ b/priam/src/test/resources/cassandra-rackdc.properties
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These properties are used with GossipingPropertyFileSnitch and will
+# indicate the rack and dc for this node
+dc=DC1
+rack=RAC1
+
+# Add a suffix to a datacenter name. Used by the Ec2Snitch and Ec2MultiRegionSnitch
+# to append a string to the EC2 region name.
+#dc_suffix=
+
+# Uncomment the following line to make this snitch prefer the internal ip when possible, as the Ec2MultiRegionSnitch does.
+# prefer_local=true
+


### PR DESCRIPTION
This PR more clearly separates the notion of Region and DC in Priam, which has always assumed the two are equal and can be used interchangeably.

Existing behaviour should not be affected, as this is done via suffixing the region name, which is optional.