### PR TITLE
Exclusion of keyspace/CF from backups, allow visibility to restore, and remove temp incremental audit file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ subprojects {
       compile 'com.google.apis:google-api-services-storage:v1-rev9-1.19.0'
       compile 'com.google.http-client:google-http-client-jackson2:1.19.0'
       provided 'javax.servlet:servlet-api:2.5'
-      testCompile 'com.googlecode.jmockit:jmockit:0.999.17'
+      testCompile 'org.jmockit:jmockit:1.19'
       testCompile 'junit:junit:4.8'
     }
 }

--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -185,7 +185,46 @@ public interface IConfiguration
      * @return Backup hour for snapshot backups (0 - 23)
      */
     public int getBackupHour();
-
+    
+    /*
+     * @return key spaces, comma delimited, to filter from restore.  If no filter is applied, returns null or empty string.
+     */
+    public String getSnapshotKeyspaceFilters();
+    
+    /*
+     * Column Family(ies), comma delimited, to filter from backup.
+     * *Note:  the expected format is keyspace.cfname  
+     * 
+     * @return Column Family(ies), comma delimited, to filter from backup.  If no filter is applied, returns null.
+     */
+    public String getSnapshotCFFilter();
+    
+    /*
+     * @return key spaces, comma delimited, to filter from restore.  If no filter is applied, returns null or empty string.
+     */
+    public String getIncrementalKeyspaceFilters();
+    
+    /*
+     * Column Family(ies), comma delimited, to filter from backup.
+     * *Note:  the expected format is keyspace.cfname  
+     * 
+     * @return Column Family(ies), comma delimited, to filter from backup.  If no filter is applied, returns null.
+     */
+    public String getIncrementalCFFilter();
+    
+    /*
+     * @return key spaces, comma delimited, to filter from restore.  If no filter is applied, returns null or empty string.
+     */
+    public String getRestoreKeyspaceFilter();
+    
+    /*
+     * Column Family(ies), comma delimited, to filter from backup.
+     * Note:  the expected format is keyspace.cfname  
+     * 
+     * @return Column Family(ies), comma delimited, to filter from restore.  If no filter is applied, returns null or empty string.
+     */
+    public String getRestoreCFFilter();
+    
     /**
      * Specifies the start and end time used for restoring data (yyyyMMddHHmm
      * format) Eg: 201201132030,201201142030

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
@@ -19,6 +19,8 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -59,6 +61,17 @@ public abstract class AbstractBackup extends Task
     protected void setFileSystem(IBackupFileSystem fs) {
     	this.fs = fs;
     }    
+    
+    /*
+     * search for "1:* alphanumeric chars including special chars""literal period"" 1:* alphanumeric chars  including special chars"
+     * @param input string
+     * @return true if input string matches search pattern; otherwise, false
+     */
+    protected boolean isValidCFFilterFormat(String cfFilter) {
+    	Pattern p = Pattern.compile(".\\..");
+    	Matcher m = p.matcher(cfFilter);
+    	return m.find();
+    }
    
     /**
      * Upload files in the specified dir. Does not delete the file in case of
@@ -145,12 +158,18 @@ public abstract class AbstractBackup extends Task
         if (!backupDir.isDirectory() && !backupDir.exists())
             return false;
         String keyspaceName = keyspaceDir.getName();
-        if (FILTER_KEYSPACE.contains(keyspaceName))
-            return false;
+        if (FILTER_KEYSPACE.contains(keyspaceName)) {
+        	logger.info(keyspaceName + " is not consider a valid keyspace backup directory, will be bypass.");
+            return false;        	
+        }
+
         String columnFamilyName = columnFamilyDir.getName();
 
-        if (FILTER_COLUMN_FAMILY.containsKey(keyspaceName) && FILTER_COLUMN_FAMILY.get(keyspaceName).contains(columnFamilyName))
-            return false;
+        if (FILTER_COLUMN_FAMILY.containsKey(keyspaceName) && FILTER_COLUMN_FAMILY.get(keyspaceName).contains(columnFamilyName)) {
+        	logger.info(columnFamilyName + " is not consider a valid CF backup directory, will be bypass.");
+            return false;        	
+        }
+
         return true;
     }
     
@@ -158,5 +177,9 @@ public abstract class AbstractBackup extends Task
      * Adds Remote path to the list of Remote Paths
      */
     protected abstract void addToRemotePath(String remotePath);
+    
+    public enum DIRECTORYTYPE {
+    	KEYSPACE, CF
+    }
     
 }

--- a/priam/src/main/java/com/netflix/priam/backup/IncrementalBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/IncrementalBackup.java
@@ -17,7 +17,11 @@ package com.netflix.priam.backup;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -29,6 +33,7 @@ import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.netflix.priam.IConfiguration;
+import com.netflix.priam.backup.AbstractBackup.DIRECTORYTYPE;
 import com.netflix.priam.backup.AbstractBackupPath.BackupFileType;
 import com.netflix.priam.backup.IMessageObserver.BACKUP_MESSAGE_TYPE;
 import com.netflix.priam.scheduler.SimpleTimer;
@@ -45,6 +50,9 @@ public class IncrementalBackup extends AbstractBackup
     
     private final List<String> incrementalRemotePaths = new ArrayList<String>();
 	private IncrementalMetaData metaData;
