### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/priam-agent/build.gradle
+++ b/priam-agent/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile 'com.netflix.astyanax:astyanax:1.56.42'
     compile 'commons-lang:commons-lang:2.6'
     compile 'commons-logging:commons-logging:1.1.3'
-    compile 'commons-collections:commons-collections:3.2.1'
+    compile 'commons-collections:commons-collections:3.2.2'
     compile 'commons-io:commons-io:2.0.1'
     compile 'commons-cli:commons-cli:1.2'
     compile 'commons-httpclient:commons-httpclient:3.1'

--- a/priam-cass-extensions/build.gradle
+++ b/priam-cass-extensions/build.gradle
@@ -8,7 +8,7 @@ jar {
 dependencies {
     compile 'commons-lang:commons-lang:2.6'
     compile 'commons-logging:commons-logging:1.1.3'
-    compile 'commons-collections:commons-collections:3.2.1'
+    compile 'commons-collections:commons-collections:3.2.2'
     compile 'commons-io:commons-io:2.0.1'
     compile 'commons-cli:commons-cli:1.2'
     compile 'commons-httpclient:commons-httpclient:3.1'

--- a/priam-dse-extensions/build.gradle
+++ b/priam-dse-extensions/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compile project(':priam')
     compile 'commons-lang:commons-lang:2.6'
     compile 'commons-logging:commons-logging:1.1.3'
-    compile 'commons-collections:commons-collections:3.2.1'
+    compile 'commons-collections:commons-collections:3.2.2'
     compile 'commons-io:commons-io:2.0.1'
     compile 'commons-cli:commons-cli:1.2'
     compile 'commons-httpclient:commons-httpclient:3.1'

--- a/priam-web/build.gradle
+++ b/priam-web/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compile project(':priam-cass-extensions')
     compile 'commons-lang:commons-lang:2.6'
     compile 'commons-logging:commons-logging:1.1.3'
-    compile 'commons-collections:commons-collections:3.2.1'
+    compile 'commons-collections:commons-collections:3.2.2'
     compile 'commons-io:commons-io:2.0.1'
     compile 'commons-cli:commons-cli:1.2'
     compile 'commons-httpclient:commons-httpclient:3.1'

--- a/priam/build.gradle
+++ b/priam/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'nebula.nebula-test-jar'
 dependencies {
     compile 'commons-lang:commons-lang:2.6'
     compile 'commons-logging:commons-logging:1.1.3'
-    compile 'commons-collections:commons-collections:3.2.1'
+    compile 'commons-collections:commons-collections:3.2.2'
     compile 'commons-io:commons-io:2.0.1'
     compile 'commons-cli:commons-cli:1.2'
     compile 'commons-httpclient:commons-httpclient:3.1'


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/