### PR TITLE
Add support for Murmur3 Partitioner

### DIFF
--- a/priam/src/test/java/com/netflix/priam/FakeConfigurationMurmur3.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfigurationMurmur3.java
@@ -1,0 +1,685 @@
+package com.netflix.priam;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Singleton;
+import com.netflix.priam.IConfiguration;
+import com.netflix.priam.defaultimpl.PriamConfiguration;
+
+@Singleton
+public class FakeConfigurationMurmur3 implements IConfiguration
+{
+
+	public static final String FAKE_REGION = "us-east-1";
+
+    public String region;
+    public String appName;
+    public String zone;
+    public String instance_id;
+    public String restorePrefix;
+
+    public FakeConfigurationMurmur3()
+    {
+        this(FAKE_REGION, "my_fake_cluster", "my_zone", "i-01234567");
+    }
+
+    public FakeConfigurationMurmur3(String region, String appName, String zone, String ins_id)
+    {
+        this.region = region;
+        this.appName = appName;
+        this.zone = zone;
+        this.instance_id = ins_id;
+        this.restorePrefix  = "";
+    }
+
+    @Override
+    public void intialize()
+    {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public String getBackupLocation()
+    {
+        // TODO Auto-generated method stub
+        return "casstestbackup";
+    }
+
+    @Override
+    public String getBackupPrefix()
+    {
+        // TODO Auto-generated method stub
+        return "TEST-netflix.platform.S3";
+    }
+
+    @Override
+    public boolean isCommitLogBackup()
+    {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public String getCommitLogLocation()
+    {
+        // TODO Auto-generated method stub
+        return "cass/commitlog";
+    }
+
+    @Override
+    public String getDataFileLocation()
+    {
+        // TODO Auto-generated method stub
+        return "target/data";
+    }
+
+    @Override
+    public String getCacheLocation()
+    {
+        // TODO Auto-generated method stub
+        return "cass/caches";
+    }
+
+    @Override
+    public List<String> getRacs()
+    {
+        return Arrays.asList("az1", "az2", "az3");
+    }
+
+    @Override
+    public int getJmxPort()
+    {
+        return 7199;
+    }
+
+    @Override
+    public int getThriftPort()
+    {
+        return 9160;
+    }
+
+    @Override
+    public int getNativeTransportPort()
+    {
+        return 9042;
+    }
+
+    @Override
+    public String getSnitch()
+    {
+        return "org.apache.cassandra.locator.SimpleSnitch";
+    }
+
+    @Override
+    public String getRac()
+    {
+        return this.zone;
+    }
+
+    @Override
+    public String getHostname()
+    {
+        // TODO Auto-generated method stub
+        return instance_id;
+    }
+
+    @Override
+    public String getInstanceName()
+    {
+        return instance_id;
+    }
+
+    @Override
+    public String getHeapSize()
+    {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public String getHeapNewSize()
+    {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public int getBackupHour()
+    {
+        // TODO Auto-generated method stub
+        return 12;
+    }
+
+    @Override
+    public String getRestoreSnapshot()
+    {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public String getAppName()
+    {
+        return appName;
+    }
+
+    @Override
+    public String getACLGroupName()
+    {
+        return this.getAppName();
+    }
+
+    @Override
+    public int getMaxBackupUploadThreads()
+    {
+        // TODO Auto-generated method stub
+        return 2;
+    }
+
+    @Override
+    public String getDC()
+    {
+        // TODO Auto-generated method stub
+        return this.region;
+    }
+
+    @Override
+    public int getMaxBackupDownloadThreads()
+    {
+        // TODO Auto-generated method stub
+        return 3;
+    }
+
+    public void setRestorePrefix(String prefix)
+    {
+        // TODO Auto-generated method stub
+        restorePrefix = prefix;
+    }
+
+    @Override
+    public String getRestorePrefix()
+    {
+        // TODO Auto-generated method stub
+        return restorePrefix;
+    }
+
+    @Override
+    public String getBackupCommitLogLocation()
+    {
+        return "cass/backup/cl/";
+    }
+
+    @Override
+    public boolean isMultiDC()
+    {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public String getASGName()
+    {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public boolean isIncrBackup()
+    {
+        return true;
+    }
+
+    @Override
+    public String getHostIP()
+    {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public int getUploadThrottle()
+    {
+        // TODO Auto-generated method stub
+        return 0;
+    }
+
+	@Override
+	public boolean isLocalBootstrapEnabled() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public int getInMemoryCompactionLimit() {
+		return 8;
+	}
+
+	@Override
+	public int getCompactionThroughput() {
+		// TODO Auto-generated method stub
+		return 0;
+	}
+
+    @Override
+    public String getMaxDirectMemory()
+    {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public String getBootClusterName()
+    {
+        // TODO Auto-generated method stub
+        return "cass_bootstrap";
+    }
+
+    @Override
+    public String getCassHome()
+    {
+        return "/tmp/priam";
+    }
+
+    @Override
+    public String getCassStartupScript()
+    {
+        // TODO Auto-generated method stub
+        return "true";
+    }
+
+    @Override
+    public List<String> getRestoreKeySpaces()
+    {
+        // TODO Auto-generated method stub
+        return Lists.newArrayList();
+    }
+
+    @Override
+    public long getBackupChunkSize()
+    {
+        return 5L*1024*1024;
+    }
+
+    @Override
+    public void setDC(String region)
+    {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public boolean isRestoreClosestToken()
+    {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public String getCassStopScript()
+    {
+        return "true";
+    }
+
+    @Override
+    public int getStoragePort()
+    {
+        return 7101;
+    }
+
+    @Override
+    public String getSeedProviderName()
+    {
+        return "org.apache.cassandra.locator.SimpleSeedProvider";
+    }
+
+    @Override
+    public int getBackupRetentionDays()
+    {
+        return 5;
+    }
+
+    @Override
+    public List<String> getBackupRacs()
+    {
+        return Lists.newArrayList();
+    }
+
+    public int getMaxHintWindowInMS()
+    {
+        return 36000;
+    }
+
+    public int getHintedHandoffThrottleKb()
+    {
+        return 1024;
+    }
+
+    public int getMaxHintThreads()
+    {
+        return 1;
+    }
+
+    @Override
+    public int getMemtableTotalSpaceMB()
+    {
+        return 0;
+    }
+
+    @Override
+    public int getStreamingThroughputMB()
+    {
+        return 400;
+    }
+
+    @Override
+    public boolean getMultithreadedCompaction()
+    {
+        return false;
+    }
+
+    public String getPartitioner()
+    {
+        return "org.apache.cassandra.dht.Murmur3Partitioner";
+    }
+
+    @Override
+    public int getSSLStoragePort()
+    {
+        // TODO Auto-generated method stub
+        return 7103;
+    }
+
+    public String getKeyCacheSizeInMB()
+    {
+        return "16";
+    }
+
+    public String getKeyCacheKeysToSave()
+    {
+        return "32";
+    }
+
+    public String getRowCacheSizeInMB()
+    {
+        return "4";
+    }
+
+    public String getRowCacheKeysToSave()
+    {
+        return "4";
+    }
+
+	@Override
+	public String getCassProcessName() {
+		return "CassandraDaemon";
+	}
+
+    public int getNumTokens()
+    {
+        return 1;
+    }
+
+    public String getYamlLocation()
+    {
+        return "conf/cassandra.yaml";
+    }
+
+    public String getAuthenticator()
+    {
+        return PriamConfiguration.DEFAULT_AUTHENTICATOR;
+    }
+
+    public String getAuthorizer()
+    {
+        return PriamConfiguration.DEFAULT_AUTHORIZER;
+    }
+
+    @Override
+	public String getTargetKSName() {
+		return null;
+	}
+
+	@Override
+	public String getTargetCFName() {
+		return null;
+	}
+
+	@Override
+	public boolean doesCassandraStartManually() {
+		return false;
+	}
+
+    @Override
+    public boolean isVpcRing() {
+        return false;
+    }
+
+    public String getInternodeCompression()
+    {
+        return "all";
+    }
+
+    @Override
+    public boolean isBackingUpCommitLogs()
+    {
+        return false;
+    }
+
+    @Override
+    public String getCommitLogBackupArchiveCmd()
+    {
+        return null;
+    }
+
+    @Override
+    public String getCommitLogBackupRestoreCmd()
+    {
+        return null;
+    }
+
+    @Override
+    public String getCommitLogBackupRestoreFromDirs()
+    {
+        return null;
+    }
+
+    @Override
+    public String getCommitLogBackupRestorePointInTime()
+    {
+        return null;
+    }
+
+    public void setRestoreKeySpaces(List<String> keyspaces) {
+
+    }
+
+    @Override
+    public int maxCommitLogsRestore() {
+       return 0;
+    }
+
+    public boolean isClientSslEnabled()
+    {
+        return true;
+    }
+
+    public String getInternodeEncryption()
+    {
+        return "all";
+    }
+
+    public boolean isDynamicSnitchEnabled()
+    {
+        return true;
+    }
+
+    public boolean isThriftEnabled()
+    {
+        return true;
+    }
+
+    public boolean isNativeTransportEnabled()
+    {
+        return false;
+    }
+
+    @Override
+    public String getS3EndPoint() {
+	return "s3-external-1.amazonaws.com";
+    }
+
+    public int getConcurrentReadsCnt()
+    {
+        return 8;
+    }
+
+    public int getConcurrentWritesCnt()
+    {
+        return 8;
+    }
+
+    public int getConcurrentCompactorsCnt()
+    {
+        return 1;
+    }
+
+	@Override
+	public String getRpcServerType() {
+		return "hsha";
+	}
+
+	@Override
+	public int getIndexInterval() {
+		return 0;
+	}
+
+	public String getExtraConfigParams() {
+		return null;
+	}
+
+    public String getCassYamlVal(String priamKey) {
+    	return "";
+    }
+
+    @Override
+    public boolean getAutoBoostrap() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public String getDseClusterType() {
+        // TODO Auto-generated method stub
+        return "cassandra";
+    }
+
+	@Override
+	public boolean isCreateNewTokenEnable() {
+		return true;  //allow Junit test to create new tokens
+	}
+
+	@Override
+	public String getPrivateKeyLocation() {
+		return null;
+	}
+
+	@Override
+	public String getRestoreSourceType() {
+		return null;
+	}
+
+	@Override
+	public boolean isEncryptBackupEnabled() {
+		return false;
+	}
+
+	@Override
+	public String getAWSRoleAssumptionArn() {
+		return null;
+	}
+
+	@Override
+	public String getGcsServiceAccountId() {
+		return null;
+	}
+
+	@Override
+	public String getGcsServiceAccountPrivateKeyLoc() {
+		return null;
+	}
+
+	@Override
+	public String getPgpPasswordPhrase() {
+		return null;
+	}
+
+	@Override
+	public String getPgpPublicKeyLoc() {
+		return null;
+	}
+
+    /**
+     * Use this method for adding extra/ dynamic cassandra startup options or env properties
+     *
+     * @return
+     */
+    @Override
+    public Map<String, String> getExtraEnvParams() {
+        return null;
+    }
+
+    @Override
+    public String getRestoreKeyspaceFilter()
+    {
+        return null;
+    }
+
+    @Override
+    public String getRestoreCFFilter() {
+    	return null;
+    }
+
+   @Override
+    public String getIncrementalKeyspaceFilters() {
+    	return null;
+    }
+
+    @Override
+    public String getIncrementalCFFilter() {
+    	return null;
+    }
+
+    @Override
+    public String getSnapshotKeyspaceFilters() {
+    	return null;
+    }
+
+    @Override
+    public String getSnapshotCFFilter() {
+    	return null;
+    }
+
+    @Override
+    public String getVpcId() {
+    	return "";
+    }
+
+	@Override
+	public Boolean isIncrBackupParallelEnabled() {
+		return false;
+	}
+
+	@Override
+	public int getIncrementalBkupMaxConsumers() {
+		return 2;
+	}
+
+	@Override
+	public int getUncrementalBkupQueueSize() {
+		return 100;
+	}
+}

--- a/priam/src/test/java/com/netflix/priam/backup/identity/DoubleRingTest.java
+++ b/priam/src/test/java/com/netflix/priam/backup/identity/DoubleRingTest.java
@@ -16,7 +16,6 @@ import static org.junit.Assert.assertEquals;
 
 public class DoubleRingTest extends InstanceTestUtils
 {
-    private static final ITokenManager tokenManager = new TokenManager();
 
     @Test
     public void testDouble() throws Exception

--- a/priam/src/test/java/com/netflix/priam/backup/identity/InstanceIdentityTest.java
+++ b/priam/src/test/java/com/netflix/priam/backup/identity/InstanceIdentityTest.java
@@ -14,7 +14,6 @@ import static org.junit.Assert.assertEquals;
 
 public class InstanceIdentityTest extends InstanceTestUtils
 {
-    private static final ITokenManager tokenManager = new TokenManager();
 
     @Test
     public void testCreateToken() throws Exception

--- a/priam/src/test/java/com/netflix/priam/backup/identity/InstanceTestUtils.java
+++ b/priam/src/test/java/com/netflix/priam/backup/identity/InstanceTestUtils.java
@@ -33,7 +33,7 @@ public abstract class InstanceTestUtils
     DeadTokenRetriever deadTokenRetriever;
     PreGeneratedTokenRetriever preGeneratedTokenRetriever;
 	NewTokenRetriever newTokenRetriever;
-	private static final ITokenManager tokenManager = new TokenManager();
+  	ITokenManager tokenManager;
 
     @Before
     public void setup()
@@ -50,6 +50,7 @@ public abstract class InstanceTestUtils
 
         membership = new FakeMembership(instances);
         config = new FakeConfiguration("fake", "fake-app", "az1", "fakeinstance1");
+        tokenManager = new TokenManager(config);
         factory = new FakePriamInstanceFactory(config);
         sleeper = new FakeSleeper();
         this.deadTokenRetriever = new DeadTokenRetriever(factory, membership, config, sleeper);
@@ -71,12 +72,12 @@ public abstract class InstanceTestUtils
         createInstanceIdentity("az3", "fakeinstance8");
         createInstanceIdentity("az3", "fakeinstance9");
     }
-    
+
     protected InstanceIdentity createInstanceIdentity(String zone, String instanceId) throws Exception
     {
         config.zone = zone;
         config.instance_id = instanceId;
-        return new InstanceIdentity(factory, membership, config, sleeper, new TokenManager()
+        return new InstanceIdentity(factory, membership, config, sleeper, new TokenManager(config)
         , this.deadTokenRetriever
         , this.preGeneratedTokenRetriever
         , this.newTokenRetriever

--- a/priam/src/test/java/com/netflix/priam/resources/BackupServletTest.java
+++ b/priam/src/test/java/com/netflix/priam/resources/BackupServletTest.java
@@ -53,16 +53,17 @@ public class BackupServletTest
     private @Mocked IPriamInstanceFactory factory;
     private @Mocked ICassandraProcess cassProcess;
     private @Mocked BackupStatusMgr bkupStatusMgr;
-    private final ITokenManager tokenManager = new TokenManager();
+    private ITokenManager tokenManager;
     private BackupServlet resource;
     private RestoreServlet restoreResource;
 
     @Before
     public void setUp()
     {
+        this.tokenManager = new TokenManager(config);
         resource = new BackupServlet(priamServer, config, bkpFs, bkpStatusFs, restoreObj, pathProvider,
             tuner, snapshotBackup, factory, tokenManager, cassProcess, bkupStatusMgr);
-        
+
         restoreResource = new RestoreServlet(config, restoreObj, pathProvider,priamServer, factory, tuner, cassProcess
         		, tokenManager);
     }
@@ -96,19 +97,19 @@ public class BackupServletTest
             {
               priamServer.getId(); result = identity; times = 2;
             }
-        };	
+        };
 
         new Expectations() {
-  
+
             {
                 config.getDC(); result = oldRegion;
                 identity.getInstance(); result = instance; times = 2;
                 instance.getToken(); result = oldToken;
 
                 config.isRestoreClosestToken(); result = false;
-  
+
                 restoreObj.restore((Date) any, (Date) any); // TODO: test default value
-  
+
                 config.setDC(oldRegion);
                 instance.setToken(oldToken);
                 tuner.updateAutoBootstrap(config.getYamlLocation(), false);
@@ -141,7 +142,7 @@ public class BackupServletTest
             }
         };
         new Expectations() {
-  
+
             {
                 pathProvider.get(); result = backupPath;
                 backupPath.parseDate(dateRange.split(",")[0]); result = new DateTime(2011, 01, 01, 00, 00).toDate(); times = 1;
@@ -156,7 +157,7 @@ public class BackupServletTest
                 restoreObj.restore(
                     new DateTime(2011, 01, 01, 00, 00).toDate(),
                     new DateTime(2011, 12, 31, 23, 59).toDate());
-  
+
                 config.setDC(oldRegion);
                 instance.setToken(oldToken);
                 tuner.updateAutoBootstrap(config.getYamlLocation(), false);
@@ -187,7 +188,7 @@ public class BackupServletTest
 //            @NonStrict InstanceIdentity identity;
 //            PriamInstance instance;
 //            @NonStrict PriamInstance instance1, instance2, instance3;
-//  
+//
 //            {
 //                config.getDC(); result = oldRegion;
 //                priamServer.getId(); result = identity; times = 3;
@@ -195,7 +196,7 @@ public class BackupServletTest
 //                instance.getToken(); result = oldToken;
 //
 //                config.isRestoreClosestToken(); result = false;
-//                
+//
 //                config.setDC(newRegion);
 //                instance.getToken(); result = oldToken;
 //                config.getAppName(); result = appName;
@@ -211,7 +212,7 @@ public class BackupServletTest
 //                instance.setToken((String) any); // TODO: test mocked closest token
 //
 //                restoreObj.restore((Date) any, (Date) any); // TODO: test default value
-//  
+//
 //                config.setDC(oldRegion);
 //                instance.setToken(oldToken);
 //                tuneCassandra.writeAllProperties(false);
@@ -244,7 +245,7 @@ public class BackupServletTest
             }
         };
         new Expectations() {
-  
+
             {
                 config.getDC(); result = oldRegion;
                 identity.getInstance(); result = instance; times = 3;
@@ -254,7 +255,7 @@ public class BackupServletTest
                 config.isRestoreClosestToken(); result = false;
 
                 restoreObj.restore((Date) any, (Date) any); // TODO: test default value
-  
+
                 config.setDC(oldRegion);
                 instance.setToken(oldToken);
                 tuner.updateAutoBootstrap(config.getYamlLocation(), false);
@@ -296,13 +297,13 @@ public class BackupServletTest
             }
         };
         new Expectations() {
-  
+
             {
                 identity.getInstance(); result = instance; times = 2;
                 instance.getToken(); result = oldToken;
 
                 restoreObj.restore((Date) any, (Date) any); // TODO: test default value
-  
+
                 instance.setToken(oldToken);
                 tuner.updateAutoBootstrap(config.getYamlLocation(), false);
             }
@@ -367,7 +368,7 @@ public class BackupServletTest
                 restoreObj.restore(
                     new DateTime(2011, 01, 01, 00, 00).toDate(),
                     new DateTime(2011, 12, 31, 23, 59).toDate());
-  
+
                 instance.setToken(oldToken);
                 tuner.updateAutoBootstrap(config.getYamlLocation(), false);
             }

--- a/priam/src/test/java/com/netflix/priam/utils/RandomTokenManagerTest.java
+++ b/priam/src/test/java/com/netflix/priam/utils/RandomTokenManagerTest.java
@@ -1,0 +1,179 @@
+package com.netflix.priam.utils;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.Before;
+
+import com.google.common.collect.ImmutableList;
+import static com.netflix.priam.utils.TokenManager.MAXIMUM_TOKEN_RANDOM;
+import static com.netflix.priam.utils.TokenManager.MINIMUM_TOKEN_RANDOM;
+import com.netflix.priam.FakeConfiguration;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class RandomTokenManagerTest
+{
+    FakeConfiguration config;
+    private TokenManager tokenManager;
+
+    @Before
+    public void setUp()
+    {
+        this.config = new FakeConfiguration();
+        this.tokenManager = new TokenManager(config);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void initialToken_zeroSize()
+    {
+        tokenManager.initialToken(0, 0, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void initialToken_negativePosition()
+    {
+        tokenManager.initialToken(1, -1, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void initialToken_negativeOffset()
+    {
+        tokenManager.initialToken(1, 0, -1);
+    }
+
+    @Test
+    public void initialToken_positionZero()
+    {
+        assertEquals(MINIMUM_TOKEN_RANDOM, tokenManager.initialToken(1, 0, 0));
+        assertEquals(MINIMUM_TOKEN_RANDOM, tokenManager.initialToken(10, 0, 0));
+        assertEquals(MINIMUM_TOKEN_RANDOM, tokenManager.initialToken(133, 0, 0));
+    }
+
+    @Test
+    public void initialToken_offsets_zeroPosition()
+    {
+        assertEquals(MINIMUM_TOKEN_RANDOM.add(BigInteger.valueOf(7)), tokenManager.initialToken(1, 0, 7));
+        assertEquals(MINIMUM_TOKEN_RANDOM.add(BigInteger.valueOf(11)), tokenManager.initialToken(2, 0, 11));
+        assertEquals(MINIMUM_TOKEN_RANDOM.add(BigInteger.valueOf(Integer.MAX_VALUE)),
+                tokenManager.initialToken(256, 0, Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void initialToken_cannotExceedMaximumToken() {
+        final int maxRingSize = Integer.MAX_VALUE;
+        final int maxPosition = maxRingSize - 1;
+        final int maxOffset = Integer.MAX_VALUE;
+        assertEquals(1, MAXIMUM_TOKEN_RANDOM.compareTo(tokenManager.initialToken(maxRingSize, maxPosition, maxOffset)));
+    }
+
+    @Test
+    public void createToken()
+    {
+        assertEquals(MAXIMUM_TOKEN_RANDOM.divide(BigInteger.valueOf(8 * 32))
+                .multiply(BigInteger.TEN)
+                .add(BigInteger.valueOf(tokenManager.regionOffset("region")))
+                .toString(),
+                tokenManager.createToken(10, 8, 32, "region"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void findClosestToken_emptyTokenList()
+    {
+        tokenManager.findClosestToken(BigInteger.ZERO, Collections.<BigInteger>emptyList());
+    }
+
+    @Test
+    public void findClosestToken_singleTokenList()
+    {
+        final BigInteger onlyToken = BigInteger.valueOf(100);
+        assertEquals(onlyToken, tokenManager.findClosestToken(BigInteger.TEN, ImmutableList.of(onlyToken)));
+    }
+
+    @Test
+    public void findClosestToken_multipleTokenList()
+    {
+        List<BigInteger> tokenList = ImmutableList.of(BigInteger.ONE, BigInteger.TEN, BigInteger.valueOf(100));
+        assertEquals(BigInteger.ONE, tokenManager.findClosestToken(BigInteger.ONE, tokenList));
+        assertEquals(BigInteger.TEN, tokenManager.findClosestToken(BigInteger.valueOf(9), tokenList));
+        assertEquals(BigInteger.TEN, tokenManager.findClosestToken(BigInteger.TEN, tokenList));
+        assertEquals(BigInteger.TEN, tokenManager.findClosestToken(BigInteger.valueOf(12), tokenList));
+        assertEquals(BigInteger.TEN, tokenManager.findClosestToken(BigInteger.valueOf(51), tokenList));
+        assertEquals(BigInteger.valueOf(100), tokenManager.findClosestToken(BigInteger.valueOf(56), tokenList));
+        assertEquals(BigInteger.valueOf(100), tokenManager.findClosestToken(BigInteger.valueOf(100), tokenList));
+    }
+
+    @Test
+    public void findClosestToken_tieGoesToLargerToken()
+    {
+        assertEquals(BigInteger.TEN, tokenManager.findClosestToken(BigInteger.valueOf(5),
+                ImmutableList.of(BigInteger.ZERO, BigInteger.TEN)));
+    }
+
+    @Test
+    public void test4Splits()
+    {
+        // example tokens from http://wiki.apache.org/cassandra/Operations
+
+        final String expectedTokens = "0,42535295865117307932921825928971026432,"
+                + "85070591730234615865843651857942052864,127605887595351923798765477786913079296";
+        String[] tokens = expectedTokens.split(",");
+        int splits = tokens.length;
+        for (int i = 0; i < splits; i++)
+            assertEquals(new BigInteger(tokens[i]), tokenManager.initialToken(splits, i, 0));
+    }
+
+    @Test
+    public void test16Splits()
+    {
+      final String expectedTokens = "0,10633823966279326983230456482242756608,"
+              + "21267647932558653966460912964485513216,31901471898837980949691369446728269824,"
+              + "42535295865117307932921825928971026432,53169119831396634916152282411213783040,"
+              + "63802943797675961899382738893456539648,74436767763955288882613195375699296256,"
+              + "85070591730234615865843651857942052864,95704415696513942849074108340184809472,"
+              + "106338239662793269832304564822427566080,116972063629072596815535021304670322688,"
+              + "127605887595351923798765477786913079296,138239711561631250781995934269155835904,"
+              + "148873535527910577765226390751398592512,159507359494189904748456847233641349120";
+        String[] tokens = expectedTokens.split(",");
+        int splits = tokens.length;
+        for (int i = 0; i < splits; i++)
+            assertEquals(new BigInteger(tokens[i]), tokenManager.initialToken(splits, i, 0));
+    }
+
+    @Test
+    public void regionOffset()
+    {
+        String allRegions = "us-west-2,us-east,us-west,eu-east,eu-west,ap-northeast,ap-southeast";
+
+        for (String region1 : allRegions.split(","))
+            for (String region2 : allRegions.split(","))
+            {
+                if (region1.equals(region2))
+                    continue;
+                assertFalse("Diffrence seems to be low",
+                        Math.abs(tokenManager.regionOffset(region1) - tokenManager.regionOffset(region2)) < 100);
+            }
+    }
+
+    @Test
+    public void testMultiToken()
+    {
+        int h1 = tokenManager.regionOffset("vijay");
+        int h2 = tokenManager.regionOffset("vijay2");
+        BigInteger t1 = tokenManager.initialToken(100, 10, h1);
+        BigInteger t2 = tokenManager.initialToken(100, 10, h2);
+
+        BigInteger tokendistance = t1.subtract(t2).abs();
+        int hashDiffrence = h1 - h2;
+
+        assertEquals(new BigInteger("" + hashDiffrence).abs(), tokendistance);
+
+        BigInteger t3 = tokenManager.initialToken(100, 99, h1);
+        BigInteger t4 = tokenManager.initialToken(100, 99, h2);
+        tokendistance = t3.subtract(t4).abs();
+
+        assertEquals(new BigInteger("" + hashDiffrence).abs(), tokendistance);
+    }
+}


### PR DESCRIPTION
TokenManager now uses configuration data to use the correct token 'space' for either random  or Murmur3 partitioners.

Have had to change the interface for ITokenManager to make this work.

I've duplicated FakeConfiguration to simulate passing in Murmur3 as a configuration option, as well as the existing tests.

By default, TokenManager will use the random token 'space', so this shouldn't kill Netflix's data :wink:.

If someone has tips on how to DRY this up a bit better, I'm all ears. Been about a decade since I've done any Java.

Related to former issues #198, #255 and #361