+	
+    private final Map<String, Object> incrementalCFFilter = new HashMap<String, Object>();
+	private final Map<String, Object> incrementalKeyspaceFilter  = new HashMap<String, Object>();
 
     static List<IMessageObserver> observers = new ArrayList<IMessageObserver>();
 
@@ -54,13 +62,55 @@ public class IncrementalBackup extends AbstractBackup
     {
         super(config, backupFileSystemCtx, pathFactory);
         this.metaData = metaData; //a means to upload audit trail (via meta_cf_yyyymmddhhmm.json) of files successfully uploaded)
+        
+        init();
     }
     
+    private void init() {
+    	populateIncrementalFilters();
+    } 
+    
+    private void populateIncrementalFilters() {
+    	String keyspaceFilters = this.config.getIncrementalKeyspaceFilters();
+    	if (keyspaceFilters == null || keyspaceFilters.isEmpty()) {
+    		
+    		logger.info("No keyspace filter set for incremental.");
+    		
+    	} else {
+
+        	String[] keyspaces = keyspaceFilters.split(",");
+        	for (int i=0; i < keyspaces.length; i++ ) {
+        		logger.info("Adding incremental keyspace filter: " + keyspaces[i]);
+        		this.incrementalKeyspaceFilter.put(keyspaces[i], null);
+        	}    		
+    		
+    	}
+    	
+    	String cfFilters = this.config.getIncrementalCFFilter();
+    	if (cfFilters == null || cfFilters.isEmpty()) {
+    		
+    		logger.info("No column family filter set for snapshot.");
+    		
+    	} else {
+
+        	String[] cf = cfFilters.split(",");
+        	for (int i=0; i < cf.length; i++) {
+        		if (isValidCFFilterFormat(cf[i])) {
+        			logger.info("Adding incremental CF filter: " + cf[i]);
+            		this.incrementalCFFilter.put(cf[i], null);        			
+        		} else {
+        			throw new IllegalArgumentException("Column family filter format is not valid.  Format needs to be \"keyspace.columnfamily\".  Invalid input: " + cf[i]);
+        		}
+        	}    		
+    		
+    	}    	
+    }
+        
     @Override
     public void execute() throws Exception
     {   	
-    		//Clearing remotePath List
-    		incrementalRemotePaths.clear();
+    	//Clearing remotePath List
+    	incrementalRemotePaths.clear();
         File dataDir = new File(config.getDataFileLocation());
         if (!dataDir.exists())
         {
@@ -72,11 +122,28 @@ public class IncrementalBackup extends AbstractBackup
         {
             if (keyspaceDir.isFile())
         			continue;
+            
+            if ( isFiltered(DIRECTORYTYPE.KEYSPACE, keyspaceDir.getName()) ) { //keyspace filtered?
+            	logger.info(keyspaceDir.getName() + " is part of keyspace filter, incremental not done.");
+            	continue;
+            }
+            
             for (File columnFamilyDir : keyspaceDir.listFiles())
             {
+            	
+                if ( isFiltered(DIRECTORYTYPE.CF, keyspaceDir.getName(), columnFamilyDir.getName()) ) { //CF filtered?
+                	logger.info("keyspace: " + keyspaceDir.getName() 
+                			+ ", CF: " + columnFamilyDir.getName() + " is part of CF filter list, incrmental not done.");
+                	continue;
+                }
+            	
                 File backupDir = new File(columnFamilyDir, "backups");
-                if (!isValidBackupDir(keyspaceDir, columnFamilyDir, backupDir))
-                    continue;
+                if (!isValidBackupDir(keyspaceDir, columnFamilyDir, backupDir)) {
+                	logger.warn("Not a valid backup dir or keyspace/cf is part of the default filter.  SnapshotDir: " + backupDir.getAbsolutePath()
+                			+ ", keyspace dir: " + keyspaceDir.getName() + ", CF: " + columnFamilyDir.getName());
+                	continue;
+                }
+                
                 List<AbstractBackupPath> uploadedFiles = upload(backupDir, BackupFileType.SST);
                 
                 if ( ! uploadedFiles.isEmpty() ) {
@@ -91,10 +158,36 @@ public class IncrementalBackup extends AbstractBackup
             }
         }
      		
-        	if(incrementalRemotePaths.size() > 0)
-        	{
-        		notifyObservers();
-        	}
+        if(incrementalRemotePaths.size() > 0)
+        {
+        	notifyObservers();
+        }
+
+    }
+    
+    /*
+     * @return true if directory should be filter from processing; otherwise, false.
+     */
+    private boolean isFiltered(DIRECTORYTYPE directoryType, String...args) {
+    	if (directoryType.equals(DIRECTORYTYPE.CF)) {
+    		String keyspaceName = args[0];
+    		String cfName = args[1];
+    		if (this.incrementalKeyspaceFilter.containsKey(keyspaceName)) { //account for keyspace which we want to filter
+    			return true;
+    		} else {
+    			StringBuffer strBuf = new StringBuffer();
+    			strBuf.append(keyspaceName);
+    			strBuf.append('.');
+    			strBuf.append(cfName);
+            	return this.incrementalCFFilter.containsKey(strBuf.toString());    			
+    		}
+        	
+    	} else if (directoryType.equals(DIRECTORYTYPE.KEYSPACE)) {
+    		return this.incrementalKeyspaceFilter.containsKey(args[0]);
+    		
+    	} else {
+    		throw new UnsupportedOperationException("Directory type not supported.  Invalid input: " + directoryType.name());
+    	}
 
     }
 

--- a/priam/src/main/java/com/netflix/priam/backup/IncrementalMetaData.java
+++ b/priam/src/main/java/com/netflix/priam/backup/IncrementalMetaData.java
@@ -24,7 +24,7 @@ public class IncrementalMetaData extends MetaData {
 	}
 	
 	@Override
-	public File createTmpMetaFile() throws IOException{
+	public File createTmpMetaFile() throws IOException {
 		File metafile = null, destFile = null;
 		
 		if (this.metaFileName == null) {
@@ -39,7 +39,16 @@ public class IncrementalMetaData extends MetaData {
 		
         if(destFile.exists())
             destFile.delete();
-        FileUtils.moveFile(metafile, destFile);
+        
+        try {
+			
+        	FileUtils.moveFile(metafile, destFile);
+			
+		} finally {
+			if (metafile != null && metafile.exists()) { //clean up resource
+				FileUtils.deleteQuietly(metafile);
+			}
+		}
         return destFile;
 
     }

--- a/priam/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
@@ -16,10 +16,9 @@
 package com.netflix.priam.backup;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.List;
-import java.util.TimeZone;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +53,8 @@ public class SnapshotBackup extends AbstractBackup
     private final ThreadSleeper sleeper = new ThreadSleeper();
     private final long WAIT_TIME_MS = 60 * 1000 * 10;
     private final CommitLogBackup clBackup;
+    private final Map<String, Object> snapshotCFFilter = new HashMap<String, Object>();
+	private final Map<String, Object> snapshotKeyspaceFilter  = new HashMap<String, Object>();
     
 
     @Inject
@@ -63,6 +64,48 @@ public class SnapshotBackup extends AbstractBackup
     	super(config, backupFileSystemCtx, pathFactory);
         this.metaData = metaData;
         this.clBackup = clBackup;
+        init();
+    }
+    
+    private void init() {
+    	populateSnapshotFilters();
+    }
+    
+    private void populateSnapshotFilters() {
+    	String keyspaceFilters = this.config.getSnapshotKeyspaceFilters();
+    	if (keyspaceFilters == null || keyspaceFilters.isEmpty()) {
+    		
+    		logger.info("No keyspace filter set for snapshot.");
+    		
+    	} else {
+
+        	String[] keyspaces = keyspaceFilters.split(",");
+        	for (int i=0; i < keyspaces.length; i++ ) {
+        		logger.info("Adding snapshot keyspace filter: " + keyspaces[i]);
+        		this.snapshotKeyspaceFilter.put(keyspaces[i], null);
+        	}    		
+    		
+    	}
+    	
+    	String cfFilters = this.config.getSnapshotCFFilter();
+    	if (cfFilters == null || cfFilters.isEmpty()) {
+    		
+    		logger.info("No column family filter set for snapshot.");
+    		
+    	} else {
+
+        	String[] cf = cfFilters.split(",");
+        	for (int i=0; i < cf.length; i++) {
+        		if (isValidCFFilterFormat(cf[i])) {
+            		logger.info("Adding snapshot CF filter: " + cf[i]);
+            		this.snapshotCFFilter.put(cf[i], null);        			
+        		} else {
+        			throw new IllegalArgumentException("Column family filter format is not valid.  Format needs to be \"keyspace.columnfamily\".  Invalid input: " + cf[i]);
+        		}
+        	}    		
+    		
+    	}
+    	
     }
 
     
@@ -91,20 +134,36 @@ public class SnapshotBackup extends AbstractBackup
             {
                 if (keyspaceDir.isFile())
                 		continue;
+                
+                if ( isFiltered(DIRECTORYTYPE.KEYSPACE, keyspaceDir.getName())  ) { //keyspace filtered?
+                	logger.info(keyspaceDir.getName() + " is part of keyspace filter, will not be backed up.");
+                	continue;
+                }
+                
+                
                 logger.debug("Entering {} keyspace..", keyspaceDir.getName());
                 for (File columnFamilyDir : keyspaceDir.listFiles())
                 {
+                	if ( isFiltered(DIRECTORYTYPE.CF, keyspaceDir.getName(), columnFamilyDir.getName() )) { //CF filtered?
+                    	logger.info("keyspace: " + keyspaceDir.getName() 
+                    			+ ", CF: " + columnFamilyDir.getName() + " is part of CF filter list, will not be backed up.");
+                    	continue;
+                	}
+                		
                     logger.debug("Entering {} columnFamily..", columnFamilyDir.getName());
                     File snpDir = new File(columnFamilyDir, "snapshots");
-                    if (!isValidBackupDir(keyspaceDir, columnFamilyDir, snpDir))
-                        continue;
+                    if (!isValidBackupDir(keyspaceDir, columnFamilyDir, snpDir)) {
+                    	continue;
+                    }
+                        
                     File snapshotDir = getValidSnapshot(columnFamilyDir, snpDir, snapshotName);
                     // Add files to this dir
                     if (null != snapshotDir)
-                        bps.addAll(upload(snapshotDir, BackupFileType.SNAP));
+                    	bps.addAll(upload(snapshotDir, BackupFileType.SNAP));
                     else
-                        logger.warn("{} folder does not contain {} snapshots", snpDir, snapshotName);
+                    	logger.warn("{} folder does not contain {} snapshots", snpDir, snapshotName);
                 }
+                
             }
             // Upload meta file
             metaData.set(bps, snapshotName);
@@ -127,6 +186,33 @@ public class SnapshotBackup extends AbstractBackup
                 logger.error(e.getMessage(), e);
             }
         }
+    }
+    
+    /*
+     * @param keyspace or columnfamily directory type.
+     * @return true if directory should be filter from processing; otherwise, false.
+     */
+    private boolean isFiltered(DIRECTORYTYPE directoryType, String...args) {
+    	if (directoryType.equals(DIRECTORYTYPE.CF)) {
+    		String keyspaceName = args[0];
+    		String cfName = args[1];
+    		if (this.snapshotKeyspaceFilter.containsKey(keyspaceName)) { //account for keyspace which we want to filter
+    			return true;
+    		} else {
+    			StringBuffer strBuf = new StringBuffer();
+    			strBuf.append(keyspaceName);
+    			strBuf.append('.');
+    			strBuf.append(cfName);
+            	return this.snapshotCFFilter.containsKey(strBuf.toString());    			
+    		}
+        	
+    	} else if (directoryType.equals(DIRECTORYTYPE.KEYSPACE)) {
+    		return this.snapshotKeyspaceFilter.containsKey(args[0]);
+    		
+    	} else {
+    		throw new UnsupportedOperationException("Directory type not supported.  Invalid input: " + directoryType.name());
+    	}
+
     }
 
     private File getValidSnapshot(File columnFamilyDir, File snpDir, String snapshotName)

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -85,6 +85,13 @@ public class PriamConfiguration implements IConfiguration
     private static final String CONFIG_BACKUP_THREADS = PRIAM_PRE + ".backup.threads";
     private static final String CONFIG_RESTORE_PREFIX = PRIAM_PRE + ".restore.prefix";
     private static final String CONFIG_INCR_BK_ENABLE = PRIAM_PRE + ".backup.incremental.enable";
+    private static final String CONFIG_SNAPSHOT_KEYSPACE_FILTER = PRIAM_PRE + ".snapshot.keyspace.filter";
+    private static final String CONFIG_SNAPSHOT_CF_FILTER = PRIAM_PRE + ".snapshot.cf.filter";
+    private static final String CONFIG_INCREMENTAL_KEYSPACE_FILTER = PRIAM_PRE + ".incremental.keyspace.filter";
+    private static final String CONFIG_INCREMENTAL_CF_FILTER = PRIAM_PRE + ".incremental.cf.filter";
+    private static final String CONFIG_RESTORE_KEYSPACE_FILTER = PRIAM_PRE + ".restore.keyspace.filter";
+    private static final String CONFIG_RESTORE_CF_FILTER = PRIAM_PRE + ".restore.cf.filter";
+    
     private static final String CONFIG_CL_BK_ENABLE = PRIAM_PRE + ".backup.commitlog.enable";
     private static final String CONFIG_AUTO_RESTORE_SNAPSHOTNAME = PRIAM_PRE + ".restore.snapshot";
     private static final String CONFIG_BUCKET_NAME = PRIAM_PRE + ".s3.bucket";
@@ -534,6 +541,36 @@ public class PriamConfiguration implements IConfiguration
     public int getBackupHour()
     {
         return config.get(CONFIG_BACKUP_HOUR, DEFAULT_BACKUP_HOUR);
+    }
+    
+    @Override
+    public String getSnapshotKeyspaceFilters() {
+    	return config.get(CONFIG_SNAPSHOT_KEYSPACE_FILTER);
+    }
+    
+    @Override
+    public String getSnapshotCFFilter() throws IllegalArgumentException{
+    	return config.get(CONFIG_SNAPSHOT_CF_FILTER);
+    }
+    
+    @Override
+    public String getIncrementalKeyspaceFilters() {
+    	return config.get(CONFIG_INCREMENTAL_KEYSPACE_FILTER);
+    }
+    
+    @Override
+    public String getIncrementalCFFilter() {
+    	return config.get(CONFIG_INCREMENTAL_CF_FILTER);
+    }
+    
+    @Override
+    public String getRestoreKeyspaceFilter() {
+    	return config.get(CONFIG_RESTORE_KEYSPACE_FILTER);
+    }
+    
+    @Override
+    public String getRestoreCFFilter() {
+    	return config.get(CONFIG_RESTORE_CF_FILTER);
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/resources/RestoreServlet.java
+++ b/priam/src/main/java/com/netflix/priam/resources/RestoreServlet.java
@@ -1,0 +1,253 @@
+package com.netflix.priam.resources;
+
+import java.math.BigInteger;
+import java.util.Date;
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang.StringUtils;
+import org.codehaus.jettison.json.JSONObject;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.netflix.priam.ICassandraProcess;
+import com.netflix.priam.IConfiguration;
+import com.netflix.priam.PriamServer;
+import com.netflix.priam.backup.AbstractBackupPath;
+import com.netflix.priam.backup.Restore;
+import com.netflix.priam.identity.IPriamInstanceFactory;
+import com.netflix.priam.identity.PriamInstance;
+import com.netflix.priam.scheduler.Task;
+import com.netflix.priam.utils.CassandraTuner;
+import com.netflix.priam.utils.ITokenManager;
+
+@Path("/v1")
+@Produces(MediaType.APPLICATION_JSON)
+public class RestoreServlet {
+	
+	private static final Logger logger = LoggerFactory.getLogger(RestoreServlet.class);
+	private static final String REST_HEADER_RANGE = "daterange";
+	private static final String REST_HEADER_REGION = "region";
+	private static final String REST_HEADER_TOKEN = "token";
+	private static final String REST_KEYSPACES = "keyspaces";
+	private static final String REST_RESTORE_PREFIX = "restoreprefix";
+	private static final String REST_SUCCESS = "[\"ok\"]";
+	
+	private IConfiguration config;
+	private Restore restoreObj;
+	private Provider<AbstractBackupPath> pathProvider;
+	private PriamServer priamServer;
+	private IPriamInstanceFactory factory;
+	private CassandraTuner tuner;
+	private ICassandraProcess cassProcess;
+	private ITokenManager tokenManager;
+
+	@Inject
+	public RestoreServlet(IConfiguration config, Restore restoreObj, Provider<AbstractBackupPath> pathProvider, PriamServer priamServer
+			, IPriamInstanceFactory factory, CassandraTuner tuner, ICassandraProcess cassProcess, ITokenManager tokenManager) {
+		this.config = config;
+		this.restoreObj = restoreObj;
+		this.pathProvider = pathProvider;
+		this.priamServer = priamServer;
+		this.factory = factory;
+		this.tuner = tuner;
+		this.cassProcess = cassProcess;
+		this.tokenManager = tokenManager;
+	}
+
+    /*
+     * @return metadata of current restore.  If no restore in progress, returns the metadata of most recent restore attempt.
+     * status:[not_started|running|success|failure]
+     * daterange:[startdaterange,enddatarange]
+     * starttime:[yyyymmddhhmm]
+     * endtime:[yyyymmddmm]
+     */
+    @GET
+    @Path("/restore/status")
+    public Response	status() throws Exception {
+        JSONObject object = new JSONObject();
+        Task.STATE state = this.restoreObj.getRestoreState();
+        if (state.equals(Task.STATE.NOT_APPLICABLE)) {
+            object.put("status", this.restoreObj.getRestoreState());
+            object.put("daterange", "not_applicable");
+            object.put("starttime", "not_applicable");
+            object.put("endtime", "not_applicable");
+            object.put("token", "not_applicable");
+            
+            return Response.status(503).type(MediaType.APPLICATION_JSON)
+            	.entity(object.toString(2)).build();
+            
+        } else if (state.equals(Task.STATE.DONE)) {
+        	object.put("status", this.restoreObj.getRestoreState());
+            if (this.restoreObj.getStartDateRange() != null && this.restoreObj.getEndDateRange() != null) {
+                object.put("daterange", this.restoreObj.getStartDateRange() + "," + this.restoreObj.getEndDateRange());
+            }
+            if (this.restoreObj.getExecStartTime() != null ) {
+            	object.put("starttime", this.restoreObj.getExecStartTime());
+            }
+            if (this.restoreObj.getExecEndTime() != null ) {
+            	object.put("endtime", this.restoreObj.getExecEndTime());
+            }
+            
+            return Response.ok(object.toString(2), MediaType.APPLICATION_JSON).build();
+            
+        } else if (state.equals(Task.STATE.RUNNING)) {
+        	object.put("status", this.restoreObj.getRestoreState());
+            if (this.restoreObj.getStartDateRange() != null && this.restoreObj.getEndDateRange() != null) {
+                object.put("daterange", this.restoreObj.getStartDateRange() + "," + this.restoreObj.getEndDateRange());
+            }
+            if (this.restoreObj.getExecStartTime() != null ) {
+            	object.put("starttime", this.restoreObj.getExecStartTime());
+            }
+            if (this.restoreObj.getExecEndTime() != null ) {
+            	object.put("endtime", this.restoreObj.getExecEndTime());
+            }
+            
+            return Response.status(206).type(MediaType.APPLICATION_JSON)
+                	.entity(object.toString(2)).build();
+            
+        } else {
+        	object.put("status", this.restoreObj.getRestoreState());
+            if (this.restoreObj.getStartDateRange() != null && this.restoreObj.getEndDateRange() != null) {
+                object.put("daterange", this.restoreObj.getStartDateRange() + "," + this.restoreObj.getEndDateRange());
+            }
+            if (this.restoreObj.getExecStartTime() != null ) {
+            	object.put("starttime", this.restoreObj.getExecStartTime());
+            }
+            if (this.restoreObj.getExecEndTime() != null ) {
+            	object.put("endtime", this.restoreObj.getExecEndTime());
+            }
+            
+            return Response.status(500).type(MediaType.APPLICATION_JSON)
+                	.entity(object.toString(2)).build();
+        }
+        
+    }
+	
+    @GET
+    @Path("/restore")
+    public Response restore(@QueryParam(REST_HEADER_RANGE) String daterange, @QueryParam(REST_HEADER_REGION) String region, @QueryParam(REST_HEADER_TOKEN) String token,
+            @QueryParam(REST_KEYSPACES) String keyspaces, @QueryParam(REST_RESTORE_PREFIX) String restorePrefix) throws Exception
+    {
+        Date startTime;
+        Date endTime;
+
+        if (StringUtils.isBlank(daterange) || daterange.equalsIgnoreCase("default"))
+        {
+            startTime = new DateTime().minusDays(1).toDate();
+            endTime = new DateTime().toDate();
+        }
+        else
+        {
+            String[] restore = daterange.split(",");
+            AbstractBackupPath path = pathProvider.get();
+            startTime = path.parseDate(restore[0]);
+            endTime = path.parseDate(restore[1]);
+        }
+        
+        String origRestorePrefix = config.getRestorePrefix();
+        if (StringUtils.isNotBlank(restorePrefix))
+        {
+            config.setRestorePrefix(restorePrefix);
+        }
+        
+        logger.info("Parameters: { token: [" + token + "], region: [" +  region + "], startTime: [" + startTime + "], endTime: [" + endTime + 
+                    "], keyspaces: [" + keyspaces + "], restorePrefix: [" + restorePrefix + "]}");
+        
+        restore(token, region, startTime, endTime, keyspaces);
+        
+        //Since this call is probably never called in parallel, config is multi-thread safe to be edited
+        if (origRestorePrefix != null)
+                config.setRestorePrefix(origRestorePrefix);       
+        else    config.setRestorePrefix(""); 
+
+        return Response.ok(REST_SUCCESS, MediaType.APPLICATION_JSON).build();
+    }
+    
+    /**
+     * Restore with the specified start and end time.
+     * 
+     * @param token
+     *            Overrides the current token with this one, if specified
+     * @param region
+     *            Override the region for searching backup
+     * @param startTime
+     *            Start time
+     * @param endTime
+     *            End time upto which the restore should fetch data
+     * @param keyspaces
+     *            Comma seperated list of keyspaces to restore
+     * @throws Exception
+     */
+    private void restore(String token, String region, Date startTime, Date endTime, String keyspaces) throws Exception
+    {
+        String origRegion = config.getDC();
+        String origToken = priamServer.getId().getInstance().getToken();
+        if (StringUtils.isNotBlank(token))
+            priamServer.getId().getInstance().setToken(token);
+
+        if( config.isRestoreClosestToken())
+            priamServer.getId().getInstance().setToken(closestToken(priamServer.getId().getInstance().getToken(), config.getDC()));
+        
+        if (StringUtils.isNotBlank(region))
+        {
+            config.setDC(region);
+            logger.info("Restoring from region " + region);
+            priamServer.getId().getInstance().setToken(closestToken(priamServer.getId().getInstance().getToken(), region));
+            logger.info("Restore will use token " + priamServer.getId().getInstance().getToken());
+        }
+
+        setRestoreKeyspaces(keyspaces);
+
+        try
+        {
+            restoreObj.restore(startTime, endTime);
+        }
+        finally
+        {
+            config.setDC(origRegion);
+            priamServer.getId().getInstance().setToken(origToken);
+        }
+        tuner.updateAutoBootstrap(config.getYamlLocation(), false);
+        cassProcess.start(true);
+    }
+    
+    /**
+     * Find closest token in the specified region
+     */
+    private String closestToken(String token, String region)
+    {
+        List<PriamInstance> plist = factory.getAllIds(config.getAppName());
+        List<BigInteger> tokenList = Lists.newArrayList();
+        for (PriamInstance ins : plist)
+        {
+            if (ins.getDC().equalsIgnoreCase(region))
+                tokenList.add(new BigInteger(ins.getToken()));
+        }
+        return tokenManager.findClosestToken(new BigInteger(token), tokenList).toString();
+    }
+    
+    /*
+     * TODO: decouple the servlet, config, and restorer. this should not rely on a side
+     *       effect of a list mutation on the config object (treating it as global var).
+     */
+    private void setRestoreKeyspaces(String keyspaces)
+    {
+        if (StringUtils.isNotBlank(keyspaces))
+        {
+                 List<String> newKeyspaces = Lists.newArrayList(keyspaces.split(","));
+                 config.setRestoreKeySpaces(newKeyspaces);
+        }
+    }
+
+}

--- a/priam/src/main/java/com/netflix/priam/scheduler/Task.java
+++ b/priam/src/main/java/com/netflix/priam/scheduler/Task.java
@@ -40,7 +40,7 @@ public abstract class Task implements Job, TaskMBean
 
     public static enum STATE
     {
-        ERROR, RUNNING, DONE
+        ERROR, RUNNING, DONE, NOT_APPLICABLE
     }
     protected final IConfiguration config;
     

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -632,4 +632,35 @@ public class FakeConfiguration implements IConfiguration
         return null;
     }
 
+    @Override
+    public String getRestoreKeyspaceFilter()
+    {
+        return null;
+    }
+	
+    @Override
+    public String getRestoreCFFilter() {
+    	return null;
+    }
+    
+   @Override
+    public String getIncrementalKeyspaceFilters() {
+    	return null;
+    }
+   
+    @Override
+    public String getIncrementalCFFilter() {
+    	return null;
+    }
+    
+    @Override
+    public String getSnapshotKeyspaceFilters() {
+    	return null;
+    }
+    
+    @Override
+    public String getSnapshotCFFilter() {
+    	return null;
+    }
+
 }

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackup.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackup.java
@@ -5,12 +5,11 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 
 import junit.framework.Assert;
 import mockit.Mock;
