### PR TITLE
cross-account support for AWS compute

### DIFF
--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -525,6 +525,21 @@ public interface IConfiguration
      * @return the vpc id of the running instance.
      */
     public String getVpcId();
+    
+    /*
+     * @return the Amazon Resource Name (ARN) for EC2 classic. 
+     */
+	public String getClassicEC2RoleAssumptionArn();
+		
+    /*
+     * @return the Amazon Resource Name (ARN) for VPC. 
+     */
+	public String getVpcEC2RoleAssumptionArn();
+	
+	/*
+	 * @return if the dual account support
+	 */
+	public boolean isDualAccount();
 
     public Boolean isIncrBackupParallelEnabled();
     /*

--- a/priam/src/main/java/com/netflix/priam/aws/S3CrossAccountFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3CrossAccountFileSystem.java
@@ -30,7 +30,7 @@ public class S3CrossAccountFileSystem  {
 	private IS3Credential s3Credential;
 	
 	@Inject
-	public S3CrossAccountFileSystem(@Named("backup") IBackupFileSystem fs, @Named("awsroleassumption") IS3Credential s3Credential, IConfiguration config) {
+	public S3CrossAccountFileSystem(@Named("backup") IBackupFileSystem fs, @Named("awss3roleassumption") IS3Credential s3Credential, IConfiguration config) {
 	
 		
 		this.s3fs = (S3FileSystem) fs;

--- a/priam/src/main/java/com/netflix/priam/aws/auth/EC2RoleAssumptionCredential.java
+++ b/priam/src/main/java/com/netflix/priam/aws/auth/EC2RoleAssumptionCredential.java
@@ -1,0 +1,73 @@
+package com.netflix.priam.aws.auth;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.google.inject.Inject;
+
+import com.netflix.priam.IConfiguration;
+import com.netflix.priam.ICredential;
+import com.netflix.priam.identity.InstanceEnvIdentity;
+
+public class EC2RoleAssumptionCredential implements ICredential {
+	private static final String AWS_ROLE_ASSUMPTION_SESSION_NAME = "AwsRoleAssumptionSession";
+	private ICredential cred;
+	private IConfiguration config;
+	private InstanceEnvIdentity insEnvIdentity;    
+	private AWSCredentialsProvider stsSessionCredentialsProvider;
+
+	@Inject
+	public EC2RoleAssumptionCredential(ICredential cred, IConfiguration config, InstanceEnvIdentity insEnvIdentity) {
+		this.cred = cred;
+		this.config = config;
+        this.insEnvIdentity = insEnvIdentity;
+	}
+	
+	@Override
+	public AWSCredentialsProvider getAwsCredentialProvider() {
+		if (this.config.isDualAccount() || this.stsSessionCredentialsProvider == null) {
+			synchronized(this) {
+				if (this.stsSessionCredentialsProvider == null) {
+					
+					String roleArn = null;
+					/**
+					 *  Create the assumed IAM role based on the environment.
+					 *  For example, if the current environment is VPC, 
+					 *  then the assumed role is for EC2 classic, and vice versa.
+					 */
+					if (this.insEnvIdentity.isClassic()) {
+						roleArn = this.config.getClassicEC2RoleAssumptionArn();      // Env is EC2 classic --> IAM assumed role for VPC created 
+				    }
+					else {
+						roleArn = this.config.getVpcEC2RoleAssumptionArn();  // Env is VPC --> IAM assumed role for EC2 classic created 
+					}
+				
+					//
+					if (roleArn == null || roleArn.isEmpty()) 
+						throw new NullPointerException("Role ARN is null or empty probably due to missing config entry");
+					
+					
+					/**
+					 *  Get handle to an implementation that uses AWS Security Token Service (STS) to create temporary, 
+					 *  short-lived session with explicit refresh for session/token expiration.
+					 */
+					try {						
+						this.stsSessionCredentialsProvider = new STSAssumeRoleSessionCredentialsProvider(this.cred.getAwsCredentialProvider(), roleArn, AWS_ROLE_ASSUMPTION_SESSION_NAME);
+						
+					} catch (Exception ex) {
+						throw new IllegalStateException("Exception in getting handle to AWS Security Token Service (STS).  Msg: " + ex.getLocalizedMessage(), ex);
+					}							
+
+				}
+
+		   }
+	   }
+	   
+	   return this.stsSessionCredentialsProvider;
+
+	}
+}

