### PR TITLE
excluding module with duplicate slf4j binding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,11 @@ allprojects {
     repositories {
         jcenter()
     }
+    
+    configurations {
+      all*.exclude group: 'ch.qos.logback', module: 'logback-classic'
+      all*.exclude group: 'ch.qos.logback', module: 'logback-core'
+    }
 
     dependencies {
       compile 'org.apache.commons:commons-lang3:3.5'


### PR DESCRIPTION
I was seeing duplicate slf4j bindings in the logs, causing the log4j one not to be picked up sometimes:
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/zmarois/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-log4j12/1.7.25/110cefe2df103412849d72ef7a67e4e91e4266b4/slf4j-log4j12-1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/zmarois/.gradle/caches/modules-2/files-2.1/ch.qos.logback/logback-classic/1.1.2/b316e9737eea25e9ddd6d88eaeee76878045c6b2/logback-classic-1.1.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
```

I believe this is the cause for issue https://github.com/Netflix/Priam/issues/597