### PR TITLE
Allow S3 Role assumption when interacting with S3 for backups

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/S3CrossAccountFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3CrossAccountFileSystem.java
@@ -51,8 +51,8 @@ public class S3CrossAccountFileSystem  {
 				if (this.s3Client == null ) {
 				
 					try {
-						
-						this.s3Client = new AmazonS3Client(s3Credential.getCredentialsProvider());
+
+						this.s3Client = new AmazonS3Client(s3Credential.getAwsCredentialProvider());
 
 					} catch (Exception e) {
 						throw new IllegalStateException("Exception in getting handle to s3 client.  Msg: " + e.getLocalizedMessage(), e);

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
+import com.netflix.priam.aws.auth.IS3Credential;
 import org.apache.commons.io.IOUtils;
 
 import com.google.common.collect.Lists;
@@ -51,8 +52,8 @@ import com.amazonaws.services.s3.model.PartETag;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
+import com.google.inject.name.Named;
 import com.netflix.priam.IConfiguration;
-import com.netflix.priam.ICredential;
 import com.netflix.priam.backup.AbstractBackupPath;
 import com.netflix.priam.backup.BackupRestoreException;
 import com.netflix.priam.backup.IBackupFileSystem;
@@ -77,7 +78,8 @@ public class S3FileSystem extends S3FileSystemBase implements IBackupFileSystem,
     private RateLimiter rateLimiter;
 
     @Inject
-    public S3FileSystem(Provider<AbstractBackupPath> pathProvider, ICompression compress, final IConfiguration config, ICredential cred)
+    public S3FileSystem(Provider<AbstractBackupPath> pathProvider, ICompression compress, final IConfiguration config,
+                        @Named("awss3roleassumption")IS3Credential cred)
     {
         this.pathProvider = pathProvider;
         this.compress = compress;

--- a/priam/src/main/java/com/netflix/priam/aws/auth/IS3Credential.java
+++ b/priam/src/main/java/com/netflix/priam/aws/auth/IS3Credential.java
@@ -2,13 +2,12 @@ package com.netflix.priam.aws.auth;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.netflix.priam.ICredential;
 
 /*
  * Credentials specific to Amazon S3
  */
-public interface IS3Credential {
+public interface IS3Credential extends ICredential{
 
 	public AWSCredentials getCredentials() throws Exception;
-	public AWSCredentialsProvider getCredentialsProvider() throws Exception;
-	
 }

--- a/priam/src/main/java/com/netflix/priam/aws/auth/S3InstanceCredential.java
+++ b/priam/src/main/java/com/netflix/priam/aws/auth/S3InstanceCredential.java
@@ -21,7 +21,7 @@ public class S3InstanceCredential implements IS3Credential {
 	}
 
 	@Override
-	public AWSCredentialsProvider getCredentialsProvider() throws Exception {
+	public AWSCredentialsProvider getAwsCredentialProvider() {
 		return this.credentialsProvider;
 	}
 	

--- a/priam/src/main/java/com/netflix/priam/aws/auth/S3RoleAssumptionCredential.java
+++ b/priam/src/main/java/com/netflix/priam/aws/auth/S3RoleAssumptionCredential.java
@@ -62,7 +62,7 @@ public class S3RoleAssumptionCredential implements IS3Credential {
 					
 					final String roleArn = this.config.getAWSRoleAssumptionArn();  //IAM role created for bucket own by account "awsprodbackup"
 					if (roleArn == null || roleArn.isEmpty()) {
-						logger.warn("Was expecting an override configuration to assume the role. Falling back to instance level credentials");
+						logger.warn("Role ARN is null or empty probably due to missing config entry. Falling back to instance level credentials");
 						this.stsSessionCredentialsProvider =  this.cred.getAwsCredentialProvider();
 						//throw new NullPointerException("Role ARN is null or empty probably due to missing config entry");
 					}

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -617,7 +617,7 @@ public class FakeConfiguration implements IConfiguration
 
 	@Override
 	public String getAWSRoleAssumptionArn() {
-		return "some:random:value";
+		return "";
 	}
 	
     @Override

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -617,7 +617,7 @@ public class FakeConfiguration implements IConfiguration
 
 	@Override
 	public String getAWSRoleAssumptionArn() {
-		return "";
+		return null;
 	}
 	
     @Override

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -617,7 +617,7 @@ public class FakeConfiguration implements IConfiguration
 
 	@Override
 	public String getAWSRoleAssumptionArn() {
-		return null;
+		return "some:random:value";
 	}
 	
     @Override

--- a/priam/src/test/java/com/netflix/priam/backup/BRTestModule.java
+++ b/priam/src/test/java/com/netflix/priam/backup/BRTestModule.java
@@ -71,6 +71,7 @@ public class BRTestModule extends AbstractModule
         bind(IDeadTokenRetriever.class).to(DeadTokenRetriever.class);
         bind(IPreGeneratedTokenRetriever.class).to(PreGeneratedTokenRetriever.class);
         bind(INewTokenRetriever.class).to(NewTokenRetriever.class); //for backward compatibility, unit test always create new tokens        
+        bind(IS3Credential.class).annotatedWith(Names.named("awss3roleassumption")).to(S3RoleAssumptionCredential.class);
 
         bind(IFileSystemContext.class).annotatedWith(Names.named("backup")).to(BackupFileSystemContext.class);
         bind(IBackupFileSystem.class).annotatedWith(Names.named("encryptedbackup")).to(FakedS3EncryptedFileSystem.class);


### PR DESCRIPTION
- This will allow S3 Role assumptions when interacting with S3. 
- Code cleanup: Make IS3Credential an extension to ICredential.