### PR TITLE
Autostart Cassandra from Priam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# Changelog
+
+## 2017/12/06: 3.1.45
+
+### Bugs
+* None
+
+### New Features
+* Priam will now automatically restart Cassandra if it fails. If you use
+  Priam to stop Cassandra (via the API) it will not automatically restart
+  Cassandra until a subsequent start via the API. You can control this
+  via the ``priam.remediate.dead.cassandra.rate`` configuration option. If
+  negative it disables auto-remediation, if zero it immediately auto-remediates
+  on any failure, and if a positive integer the auto-remediation waits for
+  that number of seconds between restarts. The default is 360 seconds
+  (one hour).
+
+### Breaking Changes
+* None
+
+## Previous changelog
 1.1
 - Support for cassandra 1.1
 - Support to publish cassandra metrics (TODO)

--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -51,7 +51,7 @@ public interface IConfiguration {
     public String getCassStopScript();
 
     /**
-     * @return double representing how often (in seconds) Priam should auto-remediate Cassandra process crash
+     * @return int representing how often (in seconds) Priam should auto-remediate Cassandra process crash
      * If zero, Priam will restart Cassandra whenever it notices it is crashed
      * If a positive number, Priam will restart cassandra no more than once in that number of seconds. For example a
      * value of 60 means that Priam will only restart Cassandra once per 60 seconds

--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -51,6 +51,15 @@ public interface IConfiguration {
     public String getCassStopScript();
 
     /**
+     * @return double representing how often (in seconds) Priam should auto-remediate Cassandra process crash
+     * If zero, Priam will restart Cassandra whenever it notices it is crashed
+     * If a positive number, Priam will restart cassandra no more than once in that number of seconds. For example a
+     * value of 60 means that Priam will only restart Cassandra once per 60 seconds
+     * If a negative number, Priam will not restart Cassandra due to crash at all
+     */
+    public int getRemediateDeadCassandraRate();
+
+    /**
      * Eg: 'my_backup' will result in all files stored under this dir/prefix
      *
      * @return Prefix that will be added to remote backup location

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/CassandraProcessManager.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/CassandraProcessManager.java
@@ -84,6 +84,8 @@ public class CassandraProcessManager implements ICassandraProcess {
         startCass.redirectErrorStream(true);
         logger.info("Start cmd: {}", startCass.command());
         logger.info("Start env: {}", startCass.environment());
+
+        instanceState.setShouldCassandraBeAlive(true);
         Process starter = startCass.start();
 
         logger.info("Starting cassandra server ....");
@@ -151,6 +153,8 @@ public class CassandraProcessManager implements ICassandraProcess {
         ProcessBuilder stopCass = new ProcessBuilder(command);
         stopCass.directory(new File("/"));
         stopCass.redirectErrorStream(true);
+
+        instanceState.setShouldCassandraBeAlive(false);
         Process stopper = stopCass.start();
         try {
             int code = stopper.waitFor();

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -86,6 +86,7 @@ public class PriamConfiguration implements IConfiguration {
     private static final String CONFIG_TARGET_KEYSPACE_NAME = PRIAM_PRE + ".target.keyspace";
     private static final String CONFIG_TARGET_COLUMN_FAMILY_NAME = PRIAM_PRE + ".target.columnfamily";
     private static final String CONFIG_CASS_MANUAL_START_ENABLE = PRIAM_PRE + ".cass.manual.start.enable";
+    private static final String CONFIG_REMEDIATE_DEAD_CASSANDRA_RATE_S = PRIAM_PRE + ".remediate.dead.cassandra.rate";
     private static final String CONFIG_CREATE_NEW_TOKEN_ENABLE = PRIAM_PRE + ".create.new.token.enable";
 
     // Backup and Restore
@@ -227,6 +228,8 @@ public class PriamConfiguration implements IConfiguration {
     private final int DEFAULT_HINTS_MAX_THREADS = 2; //default value from 1.2 yaml
     private final int DEFAULT_HINTS_THROTTLE_KB = 1024; //default value from 1.2 yaml
     private final String DEFAULT_INTERNODE_COMPRESSION = "all";  //default value from 1.2 yaml
+    // Default to restarting Cassandra automatically once per hour.
+    private final int DEFAULT_REMEDIATE_DEAD_CASSANDRA_RATE_S = 60 * 60;
 
     private static final String DEFAULT_RPC_SERVER_TYPE = "hsha";
     private static final int DEFAULT_RPC_MIN_THREADS = 16;
@@ -390,6 +393,11 @@ public class PriamConfiguration implements IConfiguration {
     @Override
     public String getCassStopScript() {
         return config.get(CONFIG_CASS_STOP_SCRIPT, DEFAULT_CASS_STOP_SCRIPT);
+    }
+
+    @Override
+    public int getRemediateDeadCassandraRate() {
+        return config.get(CONFIG_REMEDIATE_DEAD_CASSANDRA_RATE_S, DEFAULT_REMEDIATE_DEAD_CASSANDRA_RATE_S);
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/health/InstanceState.java
+++ b/priam/src/main/java/com/netflix/priam/health/InstanceState.java
@@ -52,6 +52,7 @@ public class InstanceState {
 
     //Cassandra process status
     private final AtomicBoolean isCassandraProcessAlive = new AtomicBoolean(false);
+    private final AtomicBoolean shouldCassandraBeAlive = new AtomicBoolean(false);
     private final AtomicBoolean isGossipActive = new AtomicBoolean(false);
     private final AtomicBoolean isThriftActive = new AtomicBoolean(false);
     private final AtomicBoolean isNativeTransportActive = new AtomicBoolean(false);
@@ -118,6 +119,14 @@ public class InstanceState {
     public void setCassandraProcessAlive(boolean isSideCarProcessAlive) {
         this.isCassandraProcessAlive.set(isSideCarProcessAlive);
         setHealthy();
+    }
+
+    public boolean shouldCassandraBeAlive() {
+        return shouldCassandraBeAlive.get();
+    }
+
+    public void setShouldCassandraBeAlive(boolean shouldCassandraBeAlive) {
+        this.shouldCassandraBeAlive.set(shouldCassandraBeAlive);
     }
 
     /* Boostrap */

--- a/priam/src/main/java/com/netflix/priam/utils/CassandraMonitor.java
+++ b/priam/src/main/java/com/netflix/priam/utils/CassandraMonitor.java
@@ -109,8 +109,8 @@ public class CassandraMonitor extends Task {
         try {
             int rate = config.getRemediateDeadCassandraRate();
             if (rate >= 0) {
-                if (rate == 0 || startRateLimiter.tryAcquire(rate)) {
-                    if (instanceState.shouldCassandraBeAlive() && !instanceState.isCassandraProcessAlive()) {
+                if (instanceState.shouldCassandraBeAlive() && !instanceState.isCassandraProcessAlive()) {
+                    if (rate == 0 || startRateLimiter.tryAcquire(rate)) {
                         cassProcess.start(true);
                     }
                 }

--- a/priam/src/main/java/com/netflix/priam/utils/CassandraMonitor.java
+++ b/priam/src/main/java/com/netflix/priam/utils/CassandraMonitor.java
@@ -16,8 +16,10 @@
  */
 package com.netflix.priam.utils;
 
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.netflix.priam.ICassandraProcess;
 import com.netflix.priam.IConfiguration;
 import com.netflix.priam.health.InstanceState;
 import com.netflix.priam.scheduler.SimpleTimer;
@@ -30,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -43,11 +46,15 @@ public class CassandraMonitor extends Task {
     private static final Logger logger = LoggerFactory.getLogger(CassandraMonitor.class);
     private static final AtomicBoolean isCassandraStarted = new AtomicBoolean(false);
     private InstanceState instanceState;
+    private ICassandraProcess cassProcess;
+    private RateLimiter startRateLimiter;
 
     @Inject
-    protected CassandraMonitor(IConfiguration config, InstanceState instanceState) {
+    protected CassandraMonitor(IConfiguration config, InstanceState instanceState, ICassandraProcess cassProcess) {
         super(config);
         this.instanceState = instanceState;
+        this.cassProcess = cassProcess;
+        startRateLimiter = RateLimiter.create(1.0);
     }
 
     @Override
@@ -73,6 +80,7 @@ public class CassandraMonitor extends Task {
             if (line != null) {
                 //Setting cassandra flag to true
                 instanceState.setCassandraProcessAlive(true);
+                instanceState.setShouldCassandraBeAlive(true);
                 isCassandraStarted.set(true);
                 NodeProbe bean = JMXNodeTool.instance(this.config);
                 instanceState.setIsGossipActive(bean.isGossipRunning());
@@ -96,6 +104,19 @@ public class CassandraMonitor extends Task {
 
             if (input != null)
                 IOUtils.closeQuietly(input);
+        }
+
+        try {
+            int rate = config.getRemediateDeadCassandraRate();
+            if (rate >= 0) {
+                if (rate == 0 || startRateLimiter.tryAcquire(rate)) {
+                    if (instanceState.shouldCassandraBeAlive() && !instanceState.isCassandraProcessAlive()) {
+                        cassProcess.start(true);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            logger.warn("Failed to remediate dead Cassandra", e);
         }
     }
 

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -338,6 +338,11 @@ public class FakeConfiguration implements IConfiguration {
     }
 
     @Override
+    public int getRemediateDeadCassandraRate() {
+        return 1;
+    }
+
+    @Override
     public int getStoragePort() {
         return 7101;
     }

--- a/priam/src/test/java/com/netflix/priam/utils/TestCassandraMonitor.java
+++ b/priam/src/test/java/com/netflix/priam/utils/TestCassandraMonitor.java
@@ -19,26 +19,41 @@ package com.netflix.priam.utils;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.netflix.priam.ICassandraProcess;
+import com.netflix.priam.IConfiguration;
 import com.netflix.priam.backup.BRTestModule;
-import junit.framework.Assert;
+import com.netflix.priam.health.InstanceState;
+import org.junit.Assert;
+import mockit.*;
+import org.apache.cassandra.tools.NodeProbe;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
 /**
  * Created by aagrawal on 7/18/17.
  */
 public class TestCassandraMonitor {
+    private static CassandraMonitor monitor;
+    private IConfiguration config;
+    private InstanceState instanceState;
 
-    private Injector injector;
-    private CassandraMonitor monitor;
+    @Mocked
+    private Process mockProcess;
+    @Mocked
+    private NodeProbe nodeProbe;
+    @Mocked
+    private ICassandraProcess cassProcess;
 
     @Before
     public void setUp() {
-        if (injector == null)
-            injector = Guice.createInjector(new BRTestModule());
-
+        Injector injector = Guice.createInjector(new BRTestModule());
+        config = injector.getInstance(IConfiguration.class);
+        instanceState = injector.getInstance(InstanceState.class);
         if (monitor == null)
-            monitor = injector.getInstance(CassandraMonitor.class);
+            monitor = new CassandraMonitor(config, instanceState, cassProcess);
     }
 
     @Test
@@ -53,4 +68,69 @@ public class TestCassandraMonitor {
         Assert.assertFalse(monitor.isCassadraStarted());
     }
 
+    @Test
+    public void testNoAutoRemediation() throws Exception {
+        new MockUp<JMXNodeTool>()
+        {
+            @Mock
+            NodeProbe instance(IConfiguration config) {
+                return nodeProbe;
+            }
+        };
+        final InputStream mockOutput = new ByteArrayInputStream("a process".getBytes());
+        new Expectations() {{
+            mockProcess.getInputStream(); result= mockOutput;
+            nodeProbe.isGossipRunning(); result=true;
+            nodeProbe.isNativeTransportRunning(); result=true;
+            nodeProbe.isThriftServerRunning(); result=true;
+        }};
+        // Mock out the ps call
+        final Runtime r = Runtime.getRuntime();
+        String[] cmd = { "/bin/sh", "-c", "ps -ef |grep -v -P \"\\sgrep\\s\" | grep " + config.getCassProcessName()};
+        new Expectations(r) {
+            {
+                r.exec(cmd); result=mockProcess;
+            }
+        };
+        instanceState.setShouldCassandraBeAlive(false);
+        instanceState.setCassandraProcessAlive(false);
+
+        monitor.execute();
+
+        Assert.assertTrue(instanceState.shouldCassandraBeAlive());
+        Assert.assertTrue(instanceState.isCassandraProcessAlive());
+        new Verifications() {
+            { cassProcess.start(anyBoolean); times=0; }
+        };
+    }
+
+    @Test
+    public void testAutoRemediationRateLimit() throws Exception {
+        final InputStream mockOutput = new ByteArrayInputStream("".getBytes());
+        instanceState.setShouldCassandraBeAlive(true);
+        new Expectations() {{
+            // 6 calls to execute should = 12 calls to getInputStream();
+            mockProcess.getInputStream(); result=mockOutput; times=12;
+            cassProcess.start(true); minTimes=2; maxTimes=4;
+        }};
+        // Mock out the ps call
+        final Runtime r = Runtime.getRuntime();
+        String[] cmd = { "/bin/sh", "-c", "ps -ef |grep -v -P \"\\sgrep\\s\" | grep " + config.getCassProcessName()};
+        new Expectations(r) {
+            {
+                r.exec(cmd); result=mockProcess;
+            }
+        };
+        // Sleep ahead to ensure we have permits in the rate limiter
+        Thread.sleep(1500);
+        monitor.execute();
+        monitor.execute();
+        Thread.sleep(1500);
+        monitor.execute();
+        monitor.execute();
+        monitor.execute();
+        monitor.execute();
+
+        new Verifications() {};
+    }
 }


### PR DESCRIPTION
I took a whack at having Priam auto-remediate a dead Cassandra. By default the starts are limited to once per hour.

I'm not sure the best way to test this, I tried testing it with Mocks but the rate limiter makes it tough to reliably test (threads, time, etc ...). Do we have a better way to do functional tests?