### PR TITLE
Added CommitLog archiving properties file path config option

### DIFF
--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -435,7 +435,9 @@ public interface IConfiguration
     public String getInternodeCompression();
    
     public boolean isBackingUpCommitLogs();
-    
+
+    public String getCommitLogBackupPropsFile();
+
     public String getCommitLogBackupArchiveCmd();
 
     public String getCommitLogBackupRestoreCmd();

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -124,6 +124,7 @@ public class PriamConfiguration implements IConfiguration
     private static final String CONFIG_INTERNODE_COMPRESSION = PRIAM_PRE + ".internodeCompression";
 
     private static final String CONFIG_COMMITLOG_BKUP_ENABLED = PRIAM_PRE + ".clbackup.enabled";
+    private static final String CONFIG_COMMITLOG_PROPS_FILE = PRIAM_PRE + ".clbackup.propsfile";
     private static final String CONFIG_COMMITLOG_ARCHIVE_CMD = PRIAM_PRE + ".clbackup.archiveCmd";
     private static final String CONFIG_COMMITLOG_RESTORE_CMD = PRIAM_PRE + ".clbackup.restoreCmd";
     private static final String CONFIG_COMMITLOG_RESTORE_DIRS = PRIAM_PRE + ".clbackup.restoreDirs";
@@ -210,6 +211,7 @@ public class PriamConfiguration implements IConfiguration
     private final String DEFAULT_PARTITIONER = "org.apache.cassandra.dht.RandomPartitioner";
     public static final String DEFAULT_AUTHENTICATOR = "org.apache.cassandra.auth.AllowAllAuthenticator";
     public static final String DEFAULT_AUTHORIZER = "org.apache.cassandra.auth.AllowAllAuthorizer";
+    public static final String DEFAULT_COMMITLOG_PROPS_FILE = "/conf/commitlog_archiving.properties";
 
     // rpm based. Can be modified for tar based.
     private final String DEFAULT_CASS_HOME_DIR = "/etc/cassandra";
@@ -877,6 +879,12 @@ public class PriamConfiguration implements IConfiguration
     public boolean isBackingUpCommitLogs()
     {
         return config.get(CONFIG_COMMITLOG_BKUP_ENABLED, false);
+    }
+
+    @Override
+    public String getCommitLogBackupPropsFile()
+    {
+        return config.get(CONFIG_COMMITLOG_PROPS_FILE, getCassHome() + DEFAULT_COMMITLOG_PROPS_FILE);
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/StandardTuner.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/StandardTuner.java
@@ -24,7 +24,6 @@ import org.yaml.snakeyaml.Yaml;
 public class StandardTuner implements CassandraTuner
 {
     private static final Logger logger = LoggerFactory.getLogger(StandardTuner.class);
-    private static final String CL_BACKUP_PROPS_FILE = "/conf/commitlog_archiving.properties";
     protected final IConfiguration config;
 
     @Inject
@@ -195,7 +194,7 @@ public class StandardTuner implements CassandraTuner
         FileOutputStream fos = null;
         try
         {
-            fos = new FileOutputStream(new File(config.getCassHome() + CL_BACKUP_PROPS_FILE));
+            fos = new FileOutputStream(new File(config.getCommitLogBackupPropsFile()));
             props.store(fos, "cassandra commit log archive props, as written by priam");
         }
         finally

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -494,6 +494,12 @@ public class FakeConfiguration implements IConfiguration
     }
 
     @Override
+    public String getCommitLogBackupPropsFile()
+    {
+        return getCassHome() + PriamConfiguration.DEFAULT_COMMITLOG_PROPS_FILE;
+    }
+
+    @Override
     public String getCommitLogBackupArchiveCmd()
     {
         return null;

--- a/priam/src/test/java/com/netflix/priam/FakeConfigurationMurmur3.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfigurationMurmur3.java
@@ -494,6 +494,12 @@ public class FakeConfigurationMurmur3 implements IConfiguration
     }
 
     @Override
+    public String getCommitLogBackupPropsFile()
+    {
+        return getCassHome() + PriamConfiguration.DEFAULT_COMMITLOG_PROPS_FILE;
+    }
+
+    @Override
     public String getCommitLogBackupArchiveCmd()
     {
         return null;


### PR DESCRIPTION
Hello,

The Cassandra version we use looks for the commitlog_archiving.properties file in Cassandra's home directory, not in the $cass_home/conf/ folder, so I routed the variable to a config option.

Thanks for Priam,
Peter
