### PR TITLE
Followup ColumnFamily directory naming change introduced in Cassandra…

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
@@ -165,10 +165,11 @@ public abstract class AbstractBackup extends Task
             return false;        	
         }
 
-        String columnFamilyName = columnFamilyDir.getName();
+        String dirName = columnFamilyDir.getName();
 
+        String columnFamilyName = dirName.split("-")[0];
         if (FILTER_COLUMN_FAMILY.containsKey(keyspaceName) && FILTER_COLUMN_FAMILY.get(keyspaceName).contains(columnFamilyName)) {
-        	logger.debug(columnFamilyName + " is not consider a valid CF backup directory, will be bypass.");
+            logger.debug(dirName + " is not consider a valid CF backup directory, will be bypass.");
             return false;        	
         }
 


### PR DESCRIPTION
… 2.1

The change was a fix for CASSANDRA-5202 and introduced in the following Cassandra [patch](https://github.com/apache/cassandra/commit/0a1b277d659e20cd19eaedaa7220b0fc55950dc4) 
