### PR TITLE
Upgrade tests to use JMockit 1.19, which is compatible with newer ver…

### DIFF
--- a/priam-cass-extensions/build.gradle
+++ b/priam-cass-extensions/build.gradle
@@ -38,6 +38,6 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.6.1'
     compile 'org.slf4j:slf4j-log4j12:1.6.1'
     provided 'javax.servlet:servlet-api:2.5'
-    testCompile 'com.googlecode.jmockit:jmockit:0.999.17'
+    testCompile 'org.jmockit:jmockit:1.19'
     testCompile 'junit:junit:4.8'
 }

--- a/priam-dse-extensions/build.gradle
+++ b/priam-dse-extensions/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.6.1'
     compile 'org.slf4j:slf4j-log4j12:1.6.1'
     provided 'javax.servlet:servlet-api:2.5'
-    testCompile 'com.googlecode.jmockit:jmockit:0.999.17'
+    testCompile 'org.jmockit:jmockit:1.19'
     testCompile 'junit:junit:4.8'
     testCompile project(path: ':priam', configuration: 'test')
 }

--- a/priam-web/build.gradle
+++ b/priam-web/build.gradle
@@ -40,6 +40,6 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.6.1'
     compile 'org.slf4j:slf4j-log4j12:1.6.1'
     provided 'javax.servlet:servlet-api:2.5'
-    testCompile 'com.googlecode.jmockit:jmockit:0.999.17'
+    testCompile 'org.jmockit:jmockit:1.19'
     testCompile 'junit:junit:4.8'
 }

--- a/priam/build.gradle
+++ b/priam/build.gradle
@@ -35,6 +35,6 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.6.1'
     compile 'org.slf4j:slf4j-log4j12:1.6.1'
     provided 'javax.servlet:servlet-api:2.5'
-    testCompile 'com.googlecode.jmockit:jmockit:0.999.17'
+    testCompile 'org.jmockit:jmockit:1.19'
     testCompile 'junit:junit:4.8'
 }

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackup.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackup.java
@@ -9,7 +9,7 @@ import java.util.Set;
 
 import junit.framework.Assert;
 import mockit.Mock;
-import mockit.Mockit;
+import mockit.MockUp;
 
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.commons.io.FileUtils;
@@ -42,9 +42,9 @@ public class TestBackup
     @BeforeClass
     public static void setup() throws InterruptedException, IOException
     {
+        new MockNodeProbe();
         injector = Guice.createInjector(new BRTestModule());
         filesystem = (FakeBackupFileSystem) injector.getInstance(Key.get(IBackupFileSystem.class,Names.named("backup")));
-        Mockit.setUpMock(NodeProbe.class, MockNodeProbe.class);
     }
     
     @AfterClass
@@ -136,7 +136,7 @@ public class TestBackup
 
     // Mock Nodeprobe class
     @Ignore
