### PR TITLE
Mark snapshot as a failure if there is an issue with uploading a file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+## 2018/06/12: 3.11.21
+### Bug Fixes
+* (#679) Mark snapshot as a failure if there is an issue with uploading a file. This is to ensure we fail-fast. This is in contrast to previous behavior where snapshot would "ignore" any failures in the upload of a file and mark snapshot as "success". 
+         Since it was not truly a "success" marking that as "failure" is the right thing to do. Also, meta.json should really be uploaded in case of "success" and not in case of "failure" as the presence of "meta.json" marks the backup as successful.
+         The case for fail-fast: In a scenario where we had an issue say at the start of the backup, it makes more sense to fail-fast then to keep uploading other files (and waste bandwidth and use backup resources). The remediation step for backup failure is anyways to take a full snapshot again.
+
+## 2018/06/07: 3.11.20
+### Bug Fixes
+* (#678) Change the default location of backup status and downloaded meta.json as part of backup verification
 
 ## 2018/04/05: 3.11.19
 

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
@@ -100,7 +100,9 @@ public abstract class AbstractBackup extends Task implements EventGenerator<Back
 
                 addToRemotePath(abp.getRemotePath());
             } catch (Exception e) {
-                logger.error("Failed to upload local file {} within CF {}. Ignoring to continue with rest of backup.", file.getCanonicalFile(), parent.getAbsolutePath(), e);
+                //Throw exception to the caller. This will allow them to take appropriate decision.
+                logger.error("Failed to upload local file {} within CF {}.", file.getCanonicalFile(), parent.getAbsolutePath(), e);
+                throw e;
             }
         }
         return bps;

--- a/priam/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
@@ -97,8 +97,10 @@ public class SnapshotBackup extends AbstractBackup {
 
             // Collect all snapshot dir's under keyspace dir's
             abstractBackupPaths = Lists.newArrayList();
+            // Try to upload all the files as part of snapshot. If there is any error, there will be an exception and snapshot will be considered as failure.
             initiateBackup("snapshots", backupRestoreUtil);
 
+            // All the files are uploaded successfully as part of snapshot.
             //pre condition notifiy of meta.json upload
             File tmpMetaFile = metaData.createTmpMetaFile(); //Note: no need to remove this temp as it is done within createTmpMetaFile()
             AbstractBackupPath metaJsonAbp = metaData.decorateMetaJson(tmpMetaFile, snapshotName);


### PR DESCRIPTION
Mark snapshot as a failure if there is an issue with uploading a file.This is to ensure we fail-fast. This is in contrast to previous behavior where snapshot would "ignore" any failures in the upload of a file and mark snapshot as "success".

Since it was not truly a "success" marking that as "failure" is the right thing to do. Also, meta.json should really be uploaded in case of "success" and not in case of "failure" as the presence of "meta.json" marks the backup as successful.

The case for fail-fast: In a scenario where we had an issue say at the start of the backup, it makes more sense to fail-fast then to keep uploading other files (and waste bandwidth and use backup resources). The remediation step for backup failure is anyways to take a full snapshot again.