### PR TITLE
Switch to Oracle JDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk7
+  - oraclejdk8
 sudo: false
 install: ./installViaTravis.sh
 script: ./buildViaTravis.sh


### PR DESCRIPTION
Per a comment on travis-ci/travis-ci#7884 Oracle JDK 7 is no longer supported by Travis because the installer is now only available to those with an Oracle Support account.