-    public static class MockNodeProbe
+    public static class MockNodeProbe extends MockUp<NodeProbe>
     {
         @Mock
         public void $init(String host, int port) throws IOException, InterruptedException

--- a/priam/src/test/java/com/netflix/priam/backup/TestFileIterator.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestFileIterator.java
@@ -9,8 +9,7 @@ import java.util.List;
 import java.util.Set;
 
 import mockit.Mock;
-import mockit.Mocked;
-import mockit.Mockit;
+import mockit.MockUp;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -42,7 +41,6 @@ public class TestFileIterator
     private static Date startTime, endTime;
     private static Calendar cal;
 
-    @Mocked
     private static AmazonS3Client s3client;
     
     private static IConfiguration conf;
@@ -50,13 +48,12 @@ public class TestFileIterator
     @BeforeClass
     public static void setup() throws InterruptedException, IOException
     {
+        s3client = new MockAmazonS3Client().getMockInstance();
+        new MockObjectListing();
+
         injector = Guice.createInjector(new BRTestModule());
         conf = injector.getInstance(IConfiguration.class);
         factory = injector.getInstance(InstanceIdentity.class);
-
-        Mockit.setUpMock(AmazonS3Client.class, MockAmazonS3Client.class);
-        Mockit.setUpMock(ObjectListing.class, MockObjectListing.class);
-        s3client = new AmazonS3Client();
 
         cal = Calendar.getInstance();
         cal.set(2011, 7, 11, 0, 30, 0);
@@ -68,7 +65,7 @@ public class TestFileIterator
 
     // MockAmazonS3Client class
     @Ignore
-    public static class MockAmazonS3Client
+    public static class MockAmazonS3Client extends MockUp<AmazonS3Client>
     {
         public static String bucketName = "";
         public static String prefix = "";
@@ -82,6 +79,7 @@ public class TestFileIterator
             return listing;
         }
 
+        @Mock
         public ObjectListing listNextBatchOfObjects(ObjectListing previousObjectListing) throws AmazonClientException, AmazonServiceException
         {
             ObjectListing listing = new ObjectListing();
@@ -93,7 +91,7 @@ public class TestFileIterator
 
     // MockObjectListing class
     @Ignore
-    public static class MockObjectListing
+    public static class MockObjectListing extends MockUp<ObjectListing>
     {
         public static boolean truncated = true;
         public static boolean firstcall = true;

--- a/priam/src/test/java/com/netflix/priam/backup/TestS3FileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestS3FileSystem.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import junit.framework.Assert;
 import mockit.Mock;
-import mockit.Mockit;
+import mockit.MockUp;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -45,8 +45,9 @@ public class TestS3FileSystem
     @BeforeClass
     public static void setup() throws InterruptedException, IOException
     {
-        Mockit.setUpMock(S3PartUploader.class, MockS3PartUploader.class);
-        Mockit.setUpMock(AmazonS3Client.class, MockAmazonS3Client.class);
+        new MockS3PartUploader();
+        new MockAmazonS3Client();
+
         injector = Guice.createInjector(new BRTestModule());
 
         File dir1 = new File("target/data/Keyspace1/Standard1/backups/201108082320");
@@ -154,7 +155,7 @@ public class TestS3FileSystem
     
     // Mock Nodeprobe class
     @Ignore
-    public static class MockS3PartUploader extends RetryableCallable<Void>
+    public static class MockS3PartUploader extends MockUp<S3PartUploader>
     {
         public static int compattempts = 0;
         public static int partAttempts = 0;
@@ -191,7 +192,6 @@ public class TestS3FileSystem
         {
         }
 
-        @Override
         @Mock
         public Void retriableCall() throws AmazonClientException, BackupRestoreException
         {
@@ -209,7 +209,7 @@ public class TestS3FileSystem
     }
 
     @Ignore
-    public static class MockAmazonS3Client
+    public static class MockAmazonS3Client extends MockUp<AmazonS3Client>
     {
         public static boolean ruleAvailable = false;
         public static BucketLifecycleConfiguration bconf = new BucketLifecycleConfiguration();

--- a/priam/src/test/java/com/netflix/priam/resources/BackupServletTest.java
+++ b/priam/src/test/java/com/netflix/priam/resources/BackupServletTest.java
@@ -6,7 +6,6 @@ import com.google.inject.Provider;
 import com.netflix.priam.ICassandraProcess;
 import com.netflix.priam.IConfiguration;
 import com.netflix.priam.PriamServer;
-import com.netflix.priam.aws.S3BackupPath;
 import com.netflix.priam.backup.AbstractBackupPath;
 import com.netflix.priam.backup.IBackupFileSystem;
 import com.netflix.priam.backup.Restore;
@@ -17,14 +16,18 @@ import com.netflix.priam.identity.PriamInstance;
 import com.netflix.priam.utils.CassandraTuner;
 import com.netflix.priam.utils.ITokenManager;
 import com.netflix.priam.utils.TokenManager;
-import com.netflix.priam.utils.TuneCassandra;
 import mockit.Expectations;
 import mockit.Mocked;
-import mockit.NonStrict;
+import mockit.NonStrictExpectations;
+import mockit.integration.junit4.JMockit;
+import mockit.internal.expectations.TestOnlyPhase;
+
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+import javax.annotation.Nonnull;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Date;
@@ -32,10 +35,11 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
+@RunWith(JMockit.class)
 public class BackupServletTest
 {
-    private @NonStrict PriamServer priamServer;
-    private @NonStrict IConfiguration config;
+    private @Mocked PriamServer priamServer;
+    private @Mocked IConfiguration config;
     private @Mocked IBackupFileSystem bkpFs;
     private @Mocked IBackupFileSystem bkpStatusFs;
     private @Mocked Restore restoreObj;
@@ -68,7 +72,8 @@ public class BackupServletTest
     }
 
     @Test
-    public void restore_minimal() throws Exception
+    public void restore_minimal(@Mocked final InstanceIdentity identity,
+        @Mocked final PriamInstance instance) throws Exception
     {
         final String dateRange = null;
         final String newRegion = null;
@@ -78,13 +83,14 @@ public class BackupServletTest
         final String oldRegion = "us-east-1";
         final String oldToken = "1234";
 
+        new NonStrictExpectations() {
+            {
+              priamServer.getId(); result = identity; times = 2;
+            }
+        };
         new Expectations() {
-            @NonStrict InstanceIdentity identity;
-            PriamInstance instance;
-  
             {
                 config.getDC(); result = oldRegion;
-                priamServer.getId(); result = identity; times = 2;
                 identity.getInstance(); result = instance; times = 2;
                 instance.getToken(); result = oldToken;
 
@@ -107,7 +113,8 @@ public class BackupServletTest
     }
 
     @Test
-    public void restore_withDateRange() throws Exception
+    public void restore_withDateRange(@Mocked final InstanceIdentity identity,
+        @Mocked final PriamInstance instance, @Mocked final AbstractBackupPath backupPath) throws Exception
     {
         final String dateRange = "201101010000,20111231259";
         final String newRegion = null;
@@ -117,18 +124,18 @@ public class BackupServletTest
         final String oldRegion = "us-east-1";
         final String oldToken = "1234";
 
+        new NonStrictExpectations() {
+            {
+              priamServer.getId(); result = identity; times = 2;
+            }
+        };
         new Expectations() {
-            @NonStrict InstanceIdentity identity;
-            PriamInstance instance;
-            AbstractBackupPath backupPath = new S3BackupPath(null, null);
-  
             {
                 pathProvider.get(); result = backupPath;
                 backupPath.parseDate(dateRange.split(",")[0]); result = new DateTime(2011, 01, 01, 00, 00).toDate(); times = 1;
                 backupPath.parseDate(dateRange.split(",")[1]); result = new DateTime(2011, 12, 31, 23, 59).toDate(); times = 1;
 
                 config.getDC(); result = oldRegion;
-                priamServer.getId(); result = identity; times = 2;
                 identity.getInstance(); result = instance; times = 2;
                 instance.getToken(); result = oldToken;
 
@@ -208,7 +215,8 @@ public class BackupServletTest
 //    }
 
     @Test
-    public void restore_withToken() throws Exception
+    public void restore_withToken(@Mocked final InstanceIdentity identity,
+        @Mocked final PriamInstance instance) throws Exception
     {
         final String dateRange = null;
         final String newRegion = null;
@@ -218,13 +226,14 @@ public class BackupServletTest
         final String oldRegion = "us-east-1";
         final String oldToken = "1234";
 
+        new NonStrictExpectations() {
+            {
+              priamServer.getId(); result = identity; times = 3;
+            }
+        };
         new Expectations() {
-            @NonStrict InstanceIdentity identity;
-            PriamInstance instance;
-  
             {
                 config.getDC(); result = oldRegion;
-                priamServer.getId(); result = identity; times = 3;
                 identity.getInstance(); result = instance; times = 3;
                 instance.getToken(); result = oldToken;
                 instance.setToken(newToken);
@@ -248,7 +257,8 @@ public class BackupServletTest
     }
 
     @Test
-    public void restore_withKeyspaces() throws Exception
+    public void restore_withKeyspaces(@Mocked final InstanceIdentity identity,
+        @Mocked final PriamInstance instance) throws Exception
     {
         final String dateRange = null;
         final String newRegion = null;
@@ -258,26 +268,27 @@ public class BackupServletTest
         final String oldRegion = "us-east-1";
         final String oldToken = "1234";
 
-        new Expectations() {
-            @NonStrict InstanceIdentity identity;
-            PriamInstance instance;
-  
+        new NonStrictExpectations() {
             {
-                config.getDC(); result = oldRegion;
-                priamServer.getId(); result = identity; times = 2;
+              config.getDC(); result = oldRegion;
+              config.isRestoreClosestToken(); result = false;
+
+              List<String> restoreKeyspaces = Lists.newArrayList();
+              restoreKeyspaces.clear();
+              restoreKeyspaces.addAll(ImmutableList.of("keyspace1", "keyspace2"));
+
+              config.getRestoreKeySpaces(); result = restoreKeyspaces;
+              config.setDC(oldRegion);
+              priamServer.getId(); result = identity; times = 2;
+            }
+        };
+        new Expectations() {
+            {
                 identity.getInstance(); result = instance; times = 2;
                 instance.getToken(); result = oldToken;
-
-                config.isRestoreClosestToken(); result = false;
   
-                List<String> restoreKeyspaces = Lists.newArrayList();
-                config.getRestoreKeySpaces(); result = restoreKeyspaces;
-                restoreKeyspaces.clear();
-                restoreKeyspaces.addAll(ImmutableList.of("keyspace1", "keyspace2"));
-
                 restoreObj.restore((Date) any, (Date) any); // TODO: test default value
   
-                config.setDC(oldRegion);
                 instance.setToken(oldToken);
                 tuner.updateAutoBootstrap(config.getYamlLocation(), false);
             }
@@ -293,7 +304,10 @@ public class BackupServletTest
 
     // TODO: this should also set/test newRegion and keyspaces
     @Test
-    public void restore_maximal() throws Exception
+    public void restore_maximal(@Mocked final InstanceIdentity identity,
+        @Mocked final PriamInstance instance, @Mocked final PriamInstance instance1,
+        @Mocked final PriamInstance instance2, @Mocked final PriamInstance instance3,
+        @Mocked final AbstractBackupPath backupPath) throws Exception
     {
         final String dateRange = "201101010000,20111231259";
         final String newRegion = null;
@@ -304,26 +318,26 @@ public class BackupServletTest
         final String oldToken = "1234";
         final String appName = "myApp";
 
+        new NonStrictExpectations() {
+          {
+            config.getDC(); result = oldRegion; times = 2;
+            priamServer.getId(); result = identity; times = 5;
+            config.isRestoreClosestToken(); result = true;
+            config.getAppName(); result = appName;
+            config.setDC(oldRegion);
+          }
+        };
         new Expectations() {
-            @NonStrict InstanceIdentity identity;
-            PriamInstance instance;
-            @NonStrict PriamInstance instance1, instance2, instance3;
-            AbstractBackupPath backupPath;
-
             {
                 pathProvider.get(); result = backupPath;
                 backupPath.parseDate(dateRange.split(",")[0]); result = new DateTime(2011, 01, 01, 00, 00).toDate(); times = 1;
                 backupPath.parseDate(dateRange.split(",")[1]); result = new DateTime(2011, 12, 31, 23, 59).toDate(); times = 1;
 
-                config.getDC(); result = oldRegion; times = 2;
-                priamServer.getId(); result = identity; times = 5;
                 identity.getInstance(); result = instance; times = 5;
                 instance.getToken(); result = oldToken;
                 instance.setToken(newToken);
 
-                config.isRestoreClosestToken(); result = true;
                 instance.getToken(); result = oldToken;
-                config.getAppName(); result = appName;
                 factory.getAllIds(appName); result = ImmutableList.of(instance, instance1, instance2, instance3);
                 instance.getDC();  result = oldRegion;
                 instance.getToken(); result = oldToken;
@@ -339,7 +353,6 @@ public class BackupServletTest
                     new DateTime(2011, 01, 01, 00, 00).toDate(),
                     new DateTime(2011, 12, 31, 23, 59).toDate());
   
-                config.setDC(oldRegion);
                 instance.setToken(oldToken);
                 tuner.updateAutoBootstrap(config.getYamlLocation(), false);
             }
@@ -355,7 +368,7 @@ public class BackupServletTest
 
     // TODO: create CassandraController interface and inject, instead of static util method
     private Expectations expectCassandraStartup() {
-        return new Expectations() {{
+        return new NonStrictExpectations() {{
             config.getCassStartupScript(); result = "/usr/bin/false";
             config.getHeapNewSize(); result = "2G";
             config.getHeapSize(); result = "8G";

--- a/priam/src/test/java/com/netflix/priam/resources/CassandraAdminTest.java
+++ b/priam/src/test/java/com/netflix/priam/resources/CassandraAdminTest.java
@@ -36,11 +36,11 @@ public class CassandraAdminTest
         Assert.assertNotNull(rootObj.get("10.80.147.144"));
         Assert.assertNotNull(rootObj.get("10.80.147.20"));
         Assert.assertNotNull(rootObj.get("10.75.23.21"));
-        Assert.assertTrue(rootObj.getJSONObject("10.80.147.144").get("  SCHEMA").equals("bbb09269-73c9-36a4-b656-13470aa8a3fd"));
-        Assert.assertTrue(rootObj.getJSONObject("10.75.23.21").get("  SCHEMA").equals("bbb09269-73c9-36a4-b656-13470aa8a3fd"));
-        Assert.assertTrue(rootObj.getJSONObject("10.80.147.144").get("  RPC_ADDRESS").equals("10.80.147.144"));
-        Assert.assertTrue(rootObj.getJSONObject("10.80.147.20").get("  RPC_ADDRESS").equals("10.80.147.20"));
-        Assert.assertTrue(rootObj.getJSONObject("10.75.23.21").get("  RPC_ADDRESS").equals("10.75.23.21"));
+        Assert.assertTrue(rootObj.getJSONObject("10.80.147.144").get("SCHEMA").equals("bbb09269-73c9-36a4-b656-13470aa8a3fd"));
+        Assert.assertTrue(rootObj.getJSONObject("10.75.23.21").get("SCHEMA").equals("bbb09269-73c9-36a4-b656-13470aa8a3fd"));
+        Assert.assertTrue(rootObj.getJSONObject("10.80.147.144").get("RPC_ADDRESS").equals("10.80.147.144"));
+        Assert.assertTrue(rootObj.getJSONObject("10.80.147.20").get("RPC_ADDRESS").equals("10.80.147.20"));
+        Assert.assertTrue(rootObj.getJSONObject("10.75.23.21").get("RPC_ADDRESS").equals("10.75.23.21"));
         Assert.assertEquals(rootObj.length(), 3);
     	
     }

--- a/priam/src/test/java/com/netflix/priam/resources/CassandraConfigTest.java
+++ b/priam/src/test/java/com/netflix/priam/resources/CassandraConfigTest.java
@@ -15,13 +15,16 @@ import com.netflix.priam.identity.PriamInstance;
 import mockit.Expectations;
 import mockit.Mocked;
 import mockit.NonStrictExpectations;
+import mockit.integration.junit4.JMockit;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+@RunWith(JMockit.class)
 public class CassandraConfigTest
 {
     private @Mocked PriamServer priamServer;
@@ -35,12 +38,10 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void getSeeds() throws Exception
+    public void getSeeds(@Mocked final InstanceIdentity identity) throws Exception
     {
         final List<String> seeds = ImmutableList.of("seed1", "seed2", "seed3");
         new NonStrictExpectations() {
-            InstanceIdentity identity;
-
             {
                 priamServer.getId(); result = identity; times = 1;
                 identity.getSeeds(); result = seeds; times = 1;
@@ -53,12 +54,10 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void getSeeds_notFound() throws Exception
+    public void getSeeds_notFound(@Mocked final InstanceIdentity identity) throws Exception
     {
         final List<String> seeds = ImmutableList.of();
         new NonStrictExpectations() {
-            InstanceIdentity identity;
-
             {
                 priamServer.getId(); result = identity; times = 1;
                 identity.getSeeds(); result = seeds; times = 1;
@@ -70,11 +69,9 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void getSeeds_handlesUnknownHostException() throws Exception
+    public void getSeeds_handlesUnknownHostException(@Mocked final InstanceIdentity identity) throws Exception
     {
         new Expectations() {
-            InstanceIdentity identity;
-
             {
                 priamServer.getId(); result = identity;
                 identity.getSeeds(); result = new UnknownHostException();
@@ -86,13 +83,10 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void getToken()
+    public void getToken(@Mocked final InstanceIdentity identity, @Mocked final PriamInstance instance)
     {
         final String token = "myToken";
         new NonStrictExpectations() {
-            InstanceIdentity identity;
-            PriamInstance instance;
-
             {
                 priamServer.getId(); result = identity; times = 2;
                 identity.getInstance(); result = instance; times = 2;
@@ -106,13 +100,10 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void getToken_notFound()
+    public void getToken_notFound(@Mocked final InstanceIdentity identity, @Mocked final PriamInstance instance)
     {
         final String token = "";
         new NonStrictExpectations() {
-            InstanceIdentity identity;
-            PriamInstance instance;
-
             {
                 priamServer.getId(); result = identity;
                 identity.getInstance(); result = instance;
@@ -125,12 +116,9 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void getToken_handlesException()
+    public void getToken_handlesException(@Mocked final InstanceIdentity identity, @Mocked final PriamInstance instance)
     {
         new NonStrictExpectations() {
-            InstanceIdentity identity;
-            PriamInstance instance;
-
             {
                 priamServer.getId(); result = identity;
                 identity.getInstance(); result = instance;
@@ -143,11 +131,9 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void isReplaceToken()
+    public void isReplaceToken(@Mocked final InstanceIdentity identity)
     {
         new NonStrictExpectations() {
-            InstanceIdentity identity;
-
             {
                 priamServer.getId(); result = identity;
                 identity.isReplace(); result = true;
@@ -160,11 +146,9 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void isReplaceToken_handlesException()
+    public void isReplaceToken_handlesException(@Mocked final InstanceIdentity identity)
     {
         new Expectations() {
-            InstanceIdentity identity;
-
             {
                 priamServer.getId(); result = identity;
                 identity.isReplace(); result = new RuntimeException();
@@ -176,12 +160,10 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void getReplacedAddress()
+    public void getReplacedAddress(@Mocked final InstanceIdentity identity)
     {
     	final String replacedIp = "127.0.0.1";
         new Expectations() {
-            InstanceIdentity identity;
-
             {
                 priamServer.getId(); result = identity;
                 identity.getReplacedIp(); result = replacedIp;

--- a/priam/src/test/java/com/netflix/priam/resources/PriamInstanceResourceTest.java
+++ b/priam/src/test/java/com/netflix/priam/resources/PriamInstanceResourceTest.java
@@ -12,13 +12,16 @@ import com.netflix.priam.identity.PriamInstance;
 
 import mockit.Expectations;
 import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+@RunWith(JMockit.class)
 public class PriamInstanceResourceTest
 {
     private static final String APP_NAME = "myApp";
@@ -35,10 +38,10 @@ public class PriamInstanceResourceTest
     }
 
     @Test
-    public void getInstances()
+    public void getInstances(@Mocked final PriamInstance instance1,
+        @Mocked final PriamInstance instance2, @Mocked final PriamInstance instance3)
     {
         new Expectations() {
-            PriamInstance instance1, instance2, instance3;
             List<PriamInstance> instances = ImmutableList.of(instance1, instance2, instance3);
 
             {
@@ -54,12 +57,10 @@ public class PriamInstanceResourceTest
     }
 
     @Test
-    public void getInstance()
+    public void getInstance(@Mocked final PriamInstance instance)
     {
         final String expected = "plain text describing the instance";
         new Expectations() {
-            PriamInstance instance;
-
             {
                 config.getAppName(); result = APP_NAME;
                 factory.getInstance(APP_NAME, config.getDC(), NODE_ID); result = instance;
@@ -90,7 +91,7 @@ public class PriamInstanceResourceTest
     }
 
     @Test
-    public void createInstance()
+    public void createInstance(@Mocked final PriamInstance instance)
     {
         final String instanceID = "i-abc123";
         final String hostname = "dom.com";
@@ -99,8 +100,6 @@ public class PriamInstanceResourceTest
         final String token = "1234567890";
 
         new Expectations() {
-          PriamInstance instance;
-
           {
               config.getAppName(); result = APP_NAME;
               factory.create(APP_NAME, NODE_ID, instanceID, hostname, ip, rack, null, token); result = instance;
@@ -114,11 +113,9 @@ public class PriamInstanceResourceTest
     }
 
     @Test
-    public void deleteInstance()
+    public void deleteInstance(@Mocked final PriamInstance instance)
     {
         new Expectations() {
-          PriamInstance instance;
-
           {
               config.getAppName(); result = APP_NAME;
               factory.getInstance(APP_NAME, config.getDC(), NODE_ID); result = instance;


### PR DESCRIPTION
…sions of Java; also fix CassandraAdminTest failure caused as regression in 49865ab. Addresses the comment in issue #415 