--- a/priam/src/main/java/com/netflix/priam/aws/auth/S3RoleAssumptionCredential.java
+++ b/priam/src/main/java/com/netflix/priam/aws/auth/S3RoleAssumptionCredential.java
@@ -27,8 +27,7 @@ public class S3RoleAssumptionCredential implements IS3Credential {
 	@Inject
 	public S3RoleAssumptionCredential(ICredential cred, IConfiguration config) {
 		this.cred = cred;
-		this.config = config;
-		
+		this.config = config;		
 	}
 	
 	@Override

--- a/priam/src/main/java/com/netflix/priam/cli/StaticMembership.java
+++ b/priam/src/main/java/com/netflix/priam/cli/StaticMembership.java
@@ -80,6 +80,12 @@ public class StaticMembership implements IMembership
     {
         return racMembership;
     }
+    
+    @Override
+    public List<String> getCrossAccountRacMembership()
+    {
+    	return null;
+    }
 
     @Override
     public int getRacMembershipSize()

--- a/priam/src/main/java/com/netflix/priam/cryptography/pgp/PgpCredential.java
+++ b/priam/src/main/java/com/netflix/priam/cryptography/pgp/PgpCredential.java
@@ -8,7 +8,7 @@ import com.netflix.priam.IConfiguration;
 import com.netflix.priam.ICredentialGeneric;
 
 /*
- * A generic implemention of fetch keys as plaintext.  The key values are used within PGP crypotography algorithm.  Users may
+ * A generic implementation of fetch keys as plaintext.  The key values are used within PGP cryptography algorithm.  Users may
  * want to provide an implementation where your key(s)' value is decrypted using AES encryption algorithm.  
  */
 public class PgpCredential  implements ICredentialGeneric {

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -172,8 +172,12 @@ public class PriamConfiguration implements IConfiguration
     private static String ASG_NAME = System.getenv("ASG_NAME");
     private static String REGION = System.getenv("EC2_REGION");
     private static final String CONFIG_VPC_RING = PRIAM_PRE + ".vpc";
-    private static final String CONFIG_ROLE_ASSUMPTION_ARN = PRIAM_PRE + ".roleassumption.arn"; //Restore from AWS.  This is applicable when restoring from an AWS account which requires cross account assumption. 
+    private static final String CONFIG_S3_ROLE_ASSUMPTION_ARN = PRIAM_PRE + ".roleassumption.arn"; //Restore from AWS.  This is applicable when restoring from an AWS account which requires cross account assumption. 
+    private static final String CONFIG_EC2_ROLE_ASSUMPTION_ARN = PRIAM_PRE + ".ec2.roleassumption.arn"; 
+    private static final String CONFIG_VPC_ROLE_ASSUMPTION_ARN = PRIAM_PRE + ".vpc.roleassumption.arn";
+    private static final String CONFIG_DUAL_ACCOUNT = PRIAM_PRE + ".roleassumption.dualaccount";
 
+    
     //Running instance meta data
     private String RAC;
     private String PUBLIC_HOSTNAME;
@@ -235,6 +239,8 @@ public class PriamConfiguration implements IConfiguration
     private static final String DEFAULT_EU_WEST_1_S3_ENDPOINT = "s3-eu-west-1.amazonaws.com";
     private static final String DEFAULT_SA_EAST_1_S3_ENDPOINT = "s3-sa-east-1.amazonaws.com";
     
+    // AWS EC2 Dual Account
+    private static final boolean DEFAULT_DUAL_ACCOUNT = false;
    
     private final IConfigSource config; 
     private final String BLANK = "";
@@ -1042,8 +1048,23 @@ public class PriamConfiguration implements IConfiguration
 
 	@Override
 	public String getAWSRoleAssumptionArn() {
-		return config.get(CONFIG_ROLE_ASSUMPTION_ARN);
+		return config.get(CONFIG_S3_ROLE_ASSUMPTION_ARN);
 	}
+	
+	@Override
+	public String getClassicEC2RoleAssumptionArn() {
+	   return config.get(CONFIG_EC2_ROLE_ASSUMPTION_ARN);
+	}
+	 	
+	@Override
+	public String getVpcEC2RoleAssumptionArn() {
+	 	return config.get(CONFIG_VPC_ROLE_ASSUMPTION_ARN);
+	}
+		
+	@Override
+	public boolean isDualAccount() {
+	   return config.get(CONFIG_DUAL_ACCOUNT, DEFAULT_DUAL_ACCOUNT);
+	 }
 
 	@Override
 	public String getGcsServiceAccountId() {

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamGuiceModule.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamGuiceModule.java
@@ -23,6 +23,7 @@ import com.google.inject.name.Names;
 import com.netflix.priam.aws.S3CrossAccountFileSystem;
 import com.netflix.priam.aws.S3EncryptedFileSystem;
 import com.netflix.priam.aws.S3FileSystem;
+import com.netflix.priam.aws.auth.EC2RoleAssumptionCredential;
 import com.netflix.priam.aws.auth.IS3Credential;
 import com.netflix.priam.aws.auth.S3RoleAssumptionCredential;
 import com.netflix.priam.backup.BackupFileSystemContext;
@@ -66,7 +67,8 @@ public class PriamGuiceModule extends AbstractModule
         bind(IFileSystemContext.class).annotatedWith(Names.named("backup")).to(BackupFileSystemContext.class);
         
         bind(IBackupFileSystem.class).annotatedWith(Names.named("gcsencryptedbackup")).to(GoogleEncryptedFileSystem.class);
-        bind(IS3Credential.class).annotatedWith(Names.named("awsroleassumption")).to(S3RoleAssumptionCredential.class);
+        bind(IS3Credential.class).annotatedWith(Names.named("awss3roleassumption")).to(S3RoleAssumptionCredential.class);
+        bind(ICredential.class).annotatedWith(Names.named("awsec2roleassumption")).to(EC2RoleAssumptionCredential.class);
         bind(IFileCryptography.class).annotatedWith(Names.named("filecryptoalgorithm")).to(PgpCryptography.class);
         bind(ICredentialGeneric.class).annotatedWith(Names.named("gcscredential")).to(GcsCredential.class);
         bind(ICredentialGeneric.class).annotatedWith(Names.named("pgpcredential")).to(PgpCredential.class);

--- a/priam/src/main/java/com/netflix/priam/identity/IMembership.java
+++ b/priam/src/main/java/com/netflix/priam/identity/IMembership.java
@@ -39,6 +39,13 @@ public interface IMembership
      * @return Size of current RAC
      */
     public int getRacMembershipSize();
+    
+    /**
+     * Get a list of Instances in the cross-account but current RAC
+     * 
+     * @return
+     */
+	public List<String> getCrossAccountRacMembership();
 
     /**
      * Number of RACs

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -601,6 +601,21 @@ public class FakeConfiguration implements IConfiguration
 	public String getAWSRoleAssumptionArn() {
 		return null;
 	}
+	
+    @Override
+	public String getClassicEC2RoleAssumptionArn() {
+		return null;
+	}
+
+    @Override
+	public String getVpcEC2RoleAssumptionArn() {
+		return null;
+	}
+
+    @Override
+	public boolean isDualAccount(){
+    	return false;
+    }
 
 	@Override
 	public String getGcsServiceAccountId() {

--- a/priam/src/test/java/com/netflix/priam/FakeConfigurationMurmur3.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfigurationMurmur3.java
@@ -601,6 +601,21 @@ public class FakeConfigurationMurmur3 implements IConfiguration
 	public String getAWSRoleAssumptionArn() {
 		return null;
 	}
+	
+    @Override
+	public String getClassicEC2RoleAssumptionArn() {
+		return null;
+	}
+
+    @Override
+	public String getVpcEC2RoleAssumptionArn() {
+		return null;
+	}
+
+    @Override
+	public boolean isDualAccount(){
+    	return false;
+    }
 
 	@Override
 	public String getGcsServiceAccountId() {

--- a/priam/src/test/java/com/netflix/priam/FakeMembership.java
+++ b/priam/src/test/java/com/netflix/priam/FakeMembership.java
@@ -25,6 +25,13 @@ public class FakeMembership implements IMembership
     {
         return instances;
     }
+    
+    @Override
+    public List<String> getCrossAccountRacMembership()
+    {
+       return null;	
+    }
+
 
     @Override
     public int getRacMembershipSize()

--- a/priam/src/test/java/com/netflix/priam/TestModule.java
+++ b/priam/src/test/java/com/netflix/priam/TestModule.java
@@ -11,8 +11,10 @@ import com.netflix.priam.aws.S3BackupPath;
 import com.netflix.priam.backup.AbstractBackupPath;
 import com.netflix.priam.backup.FakeCredentials;
 import com.netflix.priam.backup.IBackupFileSystem;
+import com.netflix.priam.identity.AwsInstanceEnvIdentity;
 import com.netflix.priam.identity.IMembership;
 import com.netflix.priam.identity.IPriamInstanceFactory;
+import com.netflix.priam.identity.InstanceEnvIdentity;
 import com.netflix.priam.identity.token.DeadTokenRetriever;
 import com.netflix.priam.identity.token.IDeadTokenRetriever;
 import com.netflix.priam.identity.token.INewTokenRetriever;
@@ -42,7 +44,7 @@ public class TestModule extends AbstractModule
         bind(AbstractBackupPath.class).to(S3BackupPath.class);
         bind(Sleeper.class).to(FakeSleeper.class);
         bind(ITokenManager.class).to(TokenManager.class);
-        
+        bind(InstanceEnvIdentity.class).to(AwsInstanceEnvIdentity.class);
         bind(IDeadTokenRetriever.class).to(DeadTokenRetriever.class);
         bind(IPreGeneratedTokenRetriever.class).to(PreGeneratedTokenRetriever.class);
         bind(INewTokenRetriever.class).to(NewTokenRetriever.class); //for backward compatibility, unit test always create new tokens        

--- a/priam/src/test/java/com/netflix/priam/backup/BRTestModule.java
+++ b/priam/src/test/java/com/netflix/priam/backup/BRTestModule.java
@@ -28,6 +28,7 @@ import com.netflix.priam.aws.S3EncryptedFileSystem;
 import com.netflix.priam.aws.S3FileSystem;
 import com.netflix.priam.aws.auth.IS3Credential;
 import com.netflix.priam.aws.auth.S3RoleAssumptionCredential;
+import com.netflix.priam.backup.identity.FakeInstanceEnvIdentity;
 import com.netflix.priam.compress.ICompression;
 import com.netflix.priam.compress.SnappyCompression;
 import com.netflix.priam.cryptography.IFileCryptography;
@@ -37,6 +38,7 @@ import com.netflix.priam.google.GcsCredential;
 import com.netflix.priam.google.GoogleEncryptedFileSystem;
 import com.netflix.priam.identity.IMembership;
 import com.netflix.priam.identity.IPriamInstanceFactory;
+import com.netflix.priam.identity.InstanceEnvIdentity;
 import com.netflix.priam.identity.token.DeadTokenRetriever;
 import com.netflix.priam.identity.token.IDeadTokenRetriever;
 import com.netflix.priam.identity.token.INewTokenRetriever;
@@ -74,6 +76,6 @@ public class BRTestModule extends AbstractModule
         bind(IBackupFileSystem.class).annotatedWith(Names.named("encryptedbackup")).to(FakedS3EncryptedFileSystem.class);
         bind(IFileCryptography.class).annotatedWith(Names.named("filecryptoalgorithm")).to(PgpCryptography.class);
         bind(IIncrementalBackup.class).to(IncrementalBackup.class);
-
+        bind(InstanceEnvIdentity.class).to(FakeInstanceEnvIdentity.class);
     }
 }

--- a/priam/src/test/java/com/netflix/priam/backup/identity/FakeInstanceEnvIdentity.java
+++ b/priam/src/test/java/com/netflix/priam/backup/identity/FakeInstanceEnvIdentity.java
@@ -1,0 +1,22 @@
+package com.netflix.priam.backup.identity;
+
+import com.netflix.priam.identity.InstanceEnvIdentity;
+
+public class FakeInstanceEnvIdentity implements InstanceEnvIdentity {
+
+	@Override
+	public Boolean isClassic() {
+		return null;
+	}
+
+	@Override
+	public Boolean isDefaultVpc() {
+		return null;
+	}
+
+	@Override
+	public Boolean isNonDefaultVpc() {
+		return null;
+	}
+
+}

--- a/priam/src/test/java/com/netflix/priam/backup/identity/InstanceTestUtils.java
+++ b/priam/src/test/java/com/netflix/priam/backup/identity/InstanceTestUtils.java
@@ -5,6 +5,7 @@ import com.netflix.priam.FakeMembership;
 import com.netflix.priam.FakePriamInstanceFactory;
 import com.netflix.priam.identity.IMembership;
 import com.netflix.priam.identity.IPriamInstanceFactory;
+import com.netflix.priam.identity.InstanceEnvIdentity;
 import com.netflix.priam.identity.InstanceIdentity;
 import com.netflix.priam.identity.token.DeadTokenRetriever;
 import com.netflix.priam.identity.token.NewTokenRetriever;
@@ -34,6 +35,7 @@ public abstract class InstanceTestUtils
     PreGeneratedTokenRetriever preGeneratedTokenRetriever;
 	NewTokenRetriever newTokenRetriever;
   	ITokenManager tokenManager;
+  	InstanceEnvIdentity insEnvIdentity;  
 
     @Before
     public void setup()
@@ -53,7 +55,7 @@ public abstract class InstanceTestUtils
         tokenManager = new TokenManager(config);
         factory = new FakePriamInstanceFactory(config);
         sleeper = new FakeSleeper();
-        this.deadTokenRetriever = new DeadTokenRetriever(factory, membership, config, sleeper);
+        this.deadTokenRetriever = new DeadTokenRetriever(factory, membership, config, sleeper, insEnvIdentity);
         this.preGeneratedTokenRetriever = new PreGeneratedTokenRetriever(factory, membership, config, sleeper);
         this.newTokenRetriever = new NewTokenRetriever(factory, membership, config, sleeper, tokenManager);
     }


### PR DESCRIPTION
This PR adds support for cross-account C* deployments in AWS EC2 leveraging AWS Role assumption and multiple credentials. It is by default disabled. For example, one use case would be EC2/VPC hybrid deployment. In order to support cross-account deployments, there are two new Fast Properties, .ec2.roleassumption.arn and .vpc.roleassumption.arn in which the Amazon Resource Name (ARN) is defined in order to establish the credentials for the cross-account access.