### PR TITLE
Fix PriamConfiguration init order.

### DIFF
--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -277,15 +277,6 @@ public class PriamConfiguration implements IConfiguration
     @Override
     public void intialize()
     {
-        setupEnvVars();
-        this.config.intialize(ASG_NAME, REGION);
-        setDefaultRACList(REGION);
-        populateProps();
-        SystemUtils.createDirs(getBackupCommitLogLocation());
-        SystemUtils.createDirs(getCommitLogLocation());
-        SystemUtils.createDirs(getCacheLocation());
-        SystemUtils.createDirs(getDataFileLocation());
-        
     	InstanceDataRetriever instanceDataRetriever;
 		try {
 			instanceDataRetriever = getInstanceDataRetriever();
@@ -302,6 +293,15 @@ public class PriamConfiguration implements IConfiguration
 
 		NETWORK_MAC =  instanceDataRetriever.getMac();
 		NETWORK_VPC = instanceDataRetriever.getVpcId();
+
+        setupEnvVars();
+        this.config.intialize(ASG_NAME, REGION);
+        setDefaultRACList(REGION);
+        populateProps();
+        SystemUtils.createDirs(getBackupCommitLogLocation());
+        SystemUtils.createDirs(getCommitLogLocation());
+        SystemUtils.createDirs(getCacheLocation());
+        SystemUtils.createDirs(getDataFileLocation());
     }
     
     private InstanceDataRetriever getInstanceDataRetriever() throws InstantiationException, IllegalAccessException, ClassNotFoundException


### PR DESCRIPTION
Launching Priam without the `EC2_REGION` value set causes a NullPointerException due to `RAC` not being set on line 325 in `setupEnvVars()`. This rearranges the order of statements in `initialize()` to ensure `RAC` is set before `setupEnvVars()` is called.