### PR TITLE
Perform nodetool flush on 1:* keyspaces

### DIFF
--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -575,4 +575,14 @@ public interface IConfiguration
      * @return streaming_socket_timeout_in_ms in C* yaml
      */
     int getStreamingSocketTimeoutInMS();
+
+    /*
+     * @return a comma delimited list of keyspaces to flush
+     */
+    public String getFlushKeyspaces();
+    /*
+     * @return the interval to run the flush task.  Format is name=value where
+     * “name” is an enum of hour, daily, value is ...
+     */
+    public String getFlushInterval();
 }

--- a/priam/src/main/java/com/netflix/priam/PriamServer.java
+++ b/priam/src/main/java/com/netflix/priam/PriamServer.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.priam;
 
+import com.netflix.priam.cluster.management.FlushTask;
 import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -175,6 +176,13 @@ public class PriamServer
         
         //Set cleanup
         scheduler.addTask(UpdateCleanupPolicy.JOBNAME, UpdateCleanupPolicy.class, UpdateCleanupPolicy.getTimer());
+
+        //Set up nodetool flush task
+        String timerVal = config.getFlushInterval();  //e.g. hour=0 or daily=10)
+        if (timerVal != null && !timerVal.isEmpty() ) {
+            scheduler.addTask(FlushTask.JOBNAME, FlushTask.class, FlushTask.getTimer(config));
+            logger.info("Added nodetool flush task.");
+        }
     }
 
     public InstanceIdentity getId()

--- a/priam/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
@@ -28,7 +28,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.netflix.priam.merics.IMeasurement;
-import com.netflix.priam.merics.IMetricPublisher;
 import com.netflix.priam.merics.SnapshotBackupMeasurement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,21 +68,18 @@ public class SnapshotBackup extends AbstractBackup
 	private final Map<String, Object> snapshotKeyspaceFilter  = new HashMap<String, Object>(); //key: keyspace, value: null
 
 	private BackupStatusMgr completedBackups;
-    private IMetricPublisher metricPublisher;
 
 
     @Inject
     public SnapshotBackup(IConfiguration config, Provider<AbstractBackupPath> pathFactory, 
     		              MetaData metaData, CommitLogBackup clBackup, @Named("backup") IFileSystemContext backupFileSystemCtx
     		              ,BackupStatusMgr completedBackups
-                          ,@Named("defaultmetricpublisher") IMetricPublisher metricPublisher
                         )
     {
     	super(config, backupFileSystemCtx, pathFactory);
         this.metaData = metaData;
         this.clBackup = clBackup;
         this.completedBackups = completedBackups;
-        this.metricPublisher = metricPublisher;
         init();
     }
 
@@ -239,7 +235,6 @@ public class SnapshotBackup extends AbstractBackup
     	BackupMetadata metadata = this.completedBackups.add(key, snapshotname, start, completed);
         IMeasurement measurement = new SnapshotBackupMeasurement();
         measurement.incrementSuccessCnt(1);
