### PR TITLE
Fixing initialization bug of InstanceDataRetriever

### DIFF
--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -271,6 +271,23 @@ public class PriamConfiguration implements IConfiguration
     @Override
     public void intialize()
     {
+        InstanceDataRetriever instanceDataRetriever;
+        try {
+            instanceDataRetriever = getInstanceDataRetriever();
+        } catch (Exception e) {
+            throw new IllegalStateException("Exception when instantiating the instance data retriever.  Msg: " + e.getLocalizedMessage());
+        }
+
+        RAC = instanceDataRetriever.getRac();
+        PUBLIC_HOSTNAME = instanceDataRetriever.getPublicHostname();
+        PUBLIC_IP = instanceDataRetriever.getPublicIP();
+
+        INSTANCE_ID = instanceDataRetriever.getInstanceId();
+        INSTANCE_TYPE = instanceDataRetriever.getInstanceType();
+
+        NETWORK_MAC =  instanceDataRetriever.getMac();
+        NETWORK_VPC = instanceDataRetriever.getVpcId();
+
         setupEnvVars();
         this.config.intialize(ASG_NAME, REGION);
         setDefaultRACList(REGION);
@@ -279,23 +296,6 @@ public class PriamConfiguration implements IConfiguration
         SystemUtils.createDirs(getCommitLogLocation());
         SystemUtils.createDirs(getCacheLocation());
         SystemUtils.createDirs(getDataFileLocation());
-        
-    	InstanceDataRetriever instanceDataRetriever;
-		try {
-			instanceDataRetriever = getInstanceDataRetriever();
-		} catch (Exception e) {
-			throw new IllegalStateException("Exception when instantiating the instance data retriever.  Msg: " + e.getLocalizedMessage());
-		}
-		
-	    RAC = instanceDataRetriever.getRac();
-	    PUBLIC_HOSTNAME = instanceDataRetriever.getPublicHostname();
-	    PUBLIC_IP = instanceDataRetriever.getPublicIP();
-
-	    INSTANCE_ID = instanceDataRetriever.getInstanceId();
-	    INSTANCE_TYPE = instanceDataRetriever.getInstanceType();
-
-		NETWORK_MAC =  instanceDataRetriever.getMac();
-		NETWORK_VPC = instanceDataRetriever.getVpcId();
     }
     
     private InstanceDataRetriever getInstanceDataRetriever() throws InstantiationException, IllegalAccessException, ClassNotFoundException


### PR DESCRIPTION
Hi Vinh,

This one is fixing the chicken-egg problem in config initializer.
To be honest, I have no idea if it ever worked for somebody. setupEnvVars() requires to RAC to be set, otherwise it crashes.

Please review.

Regards,
Andor
