### PR TITLE
More resilient incrementals

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -162,12 +162,12 @@ public class S3FileSystem extends S3FileSystemBase implements S3FileSystemMBean 
                 objectMetadata.setContentLength(chunk.length);
                 PutObjectRequest putObjectRequest = new PutObjectRequest(config.getBackupPrefix(), path.getRemotePath(), new ByteArrayInputStream(chunk), objectMetadata);
                 //Retry if failed.
-                PutObjectResult upload = new BoundedExponentialRetryCallable<PutObjectResult>() {
+                PutObjectResult upload = new BoundedExponentialRetryCallable<PutObjectResult>(1000, 10000, 5) {
                     @Override
                     public PutObjectResult retriableCall() throws Exception {
                         return s3Client.putObject(putObjectRequest);
                     }
-                }.retriableCall();
+                }.call();
 
                 bytesUploaded.addAndGet(chunk.length);
 

--- a/priam/src/main/java/com/netflix/priam/aws/S3PartUploader.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3PartUploader.java
@@ -20,7 +20,7 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.*;
 import com.netflix.priam.backup.BackupRestoreException;
-import com.netflix.priam.utils.RetryableCallable;
+import com.netflix.priam.utils.BoundedExponentialRetryCallable;
 import com.netflix.priam.utils.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +29,8 @@ import java.io.ByteArrayInputStream;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class S3PartUploader extends RetryableCallable<Void> {
+public class S3PartUploader extends BoundedExponentialRetryCallable<Void>
+{
     private final AmazonS3 client;
     private DataPart dataPart;
     private List<PartETag> partETags;
@@ -37,16 +38,17 @@ public class S3PartUploader extends RetryableCallable<Void> {
 
     private static final Logger logger = LoggerFactory.getLogger(S3PartUploader.class);
     private static final int MAX_RETRIES = 5;
+    private static final int DEFAULT_MIN_SLEEP_MS = 200;
 
     public S3PartUploader(AmazonS3 client, DataPart dp, List<PartETag> partETags) {
-        super(MAX_RETRIES, RetryableCallable.DEFAULT_WAIT_TIME);
+        super(DEFAULT_MIN_SLEEP_MS, BoundedExponentialRetryCallable.MAX_SLEEP, MAX_RETRIES);
         this.client = client;
         this.dataPart = dp;
         this.partETags = partETags;
     }
 
     public S3PartUploader(AmazonS3 client, DataPart dp, List<PartETag> partETags, AtomicInteger partsUploaded) {
-        super(MAX_RETRIES, RetryableCallable.DEFAULT_WAIT_TIME);
+        super(DEFAULT_MIN_SLEEP_MS, BoundedExponentialRetryCallable.MAX_SLEEP, MAX_RETRIES);
         this.client = client;
         this.dataPart = dp;
         this.partETags = partETags;

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
@@ -76,7 +76,12 @@ public abstract class AbstractBackup extends Task {
             try {
                 logger.debug("About to upload file {} for backup", file.getCanonicalFile());
 
-                AbstractBackupPath abp = new RetryableCallable<AbstractBackupPath>(3, RetryableCallable.DEFAULT_WAIT_TIME) {
+                // Allow up to 30s of arbitrary failures at the top level. The upload call itself typically has retries
+                // as well so this top level retry is on top of those retries. Assuming that each call to upload has
+                // ~30s maximum of retries this yields about 3.5 minutes of retries at the top level since
+                // (6 * (5 + 30) = 210 seconds). Even if this fails, however, higher level schedulers (e.g. in
+                // incremental) will hopefully re-enqueue.
+                AbstractBackupPath abp = new RetryableCallable<AbstractBackupPath>(6, 5000) {
                     public AbstractBackupPath retriableCall() throws Exception {
                         upload(bp);
                         file.delete();
@@ -99,33 +104,26 @@ public abstract class AbstractBackup extends Task {
 
 
     /**
-     * Upload specified file (RandomAccessFile) with retries
+     * Upload specified file (RandomAccessFile)
      *
      * @param bp backup path to be uploaded.
      */
     protected void upload(final AbstractBackupPath bp) throws Exception {
-        new RetryableCallable<Void>() {
-            @Override
-            public Void retriableCall() throws Exception {
-                java.io.InputStream is = null;
-                try {
-                    is = bp.localReader();
-                    if (is == null) {
-                        throw new NullPointerException("Unable to get handle on file: " + bp.fileName);
-                    }
-                    fs.upload(bp, is);
-                    bp.setCompressedFileSize(fs.getBytesUploaded());
-                    return null;
-                } catch (Exception e) {
-                    logger.error("Exception uploading local file {},  releasing handle, and will retry.", bp.backupFile.getCanonicalFile());
-                    if (is != null) {
-                        is.close();
-                    }
-                    throw e;
-                }
-
+        java.io.InputStream is = null;
+        try {
+            is = bp.localReader();
+            if (is == null) {
+                throw new NullPointerException("Unable to get handle on file: " + bp.fileName);
             }
-        }.call();
+            fs.upload(bp, is);
+            bp.setCompressedFileSize(fs.getBytesUploaded());
+        } catch (Exception e) {
+            logger.error("Exception uploading local file {},  releasing handle, and will retry.", bp.backupFile.getCanonicalFile());
+            if (is != null) {
+                is.close();
+            }
+            throw e;
+        }
     }
 
     protected final void initiateBackup(String monitoringFolder, BackupRestoreUtil backupRestoreUtil) throws Exception {

--- a/priam/src/main/java/com/netflix/priam/backup/parallel/CassandraBackupQueueMgr.java
+++ b/priam/src/main/java/com/netflix/priam/backup/parallel/CassandraBackupQueueMgr.java
@@ -48,40 +48,41 @@ public class CassandraBackupQueueMgr implements ITaskQueueMgr<AbstractBackupPath
 
     @Inject
     public CassandraBackupQueueMgr(IConfiguration config) {
-        tasks = new ArrayBlockingQueue<AbstractBackupPath>(config.getUncrementalBkupQueueSize());
-        tasksQueued = new HashSet<String>(config.getUncrementalBkupQueueSize()); //Key to task is the S3 absolute path (BASE/REGION/CLUSTER/TOKEN/[yyyymmddhhmm]/[SST|SNP|META]/KEYSPACE/COLUMNFAMILY/FILE
+        tasks = new ArrayBlockingQueue<AbstractBackupPath>(config.getIncrementalBkupQueueSize());
+        // Key to task is the S3 absolute path (BASE/REGION/CLUSTER/TOKEN/[yyyymmddhhmm]/[SST|SNP|META]/KEYSPACE/COLUMNFAMILY/FILE
+        tasksQueued = new HashSet<String>(config.getIncrementalBkupQueueSize());
     }
 
-    @Override
     /*
      * Add task to queue if it does not already exist.  For performance reasons, this behavior does not acquire a lock on the queue hence
-	 * it is up to the caller to handle possible duplicate tasks.
-	 * 
-	 * Note: will block until there is space in the queue.
-	 */
-    public void add(AbstractBackupPath task) {
+     * it is up to the caller to handle possible duplicate tasks.
+     *
+     * Note: will block
+     */
+    @Override
+    public void add(AbstractBackupPath task)
+    {
         if (!tasksQueued.contains(task.getRemotePath())) {
             tasksQueued.add(task.getRemotePath());
             try {
-                tasks.put(task); //block until space becomes available in queue
+                // block until space becomes available in queue
+                tasks.put(task);
                 logger.debug("Queued file {} within CF {}", task.getFileName(), task.getColumnFamily());
-
             } catch (InterruptedException e) {
                 logger.warn("Interrupted waiting for the task queue to have free space, not fatal will just move on.   Error Msg: {}", e.getLocalizedMessage());
+                tasksQueued.remove(task.getRemotePath());
             }
         } else {
             logger.debug("Already in queue, no-op.  File: {}", task.getRemotePath());
         }
-
-        return;
     }
 
     @Override
-	/*
-	 * Guarantee delivery of a task to only one consumer.
-	 * 
-	 * @return task, null if task in queue.
-	 */
+    /*
+     * Guarantee delivery of a task to only one consumer.
+     * 
+     * @return task, null if task in queue.
+     */
     public AbstractBackupPath take() throws InterruptedException {
         AbstractBackupPath task = null;
         if (!tasks.isEmpty()) {
@@ -95,34 +96,34 @@ public class CassandraBackupQueueMgr implements ITaskQueueMgr<AbstractBackupPath
     }
 
     @Override
-	/*
-	 * @return true if there are more tasks.  
-	 * 
-	 * Note: this is a best effort so the caller should call me again just before taking a task.
-	 * We anticipate this method will be invoked at a high frequency hence, making it thread-safe will slow down the appliation or
-	 * worse yet, create a deadlock.  For example, caller blocks to determine if there are more tasks and also blocks waiting to dequeue
-	 * the task.
-	 */
+    /*
+     * @return true if there are more tasks.
+     *
+     * Note: this is a best effort so the caller should call me again just before taking a task.
+     * We anticipate this method will be invoked at a high frequency hence, making it thread-safe will slow down the application or
+     * worse yet, create a deadlock.  For example, caller blocks to determine if there are more tasks and also blocks waiting to dequeue
+     * the task.
+     */
     public Boolean hasTasks() {
         return !tasks.isEmpty();
     }
 
     @Override
-	/*
-	 * A means to perform any post processing once the task has been completed.  If post processing is needed,
-	 * the consumer should notify this behavior via callback once the task is completed. 
-	 * 
-	 * *Note: "completed" here can mean success or failure.
-	 */
+    /*
+     * A means to perform any post processing once the task has been completed.  If post processing is needed,
+     * the consumer should notify this behavior via callback once the task is completed. 
+     * 
+     * *Note: "completed" here can mean success or failure.
+     */
     public void taskPostProcessing(AbstractBackupPath completedTask) {
         this.tasksQueued.remove(completedTask.getRemotePath());
     }
 
     @Override
-	/*
-	 * @return num of pending tasks.  Note, the result is a best guess, don't rely on it to be 100% accurate.
-	 */
-    public Integer getNumOfTasksToBeProessed() {
+    /*
+     * @return num of pending tasks.  Note, the result is a best guess, don't rely on it to be 100% accurate.
+     */
+    public Integer getNumOfTasksToBeProcessed() {
         return tasks.size();
     }
 

--- a/priam/src/main/java/com/netflix/priam/backup/parallel/ITaskQueueMgr.java
+++ b/priam/src/main/java/com/netflix/priam/backup/parallel/ITaskQueueMgr.java
@@ -26,19 +26,26 @@ package com.netflix.priam.backup.parallel;
  */
 public interface ITaskQueueMgr<E> {
 
+    /**
+     * Adds the provided task into the queue if it does not already exist. For performance reasons
+     * this is best effort and therefore callers are responsible for handling duplicate tasks.
+     *
+     * This method will block if the queue of tasks is full
+     * @param task The task to put onto the queue
+     */
     void add(E task);
 
-    /*
+    /**
      * @return task, null if none is available.
      */
     E take() throws InterruptedException;
 
-    /*
+    /**
      * @return true if there are tasks within queue to be processed; false otherwise.
      */
     Boolean hasTasks();
 
-    /*
+    /**
      * A means to perform any post processing once the task has been completed.  If post processing is needed,
      * the consumer should notify this behavior via callback once the task is completed.
      *
@@ -46,10 +53,9 @@ public interface ITaskQueueMgr<E> {
      */
     void taskPostProcessing(E completedTask);
 
+    Integer getNumOfTasksToBeProcessed();
 
-    Integer getNumOfTasksToBeProessed();
-
-    /*
+    /**
      * @return true if all tasks completed (includes failures) for a date; false, if at least 1 task is still in queue.
      */
     Boolean tasksCompleted(java.util.Date date);

--- a/priam/src/main/java/com/netflix/priam/backup/parallel/IncrementalBackupProducer.java
+++ b/priam/src/main/java/com/netflix/priam/backup/parallel/IncrementalBackupProducer.java
@@ -70,7 +70,8 @@ public class IncrementalBackupProducer extends AbstractBackup implements IIncrem
             try {
                 final AbstractBackupPath bp = pathFactory.get();
                 bp.parseLocal(file, BackupFileType.SST);
-                this.taskQueueMgr.add(bp); //producer -- populate the queue of files.  *Note: producer will block if queue is full.
+                // producer -- populate the queue of files.  *Note: producer will block if queue is full.
+                this.taskQueueMgr.add(bp);
             } catch (Exception e) {
                 logger.warn("Unable to queue incremental file, treating as non-fatal and moving on to next.  Msg: {} Fail to queue file: {}",
                         e.getLocalizedMessage(), file.getAbsolutePath());

--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -422,7 +422,6 @@ public interface IConfiguration {
      */
     int getHintedHandoffThrottleKb();
 
-
     /**
      * @return Size of Cassandra max direct memory
      */
@@ -447,7 +446,6 @@ public interface IConfiguration {
      * @return stream_throughput_outbound_megabits_per_sec in yaml
      */
     int getStreamingThroughputMB();
-
 
     /**
      * Get the paritioner for this cassandra cluster/node.
@@ -626,7 +624,7 @@ public interface IConfiguration {
     String getPgpPasswordPhrase();
 
     /*
-     * @return public key use by PGP cryptography.  This information is to be use within the restore and backup functionality when encryption is enabled.
+     * @return key use by PGP cryptography.  This information is to be use within the restore and backup functionality when encryption is enabled.
      * Note: for backward compatibility, this property should be optional.  Specifically, if it does not exist, it should not cause an adverse impact on current functionality. 
      */
     String getPgpPublicKeyLoc();
@@ -668,7 +666,7 @@ public interface IConfiguration {
     /*
      * The max number of files queued to be uploaded.
      */
-    int getUncrementalBkupQueueSize();
+    int getIncrementalBkupQueueSize();
 
     /**
      * @return tombstone_warn_threshold in C* yaml
@@ -746,36 +744,46 @@ public interface IConfiguration {
      *
      * @return if post restore hook is enabled
      */
-    boolean isPostRestoreHookEnabled();
+
+    default boolean isPostRestoreHookEnabled() {
+        return false;
+    }
 
     /**
      * Post restore hook to be executed
      *
      * @return post restore hook to be executed once restore is complete
      */
-    String getPostRestoreHook();
-
+    default String getPostRestoreHook() {
+        return "";
+    }
 
     /**
      * HeartBeat file of post restore hook
      *
      * @return file that indicates heartbeat of post restore hook
      */
-    String getPostRestoreHookHeartbeatFileName();
+    default String getPostRestoreHookHeartbeatFileName() {
+        return "postrestorehook_heartbeat";
+    }
 
     /**
      * Done file for post restore hook
      *
      * @return file that indicates completion of post restore hook
      */
-    String getPostRestoreHookDoneFileName();
+    default String getPostRestoreHookDoneFileName() {
+        return "postrestorehook_done";
+    }
 
     /**
      * Maximum time Priam has to wait for post restore hook sub-process to complete successfully
      *
      * @return time out for post restore hook in days
      */
-    int getPostRestoreHookTimeOutInDays();
+    default int getPostRestoreHookTimeOutInDays() {
+        return 2;
+    }
 
     /**
      * Heartbeat timeout (in ms) for post restore hook

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -1055,7 +1055,7 @@ public class PriamConfiguration implements IConfiguration {
     }
 
     @Override
-    public int getUncrementalBkupQueueSize() {
+    public int getIncrementalBkupQueueSize() {
         return config.get(PRIAM_PRE + ".incremental.bkup.queue.size", 100000);
     }
 

--- a/priam/src/main/java/com/netflix/priam/utils/BoundedExponentialRetryCallable.java
+++ b/priam/src/main/java/com/netflix/priam/utils/BoundedExponentialRetryCallable.java
@@ -23,9 +23,9 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.CancellationException;
 
 public abstract class BoundedExponentialRetryCallable<T> extends RetryableCallable<T> {
-    private final static long MAX_SLEEP = 10000;
-    private final static long MIN_SLEEP = 1000;
-    private final static int MAX_RETRIES = 10;
+    protected final static long MAX_SLEEP = 10000;
+    protected final static long MIN_SLEEP = 1000;
+    protected final static int MAX_RETRIES = 10;
 
     private static final Logger logger = LoggerFactory.getLogger(BoundedExponentialRetryCallable.class);
     private long max;

--- a/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
@@ -709,7 +709,7 @@ public class FakeConfiguration implements IConfiguration {
     }
 
     @Override
-    public int getUncrementalBkupQueueSize() {
+    public int getIncrementalBkupQueueSize() {
         return 100;
     }
 
@@ -774,7 +774,7 @@ public class FakeConfiguration implements IConfiguration {
 
     @Override
     public String getPostRestoreHook() {
-        return "iostat -d 2 10";
+        return "echo";
     }
 
     @Override


### PR DESCRIPTION
This change makes it so Priam will continue re-trying incremental uploads forever (as opposed to only retrying them the next time that you restart Priam).

Before we could fail to upload incrementals with 1.5s of AWS S3 unavailability. Now we can only fail incrementals if we're misconfigured or AWS is actually permanently down. The existing controls for queue size are sufficient to control backpressure here.