### PR TITLE
Added rpc_min_threads and rpc_max_threads config options

### DIFF
--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -453,6 +453,8 @@ public interface IConfiguration
     public int getConcurrentCompactorsCnt();
     
     public String getRpcServerType();
+    public int getRpcMinThreads();
+    public int getRpcMaxThreads();
     public int getIndexInterval();
     
     public String getExtraConfigParams();

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -130,8 +130,8 @@ public class PriamConfiguration implements IConfiguration
     private static final String CONFIG_CONCURRENT_COMPACTORS = PRIAM_PRE + ".concurrentCompactors";
     
     private static final String CONFIG_RPC_SERVER_TYPE = PRIAM_PRE + ".rpc.server.type";
-    private static final int CONFIG_RPC_MIN_THREADS = PRIAM_PRE + ".rpc.min.threads";
-    private static final int CONFIG_RPC_MAX_THREADS = PRIAM_PRE + ".rpc.max.threads";
+    private static final String CONFIG_RPC_MIN_THREADS = PRIAM_PRE + ".rpc.min.threads";
+    private static final String CONFIG_RPC_MAX_THREADS = PRIAM_PRE + ".rpc.max.threads";
     private static final String CONFIG_INDEX_INTERVAL = PRIAM_PRE + ".index.interval";
     private static final String CONFIG_EXTRA_PARAMS = PRIAM_PRE + ".extra.params";
     private static final String CONFIG_AUTO_BOOTSTRAP = PRIAM_PRE + ".auto.bootstrap";

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -130,6 +130,8 @@ public class PriamConfiguration implements IConfiguration
     private static final String CONFIG_CONCURRENT_COMPACTORS = PRIAM_PRE + ".concurrentCompactors";
     
     private static final String CONFIG_RPC_SERVER_TYPE = PRIAM_PRE + ".rpc.server.type";
+    private static final int CONFIG_RPC_MIN_THREADS = PRIAM_PRE + ".rpc.min.threads";
+    private static final int CONFIG_RPC_MAX_THREADS = PRIAM_PRE + ".rpc.max.threads";
     private static final String CONFIG_INDEX_INTERVAL = PRIAM_PRE + ".index.interval";
     private static final String CONFIG_EXTRA_PARAMS = PRIAM_PRE + ".extra.params";
     private static final String CONFIG_AUTO_BOOTSTRAP = PRIAM_PRE + ".auto.bootstrap";
@@ -218,6 +220,8 @@ public class PriamConfiguration implements IConfiguration
     private final String DEFAULT_INTERNODE_COMPRESSION = "all";  //default value from 1.2 yaml
     
     private static final String DEFAULT_RPC_SERVER_TYPE = "hsha";
+    private static final int DEFAULT_RPC_MIN_THREADS = 16;
+    private static final int DEFAULT_RPC_MAX_THREADS = 2048;
     private static final int DEFAULT_INDEX_INTERVAL = 256;
     
     
@@ -931,7 +935,15 @@ public class PriamConfiguration implements IConfiguration
     public String getRpcServerType() {
     	return config.get(CONFIG_RPC_SERVER_TYPE, DEFAULT_RPC_SERVER_TYPE);
     }
+
+    public int getRpcMinThreads() {
+        return config.get(CONFIG_RPC_MIN_THREADS, DEFAULT_RPC_MIN_THREADS);
+    }
     
+    public int getRpcMaxThreads() {
+        return config.get(CONFIG_RPC_MAX_THREADS, DEFAULT_RPC_MAX_THREADS);
+    }
+
     public int getIndexInterval() {
     	return config.get(CONFIG_INDEX_INTERVAL, DEFAULT_INDEX_INTERVAL);
     }

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/StandardTuner.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/StandardTuner.java
@@ -82,6 +82,8 @@ public class StandardTuner implements CassandraTuner
         map.put("concurrent_compactors", config.getConcurrentCompactorsCnt());
         
         map.put("rpc_server_type", config.getRpcServerType());
+        map.put("rpc_min_threads", config.getRpcMinThreads());
+        map.put("rpc_max_threads", config.getRpcMaxThreads());
         //map.put("index_interval", config.getIndexInterval());
         
         List<?> seedp = (List) map.get("seed_provider");

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -552,6 +552,16 @@ public class FakeConfiguration implements IConfiguration
 		return "hsha";
 	}
 
+    @Override
+    public int getRpcMinThreads() {
+        return 16;
+    }
+
+    @Override
+    public int getRpcMaxThreads() {
+        return 2048;
+    }
+
 	@Override
 	public int getIndexInterval() {
 		return 0;


### PR DESCRIPTION
Added rpc_min_threads and rpc_max_threads config options with default values, because Cassandra doesn't support rpc_server_type=hsha setting with rpc_max_threads=unlimited (default) from 2.0.12.
With this patch Priam will support latest Cassandra version on 2.0 branch = 2.0.17