-        this.metricPublisher.publish(measurement); //signal that there was a success
     }
     
     /*

--- a/priam/src/main/java/com/netflix/priam/cluster/management/Flush.java
+++ b/priam/src/main/java/com/netflix/priam/cluster/management/Flush.java
@@ -1,0 +1,83 @@
+package com.netflix.priam.cluster.management;
+
+import org.apache.cassandra.db.Keyspace;
+import com.netflix.priam.IConfiguration;
+import com.netflix.priam.utils.JMXConnectorMgr;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility to flush 1:8 Keyspaces from memtable to disk
+ *
+ * Created by vinhn on 10/12/16.
+ */
+public class Flush implements IClusterManagement<String> {
+    private static final Logger logger = LoggerFactory.getLogger(Flush.class);
+
+    private final IConfiguration config;
+    private final JMXConnectorMgr jmxConnectorMgr;
+    private List<String> keyspaces = new ArrayList<String>();
+
+    public Flush(IConfiguration config, JMXConnectorMgr jmxConnectorMgr) {
+        this.config = config;
+        this.jmxConnectorMgr = jmxConnectorMgr;
+    }
+
+    @Override
+    /*
+     * @return the keyspace(s) flushed.  List can be empty but never null.
+     */
+    public List<String> execute() throws Exception {
+        List<String> flushed = new ArrayList<String>();
+
+        //== fetch keyspaces
+        deriveKeyspaces();
+        if (this.keyspaces == null || this.keyspaces.isEmpty()) {
+            logger.warn("NO op on requested \"flush\" as there are no keyspaces.");
+            return flushed;
+        }
+
+        //If flush is for certain keyspaces, validate keyspace exist
+        for (String keyspace : keyspaces) {
+            if (!this.jmxConnectorMgr.getKeyspaces().contains(keyspace)) {
+                throw new IllegalArgumentException("Keyspace [" + keyspace + "] does not exist.");
+            }
+        }
+
+        for (String keyspace : keyspaces) { //flush each keyspace with the CFs.
+            if (Keyspace.SYSTEM_KS.equals(keyspace)) //no need to flush system keyspaces.
+                continue;
+
+            try {
+                this.jmxConnectorMgr.forceKeyspaceFlush(keyspace, new String[0]);
+                flushed.add(keyspace);
+            } catch (Exception e) {
+                throw new RuntimeException("Exception flush keyspace: " + keyspace, e);
+            }
+        }
+
+        return flushed;
+    }
+
+    /*
+    Derive keyspace(s) to flush in the following order:  explicit list provided by caller, property, or all keyspaces.
+     */
+    private void deriveKeyspaces() {
+        //== get value from property
+        String raw = this.config.getFlushKeyspaces();
+        if (raw != null && !raw.isEmpty() ) {
+            String k[] = raw.split(",");
+            for (int i=0; i < k.length; i++ ) {
+                this.keyspaces.add(i, k[i]);
+            }
+
+            return;
+        }
+
+        //== no override via FP, default to all keyspaces
+        this.keyspaces = this.jmxConnectorMgr.getKeyspaces();
+        return;
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/cluster/management/FlushTask.java
+++ b/priam/src/main/java/com/netflix/priam/cluster/management/FlushTask.java
@@ -1,0 +1,94 @@
+package com.netflix.priam.cluster.management;
+
+import com.amazonaws.services.lambda.model.Runtime;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import com.netflix.priam.IConfiguration;
+import com.netflix.priam.merics.IMeasurement;
+import com.netflix.priam.merics.IMetricPublisher;
+import com.netflix.priam.merics.NoOpMetricPublisher;
+import com.netflix.priam.merics.NodeToolFlushMeasurement;
+import com.netflix.priam.scheduler.CronTimer;
+import com.netflix.priam.scheduler.Task;
+import com.netflix.priam.scheduler.TaskTimer;
+import com.netflix.priam.utils.JMXConnectorMgr;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Created by vinhn on 10/13/16.
+ */
+public class FlushTask extends Task {
+    public static final String JOBNAME = "FlushTask";
+    private static final Logger logger = LoggerFactory.getLogger(FlushTask.class);
+    private IMetricPublisher metricPublisher;
+
+    @Inject
+    public FlushTask(IConfiguration config, @Named("defaultmetricpublisher") IMetricPublisher metricPublisher) {
+        super(config);
+        this.metricPublisher = metricPublisher;
+    }
+
+    @Override
+    public void execute() throws Exception {
+        JMXConnectorMgr connMgr = null;
+        try {
+            connMgr = new JMXConnectorMgr(config);
+        } catch (Exception e) {
+            throw new RuntimeException("Exception connection to remove jxm server.", e);
+        }
+        List<String> flushed = null;
+        try {
+            IClusterManagement flush = new Flush(this.config, connMgr);
+            flushed = flush.execute();
+            IMeasurement measurement = new NodeToolFlushMeasurement();
+            measurement.incrementSuccessCnt(1);
+            this.metricPublisher.publish(measurement); //signal that there was a success
+
+        } catch (Exception e) {
+            IMeasurement measurement = new NodeToolFlushMeasurement();
+            measurement.incrementFailureCnt(1);
+            this.metricPublisher.publish(measurement); //signal that there was a failure
+            throw new RuntimeException("Exception during flush.", e);
+
+        } finally {
+            connMgr.close();  //resource cleanup
+        }
+        if (flushed.isEmpty()) {
+            logger.warn("Flush task completed successfully but no keyspaces were flushed.");
+        } else {
+            for (String ks : flushed) {
+                logger.info("Flushed keyspace: " + ks);
+            }
+        }
+
+    }
+
+    @Override
+    public String getName() {
+        return JOBNAME;
+    }
+
+    /*
+    @return the hourly or daily time to execute the flush
+     */
+    public static TaskTimer getTimer(IConfiguration config) {
+        String timerVal = config.getFlushInterval();  //e.g. hour=0 or daily=10
+        String s[] = timerVal.split("=");
+        if (s.length != 2 ){
+            throw new IllegalArgumentException("Flush interval format is invalid.  Expecting name=value, received: " + timerVal);
+        }
+        String name = s[0];
+        Integer time = new Integer(s[1]);
+
+        if (name.equalsIgnoreCase("hour")) {
+            return new CronTimer(time, 0); //minute, sec after the hour
+        } if (name.equalsIgnoreCase("daily")) {
+            return new CronTimer(time, 0 , 0); //hour, minute, sec to run on a daily basis
+        } else {
+            throw new IllegalArgumentException("Flush interval type is invalid.  Expecting \"hour, daily\", received: " + name);
+        }
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/cluster/management/FlushTask.java
+++ b/priam/src/main/java/com/netflix/priam/cluster/management/FlushTask.java
@@ -24,11 +24,13 @@ public class FlushTask extends Task {
     public static final String JOBNAME = "FlushTask";
     private static final Logger logger = LoggerFactory.getLogger(FlushTask.class);
     private IMetricPublisher metricPublisher;
+    private IMeasurement measurement;
 
     @Inject
     public FlushTask(IConfiguration config, @Named("defaultmetricpublisher") IMetricPublisher metricPublisher) {
         super(config);
         this.metricPublisher = metricPublisher;
+        measurement = new NodeToolFlushMeasurement();
     }
 
     @Override
@@ -43,7 +45,6 @@ public class FlushTask extends Task {
         try {
             IClusterManagement flush = new Flush(this.config, connMgr);
             flushed = flush.execute();
-            IMeasurement measurement = new NodeToolFlushMeasurement();
             measurement.incrementSuccessCnt(1);
             this.metricPublisher.publish(measurement); //signal that there was a success
 

--- a/priam/src/main/java/com/netflix/priam/cluster/management/IClusterManagement.java
+++ b/priam/src/main/java/com/netflix/priam/cluster/management/IClusterManagement.java
@@ -1,0 +1,11 @@
+package com.netflix.priam.cluster.management;
+
+import java.util.List;
+
+/**
+ * Created by vinhn on 10/12/16.
+ */
+public interface IClusterManagement<T> {
+
+    public List<T> execute() throws Exception;
+}

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -1177,4 +1177,14 @@ public class PriamConfiguration implements IConfiguration
         return config.get(CONFIG_STREAMING_SOCKET_TIMEOUT_IN_MS, DEFAULT_STREAMING_SOCKET_TIMEOUT_IN_MS);
     }
 
+    @Override
+    public String getFlushKeyspaces() {
+        return config.get(PRIAM_PRE  + ".flush.keyspaces");
+    }
+
+    @Override
+    public String getFlushInterval() {
+        return config.get(PRIAM_PRE  + ".flush.interval");
+    }
+
 }

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamGuiceModule.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamGuiceModule.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.priam.defaultimpl;
 
+import com.netflix.priam.merics.IMetricPublisher;
+import com.netflix.priam.merics.NoOpMetricPublisher;
 import org.quartz.SchedulerFactory;
 import org.quartz.impl.StdSchedulerFactory;
 
@@ -79,6 +81,7 @@ public class PriamGuiceModule extends AbstractModule
         bind(INewTokenRetriever.class).to(NewTokenRetriever.class);
         bind(ITaskQueueMgr.class).annotatedWith(Names.named("backup")).to(CassandraBackupQueueMgr.class);
         bind(InstanceEnvIdentity.class).to(AwsInstanceEnvIdentity.class);
+        bind(IMetricPublisher.class).annotatedWith(Names.named("defaultmetricpublisher")).to(NoOpMetricPublisher.class);
         
     }
 }

--- a/priam/src/main/java/com/netflix/priam/merics/IMeasurement.java
+++ b/priam/src/main/java/com/netflix/priam/merics/IMeasurement.java
@@ -1,0 +1,20 @@
+package com.netflix.priam.merics;
+
+/**
+ *
+ * Represents a specific measurement for publishing to a metric system
+ *
+ * Created by vinhn on 10/14/16.
+ */
+public interface IMeasurement {
+
+    public MMEASUREMENT_TYPE getType();
+    public void incrementFailureCnt(int i);
+    public int getFailureCnt();
+    public void incrementSuccessCnt(int i);
+    public int getSuccessCnt();
+
+    public enum MMEASUREMENT_TYPE {
+        NOOP, NODETOOLFLUSH, SNAPSHOTBACKUP;
+    };
+}

--- a/priam/src/main/java/com/netflix/priam/merics/IMetricPublisher.java
+++ b/priam/src/main/java/com/netflix/priam/merics/IMetricPublisher.java
@@ -1,0 +1,12 @@
+package com.netflix.priam.merics;
+
+/**
+ *
+ * A means to publish Priam, Cassandra relaated metrics.
+ * The default publisher is a noop.
+ *
+ * Created by vinhn on 10/14/16.
+ */
+public interface IMetricPublisher {
+    public void publish(IMeasurement metric);
+}

--- a/priam/src/main/java/com/netflix/priam/merics/NoOpMeasurement.java
+++ b/priam/src/main/java/com/netflix/priam/merics/NoOpMeasurement.java
@@ -1,0 +1,36 @@
+package com.netflix.priam.merics;
+
+/**
+ *
+ * A dummy, no op measurement.
+ *
+ * Created by vinhn on 10/14/16.
+ */
+public class NoOpMeasurement implements IMeasurement{
+    private int failure = 0, success = 0;
+
+    @Override
+    public MMEASUREMENT_TYPE getType() {
+        return MMEASUREMENT_TYPE.NOOP;
+    }
+
+    @Override
+    public void incrementFailureCnt(int i) {
+        this.failure = i;
+    }
+
+    @Override
+    public int getFailureCnt() {
+        return this.failure;
+    }
+
+    @Override
+    public void incrementSuccessCnt(int i) {
+        this.success = i;
+    }
+
+    @Override
+    public int getSuccessCnt() {
+        return this.success;
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/merics/NoOpMetricPublisher.java
+++ b/priam/src/main/java/com/netflix/priam/merics/NoOpMetricPublisher.java
@@ -1,0 +1,13 @@
+package com.netflix.priam.merics;
+
+/**
+ * A noop metric publisher.
+ *
+ * Created by vinhn on 10/14/16.
+ */
+public class NoOpMetricPublisher implements IMetricPublisher {
+    @Override
+    public void publish(IMeasurement o) {
+        //No OP
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/merics/NodeToolFlushMeasurement.java
+++ b/priam/src/main/java/com/netflix/priam/merics/NodeToolFlushMeasurement.java
@@ -1,0 +1,31 @@
+package com.netflix.priam.merics;
+
+/**
+ *
+ * Represents the value to be publish to a telemetry endpoint
+ *
+ * Created by vinhn on 10/14/16.
+ */
+public class NodeToolFlushMeasurement implements IMeasurement {
+    private int failure = 0, success = 0;
+
+    @Override
+    public MMEASUREMENT_TYPE getType() {
+        return MMEASUREMENT_TYPE.NODETOOLFLUSH;
+    }
+
+    public void incrementFailureCnt(int val) {
+        this.failure += val;
+    }
+    public int getFailureCnt() {
+        return this.failure;
+    }
+
+    public void incrementSuccessCnt(int val) {
+        this.success += val;
+    }
+    public int getSuccessCnt() {
+        return this.success;
+    }
+
+}

--- a/priam/src/main/java/com/netflix/priam/merics/SnapshotBackupMeasurement.java
+++ b/priam/src/main/java/com/netflix/priam/merics/SnapshotBackupMeasurement.java
@@ -1,0 +1,26 @@
+package com.netflix.priam.merics;
+
+/**
+ * Created by vinhn on 10/14/16.
+ */
+public class SnapshotBackupMeasurement  implements IMeasurement  {
+    private int failure = 0, success = 0;
+    @Override
+    public MMEASUREMENT_TYPE getType() {
+        return MMEASUREMENT_TYPE.SNAPSHOTBACKUP;
+    }
+
+    public void incrementFailureCnt(int val) {
+        this.failure += val;
+    }
+    public int getFailureCnt() {
+        return this.failure;
+    }
+
+    public void incrementSuccessCnt(int val) {
+        this.success += val;
+    }
+    public int getSuccessCnt() {
+        return this.success;
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/utils/JMXConnectorMgr.java
+++ b/priam/src/main/java/com/netflix/priam/utils/JMXConnectorMgr.java
@@ -1,0 +1,36 @@
+package com.netflix.priam.utils;
+
+import com.google.inject.Inject;
+import com.netflix.priam.IConfiguration;
+import org.apache.cassandra.tools.NodeProbe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Represents a connection to remote JMX mbean server.  This object differs from JMXNodeTool as it is meant for short
+ * lived connection to remote mbean server.
+ *
+ * Created by vinhn on 10/11/16.
+ */
+public class JMXConnectorMgr extends NodeProbe {
+    private static final Logger logger = LoggerFactory.getLogger(JMXConnectorMgr.class);
+
+    /*
+     * create a connection to remote mbean server and get proxy to various mbeans
+     * @throws exception if unable to create the connection, e.g. Cassandra process not running.
+     */
+    public JMXConnectorMgr(IConfiguration config) throws IOException, InterruptedException {
+        super("localhost", config.getJmxPort());
+    }
+
+    @Override
+    /*
+    close the connection to remote mbean server
+     */
+    public void close() throws IOException {
+        super.close(); //close the connection to remote mbean server
+    }
+
+}

--- a/priam/src/main/java/com/netflix/priam/utils/SystemUtils.java
+++ b/priam/src/main/java/com/netflix/priam/utils/SystemUtils.java
@@ -185,7 +185,7 @@ public class SystemUtils
         }
         catch (Exception e)
         {
-            logger.warn("failed to close JMXConnector", e);
+            logger.warn("failed to close JMXConnectorMgr", e);
         }
     }   
     

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -747,4 +747,14 @@ public class FakeConfiguration implements IConfiguration
     public int getStreamingSocketTimeoutInMS() {
         return 86400000;
     }
+
+    @Override
+    public String getFlushKeyspaces() {
+        return new String();
+    }
+
+    @Override
+    public String getFlushInterval() {
+        return null;
+    }
 }

--- a/priam/src/test/java/com/netflix/priam/FakeConfigurationMurmur3.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfigurationMurmur3.java
@@ -747,4 +747,14 @@ public class FakeConfigurationMurmur3 implements IConfiguration
     public int getStreamingSocketTimeoutInMS() {
         return 86400000;
     }
+
+    @Override
+    public String getFlushKeyspaces() {
+        return new String();
+    }
+
+    @Override
+    public String getFlushInterval() {
+        return null;
+    }
 }

--- a/priam/src/test/java/com/netflix/priam/backup/BRTestModule.java
+++ b/priam/src/test/java/com/netflix/priam/backup/BRTestModule.java
@@ -4,6 +4,8 @@ import java.util.Arrays;
 
 import com.netflix.priam.ICassandraProcess;
 import com.netflix.priam.defaultimpl.CassandraProcessManager;
+import com.netflix.priam.merics.IMetricPublisher;
+import com.netflix.priam.merics.NoOpMetricPublisher;
 import com.netflix.priam.restore.EncryptedRestoreStrategy;
 import com.netflix.priam.restore.IRestoreStrategy;
 import com.netflix.priam.utils.ITokenManager;
@@ -78,5 +80,6 @@ public class BRTestModule extends AbstractModule
         bind(IFileCryptography.class).annotatedWith(Names.named("filecryptoalgorithm")).to(PgpCryptography.class);
         bind(IIncrementalBackup.class).to(IncrementalBackup.class);
         bind(InstanceEnvIdentity.class).to(FakeInstanceEnvIdentity.class);
+        bind(IMetricPublisher.class).annotatedWith(Names.named("defaultmetricpublisher")).to(NoOpMetricPublisher.class);
     }
 }


### PR DESCRIPTION
This feature is a first step toward enhancing to perform more management tasks for a cluster.

## Configuration
To flush specific keyspaces, create FP “Priam.flush.keyspaces” and provide a comma delimited list of values (e.g. pappyperftest,dse_system).  
If no FP exist, all kespaces (EXCLUDING system) will be flushed. 

To specify interval, create FP “Priam.flush.interval”.    The value is a name=value where “name” is an enum of hour, daily.

- hour means the flush will run at every hour.  The value is an integer representing the minute.  E.g. hour=0 will run on the hour, every hour.

- daily means the flush will run once daily at specified time.  The value is an integer representing the hour. E.g. daily=10 will run at 10:00 a.m. daily.

## Manually invocation
curl “http://localhost:8080/Priam/REST/v1/cassadmin/flush”.
The result will be a json payload.

- For success, the payload is a list of keyspace(s) flushed.  E.g. {"keyspace_flushed":["dse_system","pappyperftest","system_traces"]}

- For failure, the payload will be {“status:ERROR”, “component:flush”}
