### PR TITLE
Support for ACL's in Non-Default VPC

### DIFF
--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -276,6 +276,11 @@ public interface IConfiguration
     public String getACLGroupName();
 
     /**
+     * Get the VPC ID of the current instance.
+     */
+    public String getVpcId();
+
+    /**
      * @return true if incremental backups are enabled
      */
     boolean isIncrBackup();

--- a/priam/src/main/java/com/netflix/priam/aws/AWSMembership.java
+++ b/priam/src/main/java/com/netflix/priam/aws/AWSMembership.java
@@ -36,6 +36,7 @@ import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.AuthorizeSecurityGroupIngressRequest;
 import com.amazonaws.services.ec2.model.DescribeSecurityGroupsRequest;
 import com.amazonaws.services.ec2.model.DescribeSecurityGroupsResult;
+import com.amazonaws.services.ec2.model.Filter;
 import com.amazonaws.services.ec2.model.IpPermission;
 import com.amazonaws.services.ec2.model.RevokeSecurityGroupIngressRequest;
 import com.amazonaws.services.ec2.model.SecurityGroup;
@@ -134,7 +135,7 @@ public class AWSMembership implements IMembership
             client = getEc2Client();
             List<IpPermission> ipPermissions = new ArrayList<IpPermission>();
             ipPermissions.add(new IpPermission().withFromPort(from).withIpProtocol("tcp").withIpRanges(listIPs).withToPort(to));
-            client.authorizeSecurityGroupIngress(new AuthorizeSecurityGroupIngressRequest(config.getACLGroupName(), ipPermissions));
+            client.authorizeSecurityGroupIngress(new AuthorizeSecurityGroupIngressRequest().withGroupId(getACLGroupId()).withIpPermissions(ipPermissions));
             logger.info("Done adding ACL to: " + StringUtils.join(listIPs, ","));
         }
         finally
@@ -155,7 +156,7 @@ public class AWSMembership implements IMembership
             client = getEc2Client();
             List<IpPermission> ipPermissions = new ArrayList<IpPermission>();
             ipPermissions.add(new IpPermission().withFromPort(from).withIpProtocol("tcp").withIpRanges(listIPs).withToPort(to));
-            client.revokeSecurityGroupIngress(new RevokeSecurityGroupIngressRequest(config.getACLGroupName(), ipPermissions));
+            client.revokeSecurityGroupIngress(new RevokeSecurityGroupIngressRequest().withGroupId(getACLGroupId()).withIpPermissions(ipPermissions));
             logger.info("Done removing from ACL: " + StringUtils.join(listIPs, ","));
         }
         finally
@@ -175,7 +176,9 @@ public class AWSMembership implements IMembership
         {
             client = getEc2Client();
             List<String> ipPermissions = new ArrayList<String>();
-            DescribeSecurityGroupsRequest req = new DescribeSecurityGroupsRequest().withGroupNames(Arrays.asList(config.getACLGroupName()));
+            Filter nameFilter = new Filter().withName("group-name").withValues(config.getACLGroupName());
+            Filter vpcFilter = new Filter().withName("vpc-id").withValues(config.getVpcId());
+            DescribeSecurityGroupsRequest req = new DescribeSecurityGroupsRequest().withFilters(nameFilter, vpcFilter);
             DescribeSecurityGroupsResult result = client.describeSecurityGroups(req);
             for (SecurityGroup group : result.getSecurityGroups())
                 for (IpPermission perm : group.getIpPermissions())
@@ -206,6 +209,27 @@ public class AWSMembership implements IMembership
             ureq.setMaxSize(asg.getMinSize() + 1);
             ureq.setDesiredCapacity(asg.getMinSize() + 1);
             client.updateAutoScalingGroup(ureq);
+        }
+        finally
+        {
+            if (client != null)
+                client.shutdown();
+        }
+    }
+
+    protected String getACLGroupId()
+    {
+        AmazonEC2 client = null;
+        try
+        {
+            client = getEc2Client();
+            Filter nameFilter = new Filter().withName("group-name").withValues(config.getACLGroupName());
+            Filter vpcFilter = new Filter().withName("vpc-id").withValues(config.getVpcId());
+            DescribeSecurityGroupsRequest req = new DescribeSecurityGroupsRequest().withFilters(nameFilter, vpcFilter);
+            DescribeSecurityGroupsResult result = client.describeSecurityGroups(req);
+            for (SecurityGroup group : result.getSecurityGroups())
+                return group.getGroupId();
+            return "";
         }
         finally
         {

--- a/priam/src/main/java/com/netflix/priam/aws/AWSMembership.java
+++ b/priam/src/main/java/com/netflix/priam/aws/AWSMembership.java
@@ -228,7 +228,11 @@ public class AWSMembership implements IMembership
             DescribeSecurityGroupsRequest req = new DescribeSecurityGroupsRequest().withFilters(nameFilter, vpcFilter);
             DescribeSecurityGroupsResult result = client.describeSecurityGroups(req);
             for (SecurityGroup group : result.getSecurityGroups())
+            {
+                logger.debug(String.format("got group-id:%s for group-name:%s,vpc-id:%s", group.getGroupId(), config.getACLGroupName(), config.getVpcId()));
                 return group.getGroupId();
+            }
+            logger.error(String.format("unable to get group-id for group-name=%s vpc-id=%s", config.getACLGroupName(), config.getVpcId()));
             return "";
         }
         finally

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -172,6 +172,8 @@ public class PriamConfiguration implements IConfiguration
     private final String LOCAL_IP = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/local-ipv4").trim();
     private final String INSTANCE_ID = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/instance-id").trim();
     private final String INSTANCE_TYPE = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/instance-type").trim();
+    private final String NETWORK_MAC = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/network/interfaces/macs/").trim();
+    private final String NETWORK_VPC = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/network/interfaces/macs/" + NETWORK_MAC + "/vpc-id").trim();
     private static String ASG_NAME = System.getenv("ASG_NAME");
     private static String REGION = System.getenv("EC2_REGION");
     private static final String CONFIG_VPC_RING = PRIAM_PRE + ".vpc";
@@ -626,6 +628,12 @@ public class PriamConfiguration implements IConfiguration
     public String getACLGroupName()
     {
     	return config.get(CONFIG_ACL_GROUP_NAME, this.getAppName());
+    }
+
+    @Override
+    public String getVpcId()
+    {
+        return NETWORK_VPC;
     }
 
     @Override

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -174,6 +174,12 @@ public class FakeConfiguration implements IConfiguration
     }
 
     @Override
+    public String getVpcId()
+    {
+        return "";
+    }
+
+    @Override
     public int getMaxBackupUploadThreads()
     {
         // TODO Auto-generated method stub


### PR DESCRIPTION
This adds support to Priam for updating ACL's (security groups) in non-default VPC's.

Before this patch Priam would call DescribeSecurityGroups using the groupName. This call only searches EC2 Classic or the default VPC.

This change looks up the VPC ID of the running instance on start. The AWSMembership class has been updated to call DescribeSecurityGroups the VPC ID in conjunction with the group name. Where applicable this method is used to determine the group ID.

This has been tested against a new multi-region cluster in our in-house testing environment.