### PR TITLE
Running both sdb clients in the same region

### DIFF
--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -296,6 +296,11 @@ public interface IConfiguration {
     public String getRestoreSnapshot();
 
     /**
+     * @return Get the region to connect to SDB for instance identity
+     */
+    public String getSDBInstanceIdentityRegion();
+
+    /**
      * @return Get the Data Center name (or region for AWS)
      */
     public String getDC();

--- a/priam/src/main/java/com/netflix/priam/aws/SDBInstanceData.java
+++ b/priam/src/main/java/com/netflix/priam/aws/SDBInstanceData.java
@@ -17,6 +17,7 @@
 package com.netflix.priam.aws;
 
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.simpledb.AmazonSimpleDB;
 import com.amazonaws.services.simpledb.AmazonSimpleDBClient;
 import com.amazonaws.services.simpledb.model.*;
 import com.google.inject.Inject;
@@ -62,7 +63,7 @@ public class SDBInstanceData {
      * @return the node with the given {@code id}, or {@code null} if no such node exists
      */
     public PriamInstance getInstance(String app, String dc, int id) {
-        AmazonSimpleDBClient simpleDBClient = getSimpleDBClient();
+        AmazonSimpleDB simpleDBClient = getSimpleDBClient();
         SelectRequest request = new SelectRequest(String.format(INSTANCE_QUERY, app, dc, id));
         SelectResult result = simpleDBClient.select(request);
         if (result.getItems().size() == 0)
@@ -77,7 +78,7 @@ public class SDBInstanceData {
      * @return the set of all instances in the given {@code app}
      */
     public Set<PriamInstance> getAllIds(String app) {
-        AmazonSimpleDBClient simpleDBClient = getSimpleDBClient();
+        AmazonSimpleDB simpleDBClient = getSimpleDBClient();
         Set<PriamInstance> inslist = new HashSet<PriamInstance>();
         String nextToken = null;
         do {
@@ -101,7 +102,7 @@ public class SDBInstanceData {
      * @throws AmazonServiceException
      */
     public void createInstance(PriamInstance instance) throws AmazonServiceException {
-        AmazonSimpleDBClient simpleDBClient = getSimpleDBClient();
+        AmazonSimpleDB simpleDBClient = getSimpleDBClient();
         PutAttributesRequest putReq = new PutAttributesRequest(DOMAIN, getKey(instance), createAttributesToRegister(instance));
         simpleDBClient.putAttributes(putReq);
     }
@@ -113,7 +114,7 @@ public class SDBInstanceData {
      * @throws AmazonServiceException
      */
     public void registerInstance(PriamInstance instance) throws AmazonServiceException {
-        AmazonSimpleDBClient simpleDBClient = getSimpleDBClient();
+        AmazonSimpleDB simpleDBClient = getSimpleDBClient();
         PutAttributesRequest putReq = new PutAttributesRequest(DOMAIN, getKey(instance), createAttributesToRegister(instance));
         UpdateCondition expected = new UpdateCondition();
         expected.setName(Attributes.INSTANCE_ID);
@@ -129,7 +130,7 @@ public class SDBInstanceData {
      * @throws AmazonServiceException
      */
     public void deregisterInstance(PriamInstance instance) throws AmazonServiceException {
-        AmazonSimpleDBClient simpleDBClient = getSimpleDBClient();
+        AmazonSimpleDB simpleDBClient = getSimpleDBClient();
         DeleteAttributesRequest delReq = new DeleteAttributesRequest(DOMAIN, getKey(instance), createAttributesToDeRegister(instance));
         simpleDBClient.deleteAttributes(delReq);
     }
@@ -200,8 +201,8 @@ public class SDBInstanceData {
         return instance.getApp() + "_" + instance.getDC() + "_" + instance.getId();
     }
 
-    private AmazonSimpleDBClient getSimpleDBClient() {
+    private AmazonSimpleDB getSimpleDBClient() {
         //Create per request
-        return new AmazonSimpleDBClient(provider.getAwsCredentialProvider());
+        return AmazonSimpleDBClient.builder().withCredentials(provider.getAwsCredentialProvider()).build();
     }
 }

--- a/priam/src/main/java/com/netflix/priam/aws/SDBInstanceData.java
+++ b/priam/src/main/java/com/netflix/priam/aws/SDBInstanceData.java
@@ -22,6 +22,7 @@ import com.amazonaws.services.simpledb.AmazonSimpleDBClient;
 import com.amazonaws.services.simpledb.model.*;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.netflix.priam.IConfiguration;
 import com.netflix.priam.ICredential;
 import com.netflix.priam.identity.PriamInstance;
 
@@ -49,10 +50,12 @@ public class SDBInstanceData {
     public static final String INSTANCE_QUERY = "select * from " + DOMAIN + " where " + Attributes.APP_ID + "='%s' and " + Attributes.LOCATION + "='%s' and " + Attributes.ID + "='%d'";
 
     private final ICredential provider;
+    private final IConfiguration configuration;
 
     @Inject
-    public SDBInstanceData(ICredential provider) {
+    public SDBInstanceData(ICredential provider, IConfiguration configuration) {
         this.provider = provider;
+        this.configuration = configuration;
     }
 
     /**
@@ -203,6 +206,6 @@ public class SDBInstanceData {
 
     private AmazonSimpleDB getSimpleDBClient() {
         //Create per request
-        return AmazonSimpleDBClient.builder().withCredentials(provider.getAwsCredentialProvider()).build();
+        return AmazonSimpleDBClient.builder().withCredentials(provider.getAwsCredentialProvider()).withRegion(configuration.getSDBInstanceIdentityRegion()).build();
     }
 }

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -171,6 +171,7 @@ public class PriamConfiguration implements IConfiguration {
     private static final String CONFIG_ASG_NAME = PRIAM_PRE + ".az.asgname";
     private static final String CONFIG_SIBLING_ASG_NAMES = PRIAM_PRE + ".az.sibling.asgnames";
     private static final String CONFIG_REGION_NAME = PRIAM_PRE + ".az.region";
+    private static final String SDB_INSTANCE_INDENTITY_REGION_NAME = PRIAM_PRE + ".sdb.instanceIdentity.region";
     private static final String CONFIG_ACL_GROUP_NAME = PRIAM_PRE + ".acl.groupname";
     private final String LOCAL_IP = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/local-ipv4").trim();
     private static String ASG_NAME = System.getenv("ASG_NAME");
@@ -632,6 +633,11 @@ public class PriamConfiguration implements IConfiguration {
     @Override
     public boolean isRestoreEncrypted(){
         return config.get(PRIAM_PRE + ".encrypted.restore.enabled", false);
+    }
+
+    @Override
+    public String getSDBInstanceIdentityRegion() {
+        return config.get(SDB_INSTANCE_INDENTITY_REGION_NAME, "us-east-1");
     }
 
     @Override

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -224,6 +224,13 @@ public class FakeConfiguration implements IConfiguration
     }
 
     @Override
+    public String getSDBInstanceIdentityRegion()
+    {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
     public String getDC()
     {
         // TODO Auto-generated method stub


### PR DESCRIPTION
Uses the same (and not-deprecated) client builder as the sdb client for PriamProperties, which makes them run in the same region

@arunagrawal84 Do you want this completely as-is, or do you want it to be configurable and default to us-east-1, per your docs?

I haven't found the AWS docs on how the two builders work in this regard, but my experience was that new AmazonSimpleDBClient creates a client for us-east-1, but AmazonSimpleDBClient.builder() creates a client in the region my instances are in (I am using IAMCredential).

I just worry about breaking existing clusters.