### PR TITLE
Fix bug in autostart shouldCassandraBeAlive logic

### DIFF
--- a/priam/src/main/java/com/netflix/priam/utils/CassandraMonitor.java
+++ b/priam/src/main/java/com/netflix/priam/utils/CassandraMonitor.java
@@ -80,7 +80,6 @@ public class CassandraMonitor extends Task {
             if (line != null) {
                 //Setting cassandra flag to true
                 instanceState.setCassandraProcessAlive(true);
-                instanceState.setShouldCassandraBeAlive(true);
                 isCassandraStarted.set(true);
                 NodeProbe bean = JMXNodeTool.instance(this.config);
                 instanceState.setIsGossipActive(bean.isGossipRunning());
@@ -108,7 +107,7 @@ public class CassandraMonitor extends Task {
 
         try {
             int rate = config.getRemediateDeadCassandraRate();
-            if (rate >= 0) {
+            if (rate >= 0 && !config.doesCassandraStartManually()) {
                 if (instanceState.shouldCassandraBeAlive() && !instanceState.isCassandraProcessAlive()) {
                     if (rate == 0 || startRateLimiter.tryAcquire(rate)) {
                         cassProcess.start(true);

--- a/priam/src/test/java/com/netflix/priam/utils/TestCassandraMonitor.java
+++ b/priam/src/test/java/com/netflix/priam/utils/TestCassandraMonitor.java
@@ -37,8 +37,8 @@ import java.io.InputStream;
  */
 public class TestCassandraMonitor {
     private static CassandraMonitor monitor;
+    private static InstanceState instanceState;
     private IConfiguration config;
-    private InstanceState instanceState;
 
     @Mocked
     private Process mockProcess;
@@ -51,7 +51,8 @@ public class TestCassandraMonitor {
     public void setUp() {
         Injector injector = Guice.createInjector(new BRTestModule());
         config = injector.getInstance(IConfiguration.class);
-        instanceState = injector.getInstance(InstanceState.class);
+        if (instanceState == null)
+            instanceState = injector.getInstance(InstanceState.class);
         if (monitor == null)
             monitor = new CassandraMonitor(config, instanceState, cassProcess);
     }
@@ -97,7 +98,7 @@ public class TestCassandraMonitor {
 
         monitor.execute();
 
-        Assert.assertTrue(instanceState.shouldCassandraBeAlive());
+        Assert.assertTrue(!instanceState.shouldCassandraBeAlive());
         Assert.assertTrue(instanceState.isCassandraProcessAlive());
         new Verifications() {
             { cassProcess.start(anyBoolean); times=0; }


### PR DESCRIPTION
The monitoring thread runs every 10s, so it can race with the stop API. Just always go through start.

Either we are restoring, in which case cassProcess.start gets called at the end of the restore, or we are starting normally in which case it gets called in PriamServer.