### PR TITLE
Just use timestamps for autostart

### DIFF
--- a/priam/src/main/java/com/netflix/priam/defaultimpl/CassandraProcessManager.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/CassandraProcessManager.java
@@ -88,6 +88,7 @@ public class CassandraProcessManager implements ICassandraProcess {
         logger.info("Start cmd: {}", startCass.command());
         logger.info("Start env: {}", startCass.environment());
 
+        instanceState.markLastStartTime();
         instanceState.setShouldCassandraBeAlive(true);
         Process starter = startCass.start();
 

--- a/priam/src/main/java/com/netflix/priam/health/InstanceState.java
+++ b/priam/src/main/java/com/netflix/priam/health/InstanceState.java
@@ -20,15 +20,13 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.priam.backup.BackupMetadata;
 import com.netflix.priam.backup.Status;
-import com.netflix.priam.utils.DateUtil;
 import com.netflix.priam.utils.GsonJsonSerializer;
-import org.codehaus.jettison.json.JSONException;
-import org.codehaus.jettison.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.LocalDateTime;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Contains the state of the health of processed managed by Priam, and
@@ -53,6 +51,7 @@ public class InstanceState {
     //Cassandra process status
     private final AtomicBoolean isCassandraProcessAlive = new AtomicBoolean(false);
     private final AtomicBoolean shouldCassandraBeAlive = new AtomicBoolean(false);
+    private final AtomicLong lastStartTime = new AtomicLong(Long.MAX_VALUE);
     private final AtomicBoolean isGossipActive = new AtomicBoolean(false);
     private final AtomicBoolean isThriftActive = new AtomicBoolean(false);
     private final AtomicBoolean isNativeTransportActive = new AtomicBoolean(false);
@@ -127,6 +126,14 @@ public class InstanceState {
 
     public void setShouldCassandraBeAlive(boolean shouldCassandraBeAlive) {
         this.shouldCassandraBeAlive.set(shouldCassandraBeAlive);
+    }
+
+    public void markLastStartTime() {
+        this.lastStartTime.set(System.currentTimeMillis());
+    }
+
+    public long getLastStartTime() {
+        return this.lastStartTime.get();
     }
 
     /* Boostrap */

--- a/priam/src/main/java/com/netflix/priam/utils/CassandraMonitor.java
+++ b/priam/src/main/java/com/netflix/priam/utils/CassandraMonitor.java
@@ -16,7 +16,6 @@
  */
 package com.netflix.priam.utils;
 
-import com.google.common.util.concurrent.RateLimiter;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.priam.ICassandraProcess;
@@ -48,7 +47,6 @@ public class CassandraMonitor extends Task {
     private static final AtomicBoolean isCassandraStarted = new AtomicBoolean(false);
     private InstanceState instanceState;
     private ICassandraProcess cassProcess;
-    private RateLimiter startRateLimiter;
     private ICassMonitorMetrics cassMonitorMetrics;
 
     @Inject
@@ -56,7 +54,6 @@ public class CassandraMonitor extends Task {
         super(config);
         this.instanceState = instanceState;
         this.cassProcess = cassProcess;
-        startRateLimiter = RateLimiter.create(1.0);
         this.cassMonitorMetrics = cassMonitorMetrics;
     }
 
@@ -112,9 +109,11 @@ public class CassandraMonitor extends Task {
             int rate = config.getRemediateDeadCassandraRate();
             if (rate >= 0 && !config.doesCassandraStartManually()) {
                 if (instanceState.shouldCassandraBeAlive() && !instanceState.isCassandraProcessAlive()) {
-                    if (rate == 0 || startRateLimiter.tryAcquire(rate)) {
+                    long msNow = System.currentTimeMillis();
+                    if (rate == 0 || ((instanceState.getLastStartTime() + rate * 1000) < msNow)) {
                         cassMonitorMetrics.incCassAutoStart();
                         cassProcess.start(true);
+                        instanceState.markLastStartTime();
                     }
                 }
             }

--- a/priam/src/test/java/com/netflix/priam/utils/TestCassandraMonitor.java
+++ b/priam/src/test/java/com/netflix/priam/utils/TestCassandraMonitor.java
@@ -114,10 +114,11 @@ public class TestCassandraMonitor {
     public void testAutoRemediationRateLimit() throws Exception {
         final InputStream mockOutput = new ByteArrayInputStream("".getBytes());
         instanceState.setShouldCassandraBeAlive(true);
+        instanceState.markLastStartTime();
         new Expectations() {{
             // 6 calls to execute should = 12 calls to getInputStream();
             mockProcess.getInputStream(); result=mockOutput; times=12;
-            cassProcess.start(true); minTimes=2; maxTimes=4;
+            cassProcess.start(true); times=2;
         }};
         // Mock out the ps call
         final Runtime r = Runtime.getRuntime();
@@ -128,11 +129,11 @@ public class TestCassandraMonitor {
             }
         };
         // Sleep ahead to ensure we have permits in the rate limiter
-        Thread.sleep(1500);
-        monitor.execute();
         monitor.execute();
         Thread.sleep(1500);
         monitor.execute();
+        monitor.execute();
+        Thread.sleep(1500);
         monitor.execute();
         monitor.execute();
         monitor.execute();


### PR DESCRIPTION
Refactor of the autostart code to use timestamps instead of rate limiters. This is

1. Easier to understand
2. More closely implements our desire to not start cassandra until a full interval after we start it. For example when a node is first coming up and we run start we don't want auto-start running start 10s later.