### PR TITLE
2.0

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backup/CommitLogBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/CommitLogBackup.java
@@ -11,12 +11,14 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.netflix.priam.backup.AbstractBackupPath.BackupFileType;
 import com.netflix.priam.utils.RetryableCallable;
 
 
 //Providing this if we want to use it outside Quart
+@Singleton
 public class CommitLogBackup
 {
   private static final Logger logger = LoggerFactory.getLogger(CommitLogBackup.class);

--- a/priam/src/main/java/com/netflix/priam/backup/CommitLogBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/CommitLogBackup.java
@@ -11,14 +11,12 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.netflix.priam.backup.AbstractBackupPath.BackupFileType;
 import com.netflix.priam.utils.RetryableCallable;
 
 
 //Providing this if we want to use it outside Quart
-@Singleton
 public class CommitLogBackup
 {
   private static final Logger logger = LoggerFactory.getLogger(CommitLogBackup.class);

--- a/priam/src/main/java/com/netflix/priam/backup/Restore.java
+++ b/priam/src/main/java/com/netflix/priam/backup/Restore.java
@@ -131,13 +131,19 @@ public class Restore extends AbstractRestore
         while (backupfiles.hasNext())
         {
             AbstractBackupPath path = backupfiles.next();
-            if (path.type == BackupFileType.META)
-                metas.add(path);
+            if (path.type == BackupFileType.META) {
+            	//Since there are now meta file for incrementals as well as snapshot, we need to find the correct one (i.e. the snapshot meta file (meta.json))
+            	if (path.getFileName().equalsIgnoreCase("meta.json")) {
+                    metas.add(path);            		
+            	}
+            	
+            }
+
         }
         
         if (metas.size() == 0)
         {
-        	logger.info("[cass_backup] No meta file found, Restore Failed.");
+        	logger.info("[cass_backup] No snapshot meta file found, Restore Failed.");
         	assert false : "[cass_backup] No snapshots found, Restore Failed.";
         	return;
         }
@@ -145,7 +151,7 @@ public class Restore extends AbstractRestore
 
         Collections.sort(metas);
         AbstractBackupPath meta = Iterators.getLast(metas.iterator());
-        logger.info("Meta file for restore " + meta.getRemotePath());
+        logger.info("Snapshot Meta file for restore " + meta.getRemotePath());
 
         // Download snapshot which is listed in the meta file.
         List<AbstractBackupPath> snapshots = metaData.get(meta);


### PR DESCRIPTION
A new feature was added which creates & uploads a JSON audit file for incremental backups.  The format of this audit file  is meta_columnfamilyname_timestamp.json.  This pull request is to eliminate Priam's assumption that all JSON audit files are for SNAPSHOTS.  In looking through the codebase, the only area to which Priam makes this assumption is within the restore area.