### PR TITLE
Support the ability to query more than one ASG for RacMembership

### DIFF
--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -269,7 +269,12 @@ public interface IConfiguration
      * Amazon specific setting to query ASG Membership
      */
     public String getASGName();
-    
+
+    /**
+     * Amazon specific setting to query Additional/ Sibling ASG Memberships in csv format to consider while calculating RAC membership
+     */
+    public String getSiblingASGNames();
+
     /**
      * Get the security group associated with nodes in this cluster
      */

--- a/priam/src/main/java/com/netflix/priam/aws/AWSMembership.java
+++ b/priam/src/main/java/com/netflix/priam/aws/AWSMembership.java
@@ -17,10 +17,7 @@ package com.netflix.priam.aws;
 
 import com.google.inject.name.Named;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -76,8 +73,11 @@ public class AWSMembership implements IMembership
         AmazonAutoScaling client = null;
         try
         {
+            List<String> asgNames = new ArrayList<>();
+            asgNames.add(config.getASGName());
+            asgNames.addAll(Arrays.asList(config.getSiblingASGNames().split("\\s*,\\s*")));
             client = getAutoScalingClient();
-            DescribeAutoScalingGroupsRequest asgReq = new DescribeAutoScalingGroupsRequest().withAutoScalingGroupNames(config.getASGName());
+            DescribeAutoScalingGroupsRequest asgReq = new DescribeAutoScalingGroupsRequest().withAutoScalingGroupNames(asgNames.toArray(new String[asgNames.size()]));
             DescribeAutoScalingGroupsResult res = client.describeAutoScalingGroups(asgReq);
 
             List<String> instanceIds = Lists.newArrayList();
@@ -88,7 +88,7 @@ public class AWSMembership implements IMembership
                             .equalsIgnoreCase("Terminated")))
                         instanceIds.add(ins.getInstanceId());
             }
-            logger.info(String.format("Querying Amazon returned following instance in the ASG: %s --> %s", config.getRac(), StringUtils.join(instanceIds, ",")));
+            logger.info(String.format("Querying Amazon returned following instance in the RAC: %s, ASGs: %s --> %s", config.getRac(),StringUtils.join(asgNames, ",") ,StringUtils.join(instanceIds, ",")));
             return instanceIds;
         }
         finally

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -174,6 +174,7 @@ public class PriamConfiguration implements IConfiguration
     
     // Amazon specific
     private static final String CONFIG_ASG_NAME = PRIAM_PRE + ".az.asgname";
+    private static final String CONFIG_SIBLING_ASG_NAMES = PRIAM_PRE + ".az.sibling.asgnames";
     private static final String CONFIG_REGION_NAME = PRIAM_PRE + ".az.region";
     private static final String CONFIG_ACL_GROUP_NAME = PRIAM_PRE + ".acl.groupname";
     private final String LOCAL_HOSTNAME = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/local-hostname").trim();
@@ -680,6 +681,14 @@ public class PriamConfiguration implements IConfiguration
     public String getASGName()
     {
         return config.get(CONFIG_ASG_NAME, "");
+    }
+
+    /**
+     * Amazon specific setting to query Additional/ Sibling ASG Memberships in csv format to consider while calculating RAC membership
+     */
+    @Override
+    public String getSiblingASGNames() {
+        return config.get(CONFIG_SIBLING_ASG_NAMES, ",");
     }
 
     @Override

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -226,7 +226,15 @@ public class FakeConfiguration implements IConfiguration
         // TODO Auto-generated method stub
         return null;
     }
-    
+
+    /**
+     * Amazon specific setting to query Additional/ Sibling ASG Memberships in csv format to consider while calculating RAC membership
+     */
+    @Override
+    public String getSiblingASGNames() {
+        return null;
+    }
+
     @Override
     public boolean isIncrBackup()
     {

--- a/priam/src/test/java/com/netflix/priam/FakeConfigurationMurmur3.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfigurationMurmur3.java
@@ -227,6 +227,14 @@ public class FakeConfigurationMurmur3 implements IConfiguration
         return null;
     }
 
+    /**
+     * Amazon specific setting to query Additional/ Sibling ASG Memberships in csv format to consider while calculating RAC membership
+     */
+    @Override
+    public String getSiblingASGNames() {
+        return null;
+    }
+
     @Override
     public boolean isIncrBackup()
     {


### PR DESCRIPTION
Support the ability to query more than one ASG while looking for current RacMembership since one RAC(availability zone) members could span across different ASGs