-import mockit.Mockit;
+import mockit.MockUp;
 
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.commons.io.FileUtils;
@@ -43,9 +42,9 @@ public class TestBackup
     @BeforeClass
     public static void setup() throws InterruptedException, IOException
     {
+	new MockNodeProbe();
         injector = Guice.createInjector(new BRTestModule());
         filesystem = (FakeBackupFileSystem) injector.getInstance(Key.get(IBackupFileSystem.class,Names.named("backup")));
-        Mockit.setUpMock(NodeProbe.class, MockNodeProbe.class);
     }
     
     @AfterClass
@@ -85,7 +84,7 @@ public class TestBackup
         generateIncrementalFiles();
         IncrementalBackup backup = injector.getInstance(IncrementalBackup.class);
         backup.execute();
-        Assert.assertEquals(5, filesystem.uploadedFiles.size()); //uploaded files will now include the incremental audit log
+        Assert.assertEquals(5, filesystem.uploadedFiles.size());
         for (String filePath : expectedFiles)
             Assert.assertTrue(filesystem.uploadedFiles.contains(filePath));
     }
@@ -137,7 +136,7 @@ public class TestBackup
 
     // Mock Nodeprobe class
     @Ignore
-    public static class MockNodeProbe
+    public static class MockNodeProbe extends MockUp<NodeProbe>
     {
         @Mock
         public void $init(String host, int port) throws IOException, InterruptedException

--- a/priam/src/test/java/com/netflix/priam/backup/TestFileIterator.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestFileIterator.java
@@ -9,8 +9,7 @@ import java.util.List;
 import java.util.Set;
 
 import mockit.Mock;
-import mockit.Mocked;
-import mockit.Mockit;
+import mockit.MockUp;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -42,7 +41,6 @@ public class TestFileIterator
     private static Date startTime, endTime;
     private static Calendar cal;
 
-    @Mocked
     private static AmazonS3Client s3client;
     
     private static IConfiguration conf;
@@ -50,13 +48,12 @@ public class TestFileIterator
     @BeforeClass
     public static void setup() throws InterruptedException, IOException
     {
+	s3client = new MockAmazonS3Client().getMockInstance();
+	new MockObjectListing();
+
         injector = Guice.createInjector(new BRTestModule());
         conf = injector.getInstance(IConfiguration.class);
         factory = injector.getInstance(InstanceIdentity.class);
-
-        Mockit.setUpMock(AmazonS3Client.class, MockAmazonS3Client.class);
-        Mockit.setUpMock(ObjectListing.class, MockObjectListing.class);
-        s3client = new AmazonS3Client();
 
         cal = Calendar.getInstance();
         cal.set(2011, 7, 11, 0, 30, 0);
@@ -68,7 +65,7 @@ public class TestFileIterator
 
     // MockAmazonS3Client class
     @Ignore
-    public static class MockAmazonS3Client
+    public static class MockAmazonS3Client extends MockUp<AmazonS3Client>
     {
         public static String bucketName = "";
         public static String prefix = "";
@@ -82,6 +79,7 @@ public class TestFileIterator
             return listing;
         }
 
+	@Mock
         public ObjectListing listNextBatchOfObjects(ObjectListing previousObjectListing) throws AmazonClientException, AmazonServiceException
         {
             ObjectListing listing = new ObjectListing();
@@ -93,7 +91,7 @@ public class TestFileIterator
 
     // MockObjectListing class
     @Ignore
-    public static class MockObjectListing
+    public static class MockObjectListing extends MockUp<ObjectListing>
     {
         public static boolean truncated = true;
         public static boolean firstcall = true;

--- a/priam/src/test/java/com/netflix/priam/resources/CassandraConfigTest.java
+++ b/priam/src/test/java/com/netflix/priam/resources/CassandraConfigTest.java
@@ -15,13 +15,16 @@ import com.netflix.priam.identity.PriamInstance;
 import mockit.Expectations;
 import mockit.Mocked;
 import mockit.NonStrictExpectations;
+import mockit.integration.junit4.JMockit;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+@RunWith(JMockit.class)
 public class CassandraConfigTest
 {
     private @Mocked PriamServer priamServer;
@@ -35,12 +38,10 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void getSeeds() throws Exception
+    public void getSeeds(@Mocked final InstanceIdentity identity) throws Exception
     {
         final List<String> seeds = ImmutableList.of("seed1", "seed2", "seed3");
         new NonStrictExpectations() {
-            InstanceIdentity identity;
-
             {
                 priamServer.getId(); result = identity; times = 1;
                 identity.getSeeds(); result = seeds; times = 1;
@@ -53,12 +54,10 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void getSeeds_notFound() throws Exception
+    public void getSeeds_notFound(@Mocked final InstanceIdentity identity) throws Exception
     {
         final List<String> seeds = ImmutableList.of();
         new NonStrictExpectations() {
-            InstanceIdentity identity;
-
             {
                 priamServer.getId(); result = identity; times = 1;
                 identity.getSeeds(); result = seeds; times = 1;
@@ -70,11 +69,9 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void getSeeds_handlesUnknownHostException() throws Exception
+    public void getSeeds_handlesUnknownHostException(@Mocked final InstanceIdentity identity) throws Exception
     {
         new Expectations() {
-            InstanceIdentity identity;
-
             {
                 priamServer.getId(); result = identity;
                 identity.getSeeds(); result = new UnknownHostException();
@@ -86,13 +83,10 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void getToken()
+    public void getToken(@Mocked final InstanceIdentity identity, @Mocked final PriamInstance instance)
     {
         final String token = "myToken";
         new NonStrictExpectations() {
-            InstanceIdentity identity;
-            PriamInstance instance;
-
             {
                 priamServer.getId(); result = identity; times = 2;
                 identity.getInstance(); result = instance; times = 2;
@@ -106,13 +100,10 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void getToken_notFound()
+    public void getToken_notFound(@Mocked final InstanceIdentity identity, @Mocked final PriamInstance instance)
     {
         final String token = "";
         new NonStrictExpectations() {
-            InstanceIdentity identity;
-            PriamInstance instance;
-
             {
                 priamServer.getId(); result = identity;
                 identity.getInstance(); result = instance;
@@ -125,12 +116,9 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void getToken_handlesException()
+    public void getToken_handlesException(@Mocked final InstanceIdentity identity, @Mocked final PriamInstance instance)
     {
         new NonStrictExpectations() {
-            InstanceIdentity identity;
-            PriamInstance instance;
-
             {
                 priamServer.getId(); result = identity;
                 identity.getInstance(); result = instance;
@@ -143,11 +131,9 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void isReplaceToken()
+    public void isReplaceToken(@Mocked final InstanceIdentity identity)
     {
         new NonStrictExpectations() {
-            InstanceIdentity identity;
-
             {
                 priamServer.getId(); result = identity;
                 identity.isReplace(); result = true;
@@ -160,11 +146,9 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void isReplaceToken_handlesException()
+    public void isReplaceToken_handlesException(@Mocked final InstanceIdentity identity)
     {
         new Expectations() {
-            InstanceIdentity identity;
-
             {
                 priamServer.getId(); result = identity;
                 identity.isReplace(); result = new RuntimeException();
@@ -176,12 +160,10 @@ public class CassandraConfigTest
     }
 
     @Test
-    public void getReplacedAddress()
+    public void getReplacedAddress(@Mocked final InstanceIdentity identity)
     {
     	final String replacedIp = "127.0.0.1";
         new Expectations() {
-            InstanceIdentity identity;
-
             {
                 priamServer.getId(); result = identity;
                 identity.getReplacedIp(); result = replacedIp;

--- a/priam/src/test/java/com/netflix/priam/resources/PriamInstanceResourceTest.java
+++ b/priam/src/test/java/com/netflix/priam/resources/PriamInstanceResourceTest.java
@@ -12,13 +12,16 @@ import com.netflix.priam.identity.PriamInstance;
 
 import mockit.Expectations;
 import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+@RunWith(JMockit.class)
 public class PriamInstanceResourceTest
 {
     private static final String APP_NAME = "myApp";
@@ -35,10 +38,9 @@ public class PriamInstanceResourceTest
     }
 
     @Test
-    public void getInstances()
+    public void getInstances(@Mocked final PriamInstance instance1, @Mocked final PriamInstance instance2, @Mocked final PriamInstance instance3)
     {
         new Expectations() {
-            PriamInstance instance1, instance2, instance3;
             List<PriamInstance> instances = ImmutableList.of(instance1, instance2, instance3);
 
             {
@@ -54,12 +56,10 @@ public class PriamInstanceResourceTest
     }
 
     @Test
-    public void getInstance()
+    public void getInstance(@Mocked final PriamInstance instance)
     {
         final String expected = "plain text describing the instance";
         new Expectations() {
-            PriamInstance instance;
-
             {
                 config.getAppName(); result = APP_NAME;
                 factory.getInstance(APP_NAME, config.getDC(), NODE_ID); result = instance;
@@ -90,7 +90,7 @@ public class PriamInstanceResourceTest
     }
 
     @Test
-    public void createInstance()
+    public void createInstance(@Mocked final PriamInstance instance)
     {
         final String instanceID = "i-abc123";
         final String hostname = "dom.com";
@@ -99,8 +99,6 @@ public class PriamInstanceResourceTest
         final String token = "1234567890";
 
         new Expectations() {
-          PriamInstance instance;
-
           {
               config.getAppName(); result = APP_NAME;
               factory.create(APP_NAME, NODE_ID, instanceID, hostname, ip, rack, null, token); result = instance;
@@ -114,11 +112,9 @@ public class PriamInstanceResourceTest
     }
 
     @Test
-    public void deleteInstance()
+    public void deleteInstance(@Mocked final PriamInstance instance)
     {
         new Expectations() {
-          PriamInstance instance;
-
           {
               config.getAppName(); result = APP_NAME;
               factory.getInstance(APP_NAME, config.getDC(), NODE_ID); result = instance;


### PR DESCRIPTION
- Exclusion of keyspace(s) and/or CFs from snapshot. Exclusion of keyspace(s) and/or CFs from incremental. Exclusion keyspace(s) and/or CFs from restore.
- Decouple backup and restore from the backup servlet. 2. Allow visibility on the state of a current restore.
- In situations where moving the *.json file from src to dest fails, the src file is left. This commit cleans up src file properly
- Upgrade tests to use JMockit 1.19, which is compatible with newer version of jdk.  Also, refactor tests to account for new restore"
[2.x 0e2db68] Upgrade tests to use JMockit 1.19, which is compatible with newer version of jdk.  Also, refactor tests to account for new restore