### PR TITLE
Ability to provide Cassandra start-up/ env properties through Priam

### DIFF
--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -19,6 +19,7 @@ import com.google.inject.ImplementedBy;
 import com.netflix.priam.defaultimpl.PriamConfiguration;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Interface for Priam's configuration
@@ -475,4 +476,9 @@ public interface IConfiguration
      */    
     public String getPgpPublicKeyLoc();
 
+    /**
+     * Use this method for adding extra/ dynamic cassandra startup options or env properties
+     * @return
+     */
+    Map<String, String> getExtraEnvParams();
 }

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -913,7 +913,6 @@ public class PriamConfiguration implements IConfiguration
         Map<String, String> extraEnvParamsMap = new HashMap<String, String>();
         String[] pairs = envParams.split(",");
         logger.info("getExtraEnvParams: Extra cass params. From config :" +envParams);
-        if ( pairs.length > 0) {
             for (int i = 0; i < pairs.length; i++) {
                 String[] pair = pairs[i].split("=");
                 if (pair.length > 1) {
@@ -926,7 +925,6 @@ public class PriamConfiguration implements IConfiguration
                     }
                 }
             }
-        }
         return extraEnvParamsMap;
 
     }

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -15,7 +15,9 @@
  */
 package com.netflix.priam.defaultimpl;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2Client;
@@ -125,6 +127,7 @@ public class PriamConfiguration implements IConfiguration
     private static final String CONFIG_EXTRA_PARAMS = PRIAM_PRE + ".extra.params";
     private static final String CONFIG_AUTO_BOOTSTRAP = PRIAM_PRE + ".auto.bootstrap";
     private static final String CONFIG_DSE_CLUSTER_TYPE = PRIAM_PRE + ".dse.cluster.type";
+    private static final String CONFIG_EXTRA_ENV_PARAMS = PRIAM_PRE + ".extra.env.params";
 
     private static final String CONFIG_US_EAST_1_S3_ENDPOINT = PRIAM_PRE + ".useast1.s3url";
     private static final String CONFIG_US_WEST_1_S3_ENDPOINT = PRIAM_PRE + ".uswest1.s3url";
@@ -899,7 +902,35 @@ public class PriamConfiguration implements IConfiguration
     public String getExtraConfigParams() {
     	return config.get(CONFIG_EXTRA_PARAMS);
     }
-    
+
+    public Map<String, String> getExtraEnvParams() {
+
+        String envParams = config.get(CONFIG_EXTRA_ENV_PARAMS);
+        if (envParams == null) {
+            logger.info("getExtraEnvParams: No extra env params");
+            return null;
+        }
+        Map<String, String> extraEnvParamsMap = new HashMap<String, String>();
+        String[] pairs = envParams.split(",");
+        logger.info("getExtraEnvParams: Extra cass params. From config :" +envParams);
+        if ( pairs.length > 0) {
+            for (int i = 0; i < pairs.length; i++) {
+                String[] pair = pairs[i].split("=");
+                if (pair.length > 1) {
+                    String priamKey = pair[0];
+                    String cassKey = pair[1];
+                    String cassVal = config.get(priamKey);
+                    logger.info("getExtraEnvParams: Start-up/ env params: Priamkey[" + priamKey + "], CassStartupKey[" + cassKey + "], Val[" + cassVal + "]");
+                    if(!StringUtils.isBlank(cassKey) && !StringUtils.isBlank(cassVal)) {
+                        extraEnvParamsMap.put(cassKey, cassVal);
+                    }
+                }
+            }
+        }
+        return extraEnvParamsMap;
+
+    }
+
     public String getCassYamlVal(String priamKey) {
     	return config.get(priamKey);
     }

--- a/priam/src/main/java/com/netflix/priam/resources/CassandraConfig.java
+++ b/priam/src/main/java/com/netflix/priam/resources/CassandraConfig.java
@@ -143,7 +143,7 @@ public class CassandraConfig
         }
         catch (Exception e)
         {
-            logger.error("Error while executing get_replaced_ip", e);
+            logger.error("Error while executing get_extra_env_params", e);
             return Response.serverError().build();
         }
     }

--- a/priam/src/main/java/com/netflix/priam/resources/CassandraConfig.java
+++ b/priam/src/main/java/com/netflix/priam/resources/CassandraConfig.java
@@ -16,7 +16,9 @@
 package com.netflix.priam.resources;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -24,7 +26,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import com.netflix.priam.IConfiguration;
 import org.apache.commons.lang.StringUtils;
+import org.json.simple.JSONValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,8 +124,31 @@ public class CassandraConfig
             return Response.serverError().build();
         }
     }
+
     
-    
+    @GET
+    @Path("/get_extra_env_params")
+    public Response getExtraEnvParams()
+    {
+        try
+        {
+            Map<String, String> returnMap;
+            returnMap=priamServer.getConfiguration().getExtraEnvParams();
+            if(returnMap == null)
+            {
+                returnMap = new HashMap<String,String>();
+            }
+            String extraEnvParamsJson=JSONValue.toJSONString(returnMap);
+            return Response.ok(extraEnvParamsJson).build();
+        }
+        catch (Exception e)
+        {
+            logger.error("Error while executing get_replaced_ip", e);
+            return Response.serverError().build();
+        }
+    }
+
+
     @GET
     @Path("/double_ring")
     public Response doubleRing() throws IOException, ClassNotFoundException

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -2,6 +2,7 @@ package com.netflix.priam;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import com.google.common.collect.Lists;
 import com.google.inject.Singleton;
@@ -619,6 +620,16 @@ public class FakeConfiguration implements IConfiguration
 	@Override
 	public String getPgpPublicKeyLoc() {
 		return null;
-	}	
+	}
+
+    /**
+     * Use this method for adding extra/ dynamic cassandra startup options or env properties
+     *
+     * @return
+     */
+    @Override
+    public Map<String, String> getExtraEnvParams() {
+        return null;
+    }
 
 }


### PR DESCRIPTION
Providing JVM options/ Environment properties like below on entire cluster is a pain, Having a property in Priam to get this would be helpful and easy 
e.g:
`JVM_OPTS="$JVM_OPTS -Dcassandra.always_listen_on_unencrypted=true"`
`JVM_OPTS="$JVM_OPTS -Dcassandra.ring_delay_ms=300000"`

How to use:
*1. Set a property to list all dynamic properties to be used
`priam.extra.env.params = priam.cass.ringdelayms=cassandra.ring_delay_ms, priam.cass.loadringstate=cassandra.load_ring_state`

*2. Setting the individual properties
`priam.cass.loadringstate = true`
`priam.cass.ringdelayms = 30000`
