### PR TITLE
Add graceful stopping option

### DIFF
--- a/priam/src/main/java/com/netflix/priam/ICassandraProcess.java
+++ b/priam/src/main/java/com/netflix/priam/ICassandraProcess.java
@@ -29,5 +29,5 @@ import java.io.IOException;
 public interface ICassandraProcess {
     void start(boolean join_ring) throws IOException;
 
-    void stop() throws IOException;
+    void stop(boolean force) throws IOException;
 }

--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -53,7 +53,7 @@ public interface IConfiguration {
     /**
      * @return int representing how many seconds Priam should fail healthchecks for before gracefully draining (nodetool drain)
      * cassandra prior to stop. If this number is negative then no draining occurs and Priam immediately stops Cassanddra
-     * using the provided stop script. If this number is positive then Priam will fail healthchecks for this number of
+     * using the provided stop script. If this number is >= 0 then Priam will fail healthchecks for this number of
      * seconds before gracefully draining cassandra (nodetool drain) and stopping cassandra with the stop script.
      */
     public int getGracefulDrainHealthWaitSeconds();

--- a/priam/src/main/java/com/netflix/priam/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/IConfiguration.java
@@ -51,6 +51,14 @@ public interface IConfiguration {
     public String getCassStopScript();
 
     /**
+     * @return int representing how many seconds Priam should fail healthchecks for before gracefully draining (nodetool drain)
+     * cassandra prior to stop. If this number is negative then no draining occurs and Priam immediately stops Cassanddra
+     * using the provided stop script. If this number is positive then Priam will fail healthchecks for this number of
+     * seconds before gracefully draining cassandra (nodetool drain) and stopping cassandra with the stop script.
+     */
+    public int getGracefulDrainHealthWaitSeconds();
+
+    /**
      * @return int representing how often (in seconds) Priam should auto-remediate Cassandra process crash
      * If zero, Priam will restart Cassandra whenever it notices it is crashed
      * If a positive number, Priam will restart cassandra no more than once in that number of seconds. For example a

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/CassandraProcessManager.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/CassandraProcessManager.java
@@ -162,7 +162,7 @@ public class CassandraProcessManager implements ICassandraProcess {
         stopCass.redirectErrorStream(true);
 
         instanceState.setShouldCassandraBeAlive(false);
-        if (!force && config.getGracefulDrainHealthWaitSeconds() > 0) {
+        if (!force && config.getGracefulDrainHealthWaitSeconds() >= 0) {
             ExecutorService executor = Executors.newSingleThreadExecutor();
             Future drainFuture = executor.submit(() -> {
                 // As the node has been marked as shutting down above in setShouldCassandraBeAlive, we wait this

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -389,6 +389,11 @@ public class PriamConfiguration implements IConfiguration {
     }
 
     @Override
+    public int getGracefulDrainHealthWaitSeconds() {
+        return 0;
+    }
+
+    @Override
     public int getRemediateDeadCassandraRate() {
         return config.get(CONFIG_REMEDIATE_DEAD_CASSANDRA_RATE_S, DEFAULT_REMEDIATE_DEAD_CASSANDRA_RATE_S);
     }

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/PriamConfiguration.java
@@ -390,7 +390,7 @@ public class PriamConfiguration implements IConfiguration {
 
     @Override
     public int getGracefulDrainHealthWaitSeconds() {
-        return 0;
+        return -1;
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/resources/CassandraAdmin.java
+++ b/priam/src/main/java/com/netflix/priam/resources/CassandraAdmin.java
@@ -81,8 +81,8 @@ public class CassandraAdmin {
 
     @GET
     @Path("/stop")
-    public Response cassStop() throws IOException, InterruptedException, JSONException {
-        cassProcess.stop();
+    public Response cassStop(@DefaultValue("false") @QueryParam("force") boolean force) throws IOException, InterruptedException, JSONException {
+        cassProcess.stop(force);
         return Response.ok(REST_SUCCESS, MediaType.APPLICATION_JSON).build();
     }
 

--- a/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
@@ -139,7 +139,7 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy{
 
     private final void stopCassProcess() throws IOException {
         if (config.getRestoreKeySpaces().size() == 0)
-            cassProcess.stop();
+            cassProcess.stop(true);
     }
 
     private final String getRestorePrefix() {

--- a/priam/src/main/java/com/netflix/priam/utils/CassandraMonitor.java
+++ b/priam/src/main/java/com/netflix/priam/utils/CassandraMonitor.java
@@ -110,10 +110,10 @@ public class CassandraMonitor extends Task {
             if (rate >= 0 && !config.doesCassandraStartManually()) {
                 if (instanceState.shouldCassandraBeAlive() && !instanceState.isCassandraProcessAlive()) {
                     long msNow = System.currentTimeMillis();
-                    if (rate == 0 || ((instanceState.getLastStartTime() + rate * 1000) < msNow)) {
+                    if (rate == 0 || ((instanceState.getLastAttemptedStartTime() + rate * 1000) < msNow)) {
                         cassMonitorMetrics.incCassAutoStart();
                         cassProcess.start(true);
-                        instanceState.markLastStartTime();
+                        instanceState.markLastAttemptedStartTime();
                     }
                 }
             }

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -357,7 +357,7 @@ public class FakeConfiguration implements IConfiguration {
 
     @Override
     public int getGracefulDrainHealthWaitSeconds() {
-        return 0;
+        return -1;
     }
 
     @Override

--- a/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/FakeConfiguration.java
@@ -356,6 +356,11 @@ public class FakeConfiguration implements IConfiguration {
     }
 
     @Override
+    public int getGracefulDrainHealthWaitSeconds() {
+        return 0;
+    }
+
+    @Override
     public int getRemediateDeadCassandraRate() {
         return 1;
     }

--- a/priam/src/test/java/com/netflix/priam/defaultimpl/FakeCassandraProcess.java
+++ b/priam/src/test/java/com/netflix/priam/defaultimpl/FakeCassandraProcess.java
@@ -15,7 +15,7 @@ public class FakeCassandraProcess implements ICassandraProcess {
     }
 
     @Override
-    public void stop() throws IOException {
+    public void stop(boolean force) throws IOException {
         //do nothing
     }
 }

--- a/priam/src/test/java/com/netflix/priam/health/TestInstanceStatus.java
+++ b/priam/src/test/java/com/netflix/priam/health/TestInstanceStatus.java
@@ -25,21 +25,23 @@ public class TestInstanceStatus {
     @Test
     public void testHealth(){
         //Verify good health.
-        Assert.assertTrue(testInstanceState.setParams(false, true, true, true, true, true, true).isHealthy());
-        Assert.assertTrue(testInstanceState.setParams(false,true, true, true, true, false, true).isHealthy());
-        Assert.assertTrue(testInstanceState.setParams(false,true, true, true, false, true, true).isHealthy());
-        Assert.assertTrue(testInstanceState.setParams(true,false, true, true, false, true, true).isHealthy());
-        Assert.assertTrue(testInstanceState.setParams(true,true, false, true, true, true, true).isHealthy());
-        Assert.assertTrue(testInstanceState.setParams(true,true, true, false, true, true, true).isHealthy());
-        Assert.assertTrue(testInstanceState.setParams(true,true, true, true, true, true, false).isHealthy());
-        Assert.assertTrue(testInstanceState.setParams(true,true, true, true, false, false, true).isHealthy());
+        Assert.assertTrue(testInstanceState.setParams(false, true, true, true, true, true, true, true).isHealthy());
+        Assert.assertTrue(testInstanceState.setParams(false,true, true, true, true, false, true, true).isHealthy());
+        Assert.assertTrue(testInstanceState.setParams(false,true, true, true, false, true, true, true).isHealthy());
+        Assert.assertTrue(testInstanceState.setParams(true,false, true, true, false, true, true, true).isHealthy());
+        Assert.assertTrue(testInstanceState.setParams(true,true, false, true, true, true, true, true).isHealthy());
+        Assert.assertTrue(testInstanceState.setParams(true,true, true, false, true, true, true, true).isHealthy());
+        Assert.assertTrue(testInstanceState.setParams(true,true, true, true, true, true, false, true).isHealthy());
+        Assert.assertTrue(testInstanceState.setParams(true,true, true, true, false, false, true, true).isHealthy());
 
         //Negative health case scenarios.
-        Assert.assertFalse(testInstanceState.setParams(false,false, true, true, false, true, true).isHealthy());
-        Assert.assertFalse(testInstanceState.setParams(false,true, false, true, true, true, true).isHealthy());
-        Assert.assertFalse(testInstanceState.setParams(false,true, true, false, true, true, true).isHealthy());
-        Assert.assertFalse(testInstanceState.setParams(false,true, true, true, true, true, false).isHealthy());
-        Assert.assertFalse(testInstanceState.setParams(false,true, true, true, false, false, true).isHealthy());
+        Assert.assertFalse(testInstanceState.setParams(false,false, true, true, false, true, true, true).isHealthy());
+        Assert.assertFalse(testInstanceState.setParams(false,true, false, true, true, true, true, true).isHealthy());
+        Assert.assertFalse(testInstanceState.setParams(false,true, true, false, true, true, true, true).isHealthy());
+        Assert.assertFalse(testInstanceState.setParams(false,true, true, true, true, true, false, true).isHealthy());
+        Assert.assertFalse(testInstanceState.setParams(false,true, true, true, false, false, true, true).isHealthy());
+        Assert.assertFalse(testInstanceState.setParams(false,true, true, true, false, false, true, false).isHealthy());
+
     }
 
     private class TestInstanceState{
@@ -49,13 +51,14 @@ public class TestInstanceStatus {
             this.instanceState = instanceState1;
         }
 
-        InstanceState setParams(boolean isRestoring, boolean isYmlWritten, boolean isCassandraProcessAlive, boolean isGossipEnabled, boolean isThriftEnabled, boolean isNativeEnabled, boolean isRequiredDirectoriesExist){
+        InstanceState setParams(boolean isRestoring, boolean isYmlWritten, boolean isCassandraProcessAlive, boolean isGossipEnabled, boolean isThriftEnabled, boolean isNativeEnabled, boolean isRequiredDirectoriesExist, boolean shouldCassandraBeAlive){
             instanceState.setYmlWritten(isYmlWritten);
             instanceState.setCassandraProcessAlive(isCassandraProcessAlive);
             instanceState.setIsNativeTransportActive(isNativeEnabled);
             instanceState.setIsThriftActive(isThriftEnabled);
             instanceState.setIsGossipActive(isGossipEnabled);
             instanceState.setIsRequiredDirectoriesExist(isRequiredDirectoriesExist);
+            instanceState.setShouldCassandraBeAlive(shouldCassandraBeAlive);
 
             if (isRestoring)
                 instanceState.setRestoreStatus(Status.STARTED);

--- a/priam/src/test/java/com/netflix/priam/utils/TestCassandraMonitor.java
+++ b/priam/src/test/java/com/netflix/priam/utils/TestCassandraMonitor.java
@@ -114,7 +114,7 @@ public class TestCassandraMonitor {
     public void testAutoRemediationRateLimit() throws Exception {
         final InputStream mockOutput = new ByteArrayInputStream("".getBytes());
         instanceState.setShouldCassandraBeAlive(true);
-        instanceState.markLastStartTime();
+        instanceState.markLastAttemptedStartTime();
         new Expectations() {{
             // 6 calls to execute should = 12 calls to getInputStream();
             mockProcess.getInputStream(); result=mockOutput; times=12;


### PR DESCRIPTION
Introduces a new configuration option gracefulDrainHealthWaitSeconds
which allows Priam controlled stops to fail healthchecks for a
configurable number of seconds before draining (via nodetool drain) and
stopping Cassandra (via the stop script). For backwards compatibility
this functionality is _disabled_ by default. If you want it change the
configuration to a positive number.