### PR TITLE
First take at supporting Cassandra 4.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ allprojects {
     repositories {
         jcenter()
     }
-    
+
     configurations {
       all*.exclude group: 'ch.qos.logback', module: 'logback-classic'
       all*.exclude group: 'ch.qos.logback', module: 'logback-core'
@@ -40,7 +40,9 @@ allprojects {
       compile 'com.googlecode.json-simple:json-simple:1.1.1'
       compile 'org.xerial.snappy:snappy-java:1.1.2.6'
       compile 'org.yaml:snakeyaml:1.19'
-      compile 'org.apache.cassandra:cassandra-all:3.0.17'
+      // Until Cassandra releases cassandra-all jars for 4.0
+      compile files(project.rootDir.getPath() + '/libs/apache-cassandra-4.0-SNAPSHOT.jar')
+      //compile 'org.apache.cassandra:cassandra-all:3.0.17'
       compile 'javax.ws.rs:jsr311-api:1.1.1'
       compile 'joda-time:joda-time:2.9.9'
       compile 'org.apache.commons:commons-configuration2:2.1.1'

--- a/priam-cass-extensions/src/main/java/com/netflix/priam/cassandra/extensions/NFSeedProvider.java
+++ b/priam-cass-extensions/src/main/java/com/netflix/priam/cassandra/extensions/NFSeedProvider.java
@@ -16,11 +16,11 @@
  */
 package com.netflix.priam.cassandra.extensions;
 
-import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.SeedProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,14 +36,14 @@ public class NFSeedProvider implements SeedProvider
     {    }
 
     @Override
-    public List<InetAddress> getSeeds()
+    public List<InetAddressAndPort> getSeeds()
     {
-        List<InetAddress> seeds = new ArrayList<InetAddress>();
+        List<InetAddressAndPort> seeds = new ArrayList<>();
         try
         {
             String priamSeeds = DataFetcher.fetchData("http://127.0.0.1:8080/Priam/REST/v1/cassconfig/get_seeds");
             for (String seed : priamSeeds.split(","))
-                seeds.add(InetAddress.getByName(seed));
+                seeds.add(InetAddressAndPort.getByName(seed));
         }
         catch (Exception e)
         {

--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -24,6 +24,11 @@ import com.netflix.priam.identity.config.InstanceDataRetriever;
 import com.netflix.priam.scheduler.SchedulerType;
 import com.netflix.priam.scheduler.UnsupportedTypeException;
 
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -39,6 +44,16 @@ public interface IConfiguration {
      * @return Path to the home dir of Cassandra
      */
     String getCassHome();
+
+    /**
+     * Returns the path to the Cassandra configuration directory, this varies by distribution but the default
+     * of finding the yaml file and going up one directory is a reasonable default. If you have a custom Yaml
+     * Location that doesn't have all the other configuration files you may want to tune this.
+     * @return
+     */
+    default String getCassConfigurationDirectory() {
+        return new File(getYamlLocation()).getParentFile().getPath();
+    }
 
     String getYamlLocation();
 
@@ -790,4 +805,21 @@ public interface IConfiguration {
     default int getPostRestoreHookHeartbeatCheckFrequencyInMs() {
         return 120000;
     }
+
+    /**
+     * Return a comma delimited list of property files that should be tuned in the configuration
+     * directory by Priam. These files live relative to the configuration directory.
+     * @return A comma delimited list of relative file paths to the configuration directory
+     */
+    default String getTunablePropertyFiles() { return ""; }
+
+    /**
+     * Escape hatch for getting any arbitrary property by key
+     * This is useful so we don't have to keep adding methods to this interface for every single configuration
+     * option ever.
+     * @param key The arbitrary configuration property to look up
+     * @param defaultValue The default value to return if the key is not found.
+     * @return The result for the property
+     */
+    String getProperty(String key, String defaultValue);
 }

--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -194,11 +194,6 @@ public interface IConfiguration {
     int getSSLStoragePort();
 
     /**
-     * @return Cassandra's thrift port
-     */
-    int getThriftPort();
-
-    /**
      * @return Port for CQL binary transport.
      */
     int getNativeTransportPort();
@@ -554,8 +549,6 @@ public interface IConfiguration {
 
     boolean isDynamicSnitchEnabled();
 
-    boolean isThriftEnabled();
-
     boolean isNativeTransportEnabled();
 
     int getConcurrentReadsCnt();
@@ -563,12 +556,6 @@ public interface IConfiguration {
     int getConcurrentWritesCnt();
 
     int getConcurrentCompactorsCnt();
-
-    String getRpcServerType();
-
-    int getRpcMinThreads();
-
-    int getRpcMaxThreads();
 
     int getIndexInterval();
 

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -1136,8 +1136,14 @@ public class PriamConfiguration implements IConfiguration {
     public int getPostRestoreHookHeartBeatTimeoutInMs() {
         return config.get(CONFIG_POST_RESTORE_HOOK_HEARTBEAT_TIMEOUT_MS, 120000);
     }
+
     @Override
     public int getPostRestoreHookHeartbeatCheckFrequencyInMs() {
         return config.get(CONFIG_POST_RESTORE_HOOK_HEARTBEAT_CHECK_FREQUENCY_MS, 120000);
+    }
+
+    @Override
+    public String getProperty(String key, String defaultValue) {
+        return config.get(PRIAM_PRE + "." + key, defaultValue);
     }
 }

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -67,8 +67,6 @@ public class PriamConfiguration implements IConfiguration {
     private static final String CONFIG_SAVE_CACHE_LOCATION = PRIAM_PRE + ".cache.location";
     private static final String CONFIG_NEW_MAX_HEAP_SIZE = PRIAM_PRE + ".heap.newgen.size.";
     private static final String CONFIG_DIRECT_MAX_HEAP_SIZE = PRIAM_PRE + ".direct.memory.size.";
-    private static final String CONFIG_THRIFT_LISTEN_PORT_NAME = PRIAM_PRE + ".thrift.port";
-    private static final String CONFIG_THRIFT_ENABLED = PRIAM_PRE + ".thrift.enabled";
     private static final String CONFIG_NATIVE_PROTOCOL_PORT = PRIAM_PRE + ".nativeTransport.port";
     private static final String CONFIG_NATIVE_PROTOCOL_ENABLED = PRIAM_PRE + ".nativeTransport.enabled";
     private static final String CONFIG_STORAGE_LISTERN_PORT_NAME = PRIAM_PRE + ".storage.port";
@@ -229,7 +227,6 @@ public class PriamConfiguration implements IConfiguration {
     private final String DEFAULT_MAX_HEAP = "8G";
     private final String DEFAULT_MAX_NEWGEN_HEAP = "2G";
     private final int DEFAULT_JMX_PORT = 7199;
-    private final int DEFAULT_THRIFT_PORT = 9160;
     private final int DEFAULT_NATIVE_PROTOCOL_PORT = 9042;
     private final int DEFAULT_STORAGE_PORT = 7000;
     private final int DEFAULT_SSL_STORAGE_PORT = 7001;
@@ -246,9 +243,6 @@ public class PriamConfiguration implements IConfiguration {
     // Default to restarting Cassandra automatically once per hour.
     private final int DEFAULT_REMEDIATE_DEAD_CASSANDRA_RATE_S = 60 * 60;
 
-    private static final String DEFAULT_RPC_SERVER_TYPE = "hsha";
-    private static final int DEFAULT_RPC_MIN_THREADS = 16;
-    private static final int DEFAULT_RPC_MAX_THREADS = 2048;
     private static final int DEFAULT_INDEX_INTERVAL = 256;
     private static final int DEFAULT_STREAMING_SOCKET_TIMEOUT_IN_MS = 86400000; // 24 Hours
     private static final int DEFAULT_TOMBSTONE_WARNING_THRESHOLD = 1000; // C* defaults
@@ -510,11 +504,6 @@ public class PriamConfiguration implements IConfiguration {
 
     public int getNativeTransportPort() {
         return config.get(CONFIG_NATIVE_PROTOCOL_PORT, DEFAULT_NATIVE_PROTOCOL_PORT);
-    }
-
-    @Override
-    public int getThriftPort() {
-        return config.get(CONFIG_THRIFT_LISTEN_PORT_NAME, DEFAULT_THRIFT_PORT);
     }
 
     @Override
@@ -822,7 +811,7 @@ public class PriamConfiguration implements IConfiguration {
     @Override
     public String getJVMOptionsFileLocation()
     {
-        return config.get(PRIAM_PRE + ".jvm.options.location", getCassHome() + "/conf/jvm.options");
+        return config.get(PRIAM_PRE + ".jvm.options.location", getCassHome() + "/conf/jvm-server.options");
     }
 
     public String getAuthenticator() {
@@ -916,10 +905,6 @@ public class PriamConfiguration implements IConfiguration {
         return config.get(CONFIG_DSNITCH_ENABLED, true);
     }
 
-    public boolean isThriftEnabled() {
-        return config.get(CONFIG_THRIFT_ENABLED, true);
-    }
-
     public boolean isNativeTransportEnabled() {
         return config.get(CONFIG_NATIVE_PROTOCOL_ENABLED, false);
     }
@@ -935,18 +920,6 @@ public class PriamConfiguration implements IConfiguration {
     public int getConcurrentCompactorsCnt() {
         int cpus = Runtime.getRuntime().availableProcessors();
         return config.get(CONFIG_CONCURRENT_COMPACTORS, cpus);
-    }
-
-    public String getRpcServerType() {
-        return config.get(CONFIG_RPC_SERVER_TYPE, DEFAULT_RPC_SERVER_TYPE);
-    }
-
-    public int getRpcMinThreads() {
-        return config.get(CONFIG_RPC_MIN_THREADS, DEFAULT_RPC_MIN_THREADS);
-    }
-
-    public int getRpcMaxThreads() {
-        return config.get(CONFIG_RPC_MAX_THREADS, DEFAULT_RPC_MAX_THREADS);
     }
 
     public int getIndexInterval() {

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/CassandraOperations.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/CassandraOperations.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import java.util.*;
 
+import static com.google.common.collect.Iterables.toArray;
+
 /**
  * This class encapsulates interactions with Cassandra.
  * Created by aagrawal on 6/19/18.
@@ -60,7 +62,7 @@ public class CassandraOperations {
             new RetryableCallable<Void>(6, 10000) {
                 public Void retriableCall() throws Exception {
                     JMXNodeTool nodetool = JMXNodeTool.instance(configuration);
-                    nodetool.takeSnapshot(snapshotName, null);
+                    nodetool.takeSnapshot(snapshotName, null, Collections.emptyMap());
                     return null;
                 }
             }.call();

--- a/priam/src/main/java/com/netflix/priam/health/InstanceState.java
+++ b/priam/src/main/java/com/netflix/priam/health/InstanceState.java
@@ -53,7 +53,6 @@ public class InstanceState {
     private final AtomicBoolean shouldCassandraBeAlive = new AtomicBoolean(false);
     private final AtomicLong lastAttemptedStartTime = new AtomicLong(Long.MAX_VALUE);
     private final AtomicBoolean isGossipActive = new AtomicBoolean(false);
-    private final AtomicBoolean isThriftActive = new AtomicBoolean(false);
     private final AtomicBoolean isNativeTransportActive = new AtomicBoolean(false);
     private final AtomicBoolean isRequiredDirectoriesExist = new AtomicBoolean(false);
     private final AtomicBoolean isYmlWritten = new AtomicBoolean(false);
@@ -82,15 +81,6 @@ public class InstanceState {
 
     public void setIsGossipActive(boolean isGossipActive) {
         this.isGossipActive.set(isGossipActive);
-        setHealthy();
-    }
-
-    public boolean isThriftActive() {
-        return isThriftActive.get();
-    }
-
-    public void setIsThriftActive(boolean isThriftActive) {
-        this.isThriftActive.set(isThriftActive);
         setHealthy();
     }
 
@@ -206,7 +196,7 @@ public class InstanceState {
                     isGossipActive() &&
                     isYmlWritten() &&
                     isHealthyOverride() &&
-                    (isThriftActive() || isNativeTransportActive())
+                    isNativeTransportActive()
                 )
         );
     }

--- a/priam/src/main/java/com/netflix/priam/resources/CassandraAdmin.java
+++ b/priam/src/main/java/com/netflix/priam/resources/CassandraAdmin.java
@@ -265,50 +265,6 @@ public class CassandraAdmin {
     }
 
     @GET
-    @Path("/disablethrift")
-    public Response disablethrift() throws IOException, ExecutionException, InterruptedException {
-        JMXNodeTool nodeTool;
-        try {
-            nodeTool = JMXNodeTool.instance(config);
-        } catch (JMXConnectionException e) {
-            logger.error("Exception in fetching c* jmx tool .  Msgl: {}", e.getLocalizedMessage(), e);
-            return Response.status(503).entity("JMXConnectionException")
-                    .build();
-        }
-        nodeTool.stopThriftServer();
-        return Response.ok(REST_SUCCESS, MediaType.APPLICATION_JSON).build();
-    }
-
-    @GET
-    @Path("/enablethrift")
-    public Response enablethrift() throws IOException, ExecutionException, InterruptedException {
-        JMXNodeTool nodeTool;
-        try {
-            nodeTool = JMXNodeTool.instance(config);
-        } catch (JMXConnectionException e) {
-            logger.error("Exception in fetching c* jmx tool .  Msgl: {}", e.getLocalizedMessage(), e);
-            return Response.status(503).entity("JMXConnectionException")
-                    .build();
-        }
-        nodeTool.startThriftServer();
-        return Response.ok(REST_SUCCESS, MediaType.APPLICATION_JSON).build();
-    }
-
-    @GET
-    @Path("/statusthrift")
-    public Response statusthrift() throws IOException, ExecutionException, InterruptedException, JSONException {
-        JMXNodeTool nodeTool;
-        try {
-            nodeTool = JMXNodeTool.instance(config);
-        } catch (JMXConnectionException e) {
-            logger.error("Exception in fetching c* jmx tool .  Msgl: {}", e.getLocalizedMessage(), e);
-            return Response.status(503).entity("JMXConnectionException")
-                    .build();
-        }
-        return Response.ok(new JSONObject().put("status", (nodeTool.isThriftServerRunning() ? "running" : "not running")), MediaType.APPLICATION_JSON).build();
-    }
-
-    @GET
     @Path("/gossipinfo")
     public Response gossipinfo() throws IOException, ExecutionException, InterruptedException, JSONException {
         JMXNodeTool nodeTool;
@@ -319,7 +275,7 @@ public class CassandraAdmin {
             return Response.status(503).entity("JMXConnectionException")
                     .build();
         }
-        JSONObject rootObj = parseGossipInfo(nodeTool.getGossipInfo());
+        JSONObject rootObj = parseGossipInfo(nodeTool.getGossipInfo(false));
         return Response.ok(rootObj, MediaType.APPLICATION_JSON).build();
     }
 

--- a/priam/src/main/java/com/netflix/priam/tuner/PropertiesFileTuner.java
+++ b/priam/src/main/java/com/netflix/priam/tuner/PropertiesFileTuner.java
@@ -1,0 +1,92 @@
+package com.netflix.priam.tuner;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.lang3.text.StrSubstitutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.JsonElement;
+import com.google.inject.Inject;
+import com.netflix.priam.config.IConfiguration;
+import com.netflix.priam.utils.GsonJsonSerializer;
+
+/**
+ * Support tuning standard .properties files
+ * <p>
+ */
+public class PropertiesFileTuner
+{
+    private static final Logger logger = LoggerFactory.getLogger(JVMOptionsTuner.class);
+    protected final IConfiguration config;
+    protected final String propertyPrefix;
+
+    @Inject
+    public PropertiesFileTuner(IConfiguration config, String prefix) {
+        this.config = config;
+        this.propertyPrefix = prefix;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void updateAndSaveProperties(String configPath) {
+        File propertiesFile = new File(configPath);
+        try {
+            if (propertiesFile.exists() && !propertiesFile.canWrite()) {
+                throw new IOException("Can't write and therefore cannot tune" + configPath);
+            }
+
+            PropertiesConfiguration properties = new PropertiesConfiguration();
+            properties.getLayout().load(properties, new FileReader(propertiesFile.getPath()));
+
+            Set<String> keys = new HashSet<>();
+            properties.getKeys().forEachRemaining(keys::add);
+
+            Map<String, String> overridenProperties = new HashMap<>();
+            String propertyOverrides = config.getProperty("propertyOverrides." + propertyPrefix, null);
+
+            if (propertyOverrides != null) {
+                // Allow use of the IConfiguration object as template strings
+                ObjectMapper objectMapper = new ObjectMapper();
+                Map<String, Object> map = objectMapper.convertValue(config, Map.class);
+                StrSubstitutor sub = new StrSubstitutor(map);
+                String resolvedPropertyOverrides = sub.replace(propertyOverrides);
+
+                String[] pairs = resolvedPropertyOverrides.split(",");
+                for (String kv : pairs) {
+                    String[] entry = kv.split("=");
+                    if (entry.length != 2)
+                        continue;
+                    keys.add(entry[0]);
+                    overridenProperties.put(entry[0], entry[1]);
+                }
+            }
+
+            for (String key: keys) {
+                if (overridenProperties.containsKey(key))
+                    properties.setProperty(key, overridenProperties.get(key));
+            }
+
+            properties.getLayout().save(properties, new FileWriter(propertiesFile.getPath()));
+        }
+        catch (IOException | ConfigurationException e) {
+            logger.error("Could not tune " + configPath, e);
+        }
+    }
+
+}

--- a/priam/src/main/java/com/netflix/priam/tuner/PropertiesFileTuner.java
+++ b/priam/src/main/java/com/netflix/priam/tuner/PropertiesFileTuner.java
@@ -4,15 +4,10 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 
 import org.apache.commons.configuration2.PropertiesConfiguration;
@@ -22,10 +17,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.JsonElement;
 import com.google.inject.Inject;
 import com.netflix.priam.config.IConfiguration;
-import com.netflix.priam.utils.GsonJsonSerializer;
 
 /**
  * Support tuning standard .properties files
@@ -44,7 +37,8 @@ public class PropertiesFileTuner
     }
 
     @SuppressWarnings("unchecked")
-    public void updateAndSaveProperties(String configPath) {
+    public void updateAndSaveProperties(String configPath) throws IOException, ConfigurationException
+    {
         File propertiesFile = new File(configPath);
         try {
             if (propertiesFile.exists() && !propertiesFile.canWrite()) {
@@ -86,6 +80,7 @@ public class PropertiesFileTuner
         }
         catch (IOException | ConfigurationException e) {
             logger.error("Could not tune " + configPath, e);
+            throw e;
         }
     }
 

--- a/priam/src/main/java/com/netflix/priam/tuner/StandardTuner.java
+++ b/priam/src/main/java/com/netflix/priam/tuner/StandardTuner.java
@@ -49,12 +49,10 @@ public class StandardTuner implements ICassandraTuner {
         options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
         Yaml yaml = new Yaml(options);
         File yamlFile = new File(yamlLocation);
-        Map map = (Map) yaml.load(new FileInputStream(yamlFile));
+        Map map = yaml.load(new FileInputStream(yamlFile));
         map.put("cluster_name", config.getAppName());
         map.put("storage_port", config.getStoragePort());
         map.put("ssl_storage_port", config.getSSLStoragePort());
-        map.put("start_rpc", config.isThriftEnabled());
-        map.put("rpc_port", config.getThriftPort());
         map.put("start_native_transport", config.isNativeTransportEnabled());
         map.put("native_transport_port", config.getNativeTransportPort());
         map.put("listen_address", hostname);
@@ -101,9 +99,6 @@ public class StandardTuner implements ICassandraTuner {
         map.put("concurrent_writes", config.getConcurrentWritesCnt());
         map.put("concurrent_compactors", config.getConcurrentCompactorsCnt());
 
-        map.put("rpc_server_type", config.getRpcServerType());
-        map.put("rpc_min_threads", config.getRpcMinThreads());
-        map.put("rpc_max_threads", config.getRpcMaxThreads());
         // Add private ip address as broadcast_rpc_address. This will ensure that COPY function works correctly. 
         map.put("broadcast_rpc_address", config.getInstanceDataRetriever().getPrivateIP());
         //map.put("index_interval", config.getIndexInterval());

--- a/priam/src/main/java/com/netflix/priam/tuner/StandardTuner.java
+++ b/priam/src/main/java/com/netflix/priam/tuner/StandardTuner.java
@@ -138,16 +138,17 @@ public class StandardTuner implements ICassandraTuner {
 
         File configurationDirectory = new File(config.getCassConfigurationDirectory());
         if (configurationDirectory.exists() && configurationDirectory.isDirectory()) {
-            Arrays.asList(config.getTunablePropertyFiles().split(",")).forEach(f -> {
+            String[] tunablePropertyFiles = config.getTunablePropertyFiles().split(",");
+            for (String file: tunablePropertyFiles) {
                 // e.g. cassandra-rackdc.properties
-                String[] propertiesFile = f.split("\\.");
+                String[] propertiesFile = file.split("\\.");
                 if (propertiesFile.length > 1 && !propertiesFile[0].isEmpty())
                 {
                     String prefix = propertiesFile[0];
                     PropertiesFileTuner propertyTuner = new PropertiesFileTuner(config, prefix);
-                    propertyTuner.updateAndSaveProperties(Paths.get(configurationDirectory.getPath(), f).toString());
+                    propertyTuner.updateAndSaveProperties(Paths.get(configurationDirectory.getPath(), file).toString());
                 }
-            });
+            }
         }
     }
 
@@ -205,7 +206,8 @@ public class StandardTuner implements ICassandraTuner {
         serverEnc.put("internode_encryption", config.getInternodeEncryption());
     }
 
-    protected void configureCommitLogBackups() {
+    protected void configureCommitLogBackups() throws IOException
+    {
         if (!config.isBackingUpCommitLogs())
             return;
         Properties props = new Properties();
@@ -218,6 +220,7 @@ public class StandardTuner implements ICassandraTuner {
             props.store(fos, "cassandra commit log archive props, as written by priam");
         } catch (IOException e) {
             logger.error("Could not store commitlog_archiving.properties", e);
+            throw e;
         }
     }
 

--- a/priam/src/main/java/com/netflix/priam/utils/CassandraMonitor.java
+++ b/priam/src/main/java/com/netflix/priam/utils/CassandraMonitor.java
@@ -84,7 +84,6 @@ public class CassandraMonitor extends Task {
                 NodeProbe bean = JMXNodeTool.instance(this.config);
                 instanceState.setIsGossipActive(bean.isGossipRunning());
                 instanceState.setIsNativeTransportActive(bean.isNativeTransportRunning());
-                instanceState.setIsThriftActive(bean.isThriftServerRunning());
             } else {
                 //Setting cassandra flag to false
                 instanceState.setCassandraProcessAlive(false);

--- a/priam/src/main/java/com/netflix/priam/utils/JMXNodeTool.java
+++ b/priam/src/main/java/com/netflix/priam/utils/JMXNodeTool.java
@@ -230,7 +230,6 @@ public class JMXNodeTool extends NodeProbe implements INodeToolObservable {
     public JSONObject info() throws JSONException {
         JSONObject object = new JSONObject();
         object.put("gossip_active", isInitialized());
-        object.put("thrift_active", isThriftServerRunning());
         object.put("token", getTokens().toString());
         object.put("load", getLoadString());
         object.put("generation_no", getCurrentGenerationNumber());
@@ -247,15 +246,15 @@ public class JMXNodeTool extends NodeProbe implements INodeToolObservable {
     @SuppressWarnings("unchecked")
     public JSONArray ring(String keyspace) throws JSONException {
         JSONArray ring = new JSONArray();
-        Map<String, String> tokenToEndpoint = getTokenToEndpointMap();
+        Map<String, String> tokenToEndpoint = getTokenToEndpointMap(false);
         List<String> sortedTokens = new ArrayList<String>(tokenToEndpoint.keySet());
 
-        Collection<String> liveNodes = getLiveNodes();
-        Collection<String> deadNodes = getUnreachableNodes();
-        Collection<String> joiningNodes = getJoiningNodes();
-        Collection<String> leavingNodes = getLeavingNodes();
-        Collection<String> movingNodes = getMovingNodes();
-        Map<String, String> loadMap = getLoadMap();
+        Collection<String> liveNodes = getLiveNodes(false);
+        Collection<String> deadNodes = getUnreachableNodes(false);
+        Collection<String> joiningNodes = getJoiningNodes(false);
+        Collection<String> leavingNodes = getLeavingNodes(false);
+        Collection<String> movingNodes = getMovingNodes(false);
+        Map<String, String> loadMap = getLoadMap(false);
 
         String format = "%-16s%-12s%-12s%-7s%-8s%-16s%-20s%-44s%n";
 

--- a/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
@@ -30,6 +30,7 @@ import com.netflix.priam.scheduler.UnsupportedTypeException;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -44,6 +45,7 @@ public class FakeConfiguration implements IConfiguration
     public String zone;
     public String instance_id;
     public String restorePrefix;
+    public Map<String, String> fakeProperties = new HashMap<>();
 
     public FakeConfiguration()
     {
@@ -500,9 +502,10 @@ public class FakeConfiguration implements IConfiguration
         return 1;
     }
 
+    @Override
     public String getYamlLocation()
     {
-        return "conf/cassandra.yaml";
+        return getCassHome() + "/conf/cassandra.yaml";
     }
 
     @Override
@@ -865,5 +868,16 @@ public class FakeConfiguration implements IConfiguration
     @Override
     public int getPostRestoreHookTimeOutInDays() {
         return 2;
+    }
+
+    @Override
+    public String getTunablePropertyFiles() {
+        return "cassandra-rackdc.properties";
+    }
+
+    @Override
+    public String getProperty(String key, String defaultValue)
+    {
+        return fakeProperties.getOrDefault(key, defaultValue);
     }
 }

--- a/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
@@ -513,7 +513,7 @@ public class FakeConfiguration implements IConfiguration
 
     @Override
     public String getJVMOptionsFileLocation() {
-        return "src/test/resources/conf/jvm.options";
+        return "src/test/resources/conf/jvm-server.options";
     }
 
     @Override

--- a/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
@@ -144,12 +144,6 @@ public class FakeConfiguration implements IConfiguration
     }
 
     @Override
-    public int getThriftPort()
-    {
-        return 9160;
-    }
-
-    @Override
     public int getNativeTransportPort()
     {
         return 9042;
@@ -613,11 +607,6 @@ public class FakeConfiguration implements IConfiguration
         return true;
     }
 
-    public boolean isThriftEnabled()
-    {
-        return true;
-    }
-
     public boolean isNativeTransportEnabled()
     {
         return false;
@@ -636,21 +625,6 @@ public class FakeConfiguration implements IConfiguration
     public int getConcurrentCompactorsCnt()
     {
         return 1;
-    }
-
-	@Override
-	public String getRpcServerType() {
-		return "hsha";
-	}
-
-    @Override
-    public int getRpcMinThreads() {
-        return 16;
-    }
-
-    @Override
-    public int getRpcMaxThreads() {
-        return 2048;
     }
 
 	@Override

--- a/priam/src/test/java/com/netflix/priam/health/TestInstanceStatus.java
+++ b/priam/src/test/java/com/netflix/priam/health/TestInstanceStatus.java
@@ -25,22 +25,21 @@ public class TestInstanceStatus {
     @Test
     public void testHealth(){
         //Verify good health.
-        Assert.assertTrue(testInstanceState.setParams(false, true, true, true, true, true, true, true).isHealthy());
-        Assert.assertTrue(testInstanceState.setParams(false,true, true, true, true, false, true, true).isHealthy());
-        Assert.assertTrue(testInstanceState.setParams(false,true, true, true, false, true, true, true).isHealthy());
-        Assert.assertTrue(testInstanceState.setParams(true,false, true, true, false, true, true, true).isHealthy());
-        Assert.assertTrue(testInstanceState.setParams(true,true, false, true, true, true, true, true).isHealthy());
-        Assert.assertTrue(testInstanceState.setParams(true,true, true, false, true, true, true, true).isHealthy());
-        Assert.assertTrue(testInstanceState.setParams(true,true, true, true, true, true, false, true).isHealthy());
-        Assert.assertTrue(testInstanceState.setParams(true,true, true, true, false, false, true, true).isHealthy());
+        Assert.assertTrue(testInstanceState.setParams(false, true, true, true, true, true, true).isHealthy());
+        Assert.assertTrue(testInstanceState.setParams(false, true, true, true, true, true, true).isHealthy());
+        Assert.assertTrue(testInstanceState.setParams(true, false, true, true, true, true, true).isHealthy());
+        Assert.assertTrue(testInstanceState.setParams(true, true, false, true, true, true, true).isHealthy());
+        Assert.assertTrue(testInstanceState.setParams(true, true, true, false, true, true, true).isHealthy());
+        Assert.assertTrue(testInstanceState.setParams(true, true, true, true, true, false, true).isHealthy());
+        Assert.assertTrue(testInstanceState.setParams(true, true, true, true, false, true, true).isHealthy());
 
         //Negative health case scenarios.
-        Assert.assertFalse(testInstanceState.setParams(false,false, true, true, false, true, true, true).isHealthy());
-        Assert.assertFalse(testInstanceState.setParams(false,true, false, true, true, true, true, true).isHealthy());
-        Assert.assertFalse(testInstanceState.setParams(false,true, true, false, true, true, true, true).isHealthy());
-        Assert.assertFalse(testInstanceState.setParams(false,true, true, true, true, true, false, true).isHealthy());
-        Assert.assertFalse(testInstanceState.setParams(false,true, true, true, false, false, true, true).isHealthy());
-        Assert.assertFalse(testInstanceState.setParams(false,true, true, true, false, false, true, false).isHealthy());
+        Assert.assertFalse(testInstanceState.setParams(false, false, true, true, true, true, true).isHealthy());
+        Assert.assertFalse(testInstanceState.setParams(false, true, false, true, true, true, true).isHealthy());
+        Assert.assertFalse(testInstanceState.setParams(false, true, true, false, true, true, true).isHealthy());
+        Assert.assertFalse(testInstanceState.setParams(false, true, true, true, true, false, true).isHealthy());
+        Assert.assertFalse(testInstanceState.setParams(false, true, true, true, false, true, true).isHealthy());
+        Assert.assertFalse(testInstanceState.setParams(false, true, true, true, false, true, false).isHealthy());
 
     }
 
@@ -51,11 +50,10 @@ public class TestInstanceStatus {
             this.instanceState = instanceState1;
         }
 
-        InstanceState setParams(boolean isRestoring, boolean isYmlWritten, boolean isCassandraProcessAlive, boolean isGossipEnabled, boolean isThriftEnabled, boolean isNativeEnabled, boolean isRequiredDirectoriesExist, boolean shouldCassandraBeAlive){
+        InstanceState setParams(boolean isRestoring, boolean isYmlWritten, boolean isCassandraProcessAlive, boolean isGossipEnabled, boolean isNativeEnabled, boolean isRequiredDirectoriesExist, boolean shouldCassandraBeAlive){
             instanceState.setYmlWritten(isYmlWritten);
             instanceState.setCassandraProcessAlive(isCassandraProcessAlive);
             instanceState.setIsNativeTransportActive(isNativeEnabled);
-            instanceState.setIsThriftActive(isThriftEnabled);
             instanceState.setIsGossipActive(isGossipEnabled);
             instanceState.setIsRequiredDirectoriesExist(isRequiredDirectoriesExist);
             instanceState.setShouldCassandraBeAlive(shouldCassandraBeAlive);

--- a/priam/src/test/java/com/netflix/priam/tuner/StandardTunerTest.java
+++ b/priam/src/test/java/com/netflix/priam/tuner/StandardTunerTest.java
@@ -47,6 +47,9 @@ public class StandardTunerTest
 
         config = new FakeConfiguration();
         tuner = new StandardTuner(config);
+        File targetDir = new File(config.getCassConfigurationDirectory());
+        if(!targetDir.exists())
+            targetDir.mkdirs();
     }
 
     @Test
@@ -102,19 +105,17 @@ public class StandardTunerTest
     public void testPropertiesFiles() throws Exception
     {
         FakeConfiguration fake = (FakeConfiguration) config;
+        String target = "/tmp/priam_test.yaml";
+        Files.copy(new File("src/main/resources/incr-restore-cassandra.yaml"), new File(target));
+
         File testRackDcFile = new File("src/test/resources/conf/cassandra-rackdc.properties");
-        File testYamlFile = new File("src/main/resources/incr-restore-cassandra.yaml");
         File rackDcFile = new File(Paths.get(config.getCassConfigurationDirectory(), "cassandra-rackdc.properties").normalize().toString());
-        File configFile = new File(Paths.get(config.getCassConfigurationDirectory(), "properties_test.yaml").normalize().toString());
-        System.out.println(testRackDcFile);
-        System.out.println(rackDcFile);
         Files.copy(testRackDcFile, rackDcFile);
-        Files.copy(testYamlFile, configFile);
 
         try {
             fake.fakeProperties.put("propertyOverrides.cassandra-rackdc", "dc=${dc},rack=${rac},ec2_naming_scheme=legacy,dc_suffix=testsuffix");
 
-            tuner.writeAllProperties(configFile.getPath(), "your_host", "YourSeedProvider");
+            tuner.writeAllProperties(target, "your_host", "YourSeedProvider");
             Properties prop = new Properties();
             prop.load(new FileReader(rackDcFile));
             assertEquals("us-east-1", prop.getProperty("dc"));
@@ -131,7 +132,6 @@ public class StandardTunerTest
             }
 
             Files.copy(testRackDcFile, rackDcFile);
-            Files.copy(testYamlFile, configFile);
         }
     }
 }

--- a/priam/src/test/java/com/netflix/priam/tuner/StandardTunerTest.java
+++ b/priam/src/test/java/com/netflix/priam/tuner/StandardTunerTest.java
@@ -17,12 +17,17 @@
 package com.netflix.priam.tuner;
 
 import java.io.File;
+import java.io.FileReader;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
+import java.util.Properties;
 
 import com.google.common.io.Files;
 import com.netflix.priam.config.FakeConfiguration;
 import com.netflix.priam.config.IConfiguration;
 import org.junit.Before;
 import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 
 public class StandardTunerTest
@@ -34,12 +39,13 @@ public class StandardTunerTest
     private static final String BOP_PARTITIONER = "org.apache.cassandra.dht.ByteOrderedPartitioner";
 
     private StandardTuner tuner;
+    private IConfiguration config;
 
     @Before
     public void setup()
     {
 
-        IConfiguration config = new FakeConfiguration();
+        config = new FakeConfiguration();
         tuner = new StandardTuner(config);
     }
 
@@ -90,5 +96,42 @@ public class StandardTunerTest
         String target = "/tmp/priam_test.yaml";
         Files.copy(new File("src/main/resources/incr-restore-cassandra.yaml"), new File("/tmp/priam_test.yaml"));
         tuner.writeAllProperties(target, "your_host", "YourSeedProvider");
+    }
+
+    @Test
+    public void testPropertiesFiles() throws Exception
+    {
+        FakeConfiguration fake = (FakeConfiguration) config;
+        File testRackDcFile = new File("src/test/resources/conf/cassandra-rackdc.properties");
+        File testYamlFile = new File("src/main/resources/incr-restore-cassandra.yaml");
+        File rackDcFile = new File(Paths.get(config.getCassConfigurationDirectory(), "cassandra-rackdc.properties").normalize().toString());
+        File configFile = new File(Paths.get(config.getCassConfigurationDirectory(), "properties_test.yaml").normalize().toString());
+        System.out.println(testRackDcFile);
+        System.out.println(rackDcFile);
+        Files.copy(testRackDcFile, rackDcFile);
+        Files.copy(testYamlFile, configFile);
+
+        try {
+            fake.fakeProperties.put("propertyOverrides.cassandra-rackdc", "dc=${dc},rack=${rac},ec2_naming_scheme=legacy,dc_suffix=testsuffix");
+
+            tuner.writeAllProperties(configFile.getPath(), "your_host", "YourSeedProvider");
+            Properties prop = new Properties();
+            prop.load(new FileReader(rackDcFile));
+            assertEquals("us-east-1", prop.getProperty("dc"));
+            assertEquals("my_zone", prop.getProperty("rack"));
+            assertEquals("legacy", prop.getProperty("ec2_naming_scheme"));
+            assertEquals("testsuffix", prop.getProperty("dc_suffix"));
+
+            assertEquals(4, prop.stringPropertyNames().size());
+        } finally {
+            fake.fakeProperties.clear();
+            for (String line : Files.readLines(rackDcFile, Charset.defaultCharset()))
+            {
+                System.out.println(line);
+            }
+
+            Files.copy(testRackDcFile, rackDcFile);
+            Files.copy(testYamlFile, configFile);
+        }
     }
 }

--- a/priam/src/test/java/com/netflix/priam/utils/TestCassandraMonitor.java
+++ b/priam/src/test/java/com/netflix/priam/utils/TestCassandraMonitor.java
@@ -90,7 +90,6 @@ public class TestCassandraMonitor {
             mockProcess.getInputStream(); result= mockOutput;
             nodeProbe.isGossipRunning(); result=true;
             nodeProbe.isNativeTransportRunning(); result=true;
-            nodeProbe.isThriftServerRunning(); result=true;
         }};
         // Mock out the ps call
         final Runtime r = Runtime.getRuntime();

--- a/priam/src/test/resources/conf/cassandra-rackdc.properties
+++ b/priam/src/test/resources/conf/cassandra-rackdc.properties
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These properties are used with GossipingPropertyFileSnitch and will
+# indicate the rack and dc for this node
+dc=dc1
+rack=rack1
+
+# Add a suffix to a datacenter name. Used by the Ec2Snitch and Ec2MultiRegionSnitch
+# to append a string to the EC2 region name.
+#dc_suffix=
+
+# Uncomment the following line to make this snitch prefer the internal ip when possible, as the Ec2MultiRegionSnitch does.
+# prefer_local=true
+
+# Datacenter and rack naming convention used by the Ec2Snitch and Ec2MultiRegionSnitch.
+# Options are:
+#   legacy : datacenter name is the part of the availability zone name preceding the last "-"
+#       when the zone ends in -1 and includes the number if not -1. Rack is the portion of
+#       the availability zone name following  the last "-".
+#       Examples: us-west-1a => dc: us-west, rack: 1a; us-west-2b => dc: us-west-2, rack: 2b;
+#       YOU MUST USE THIS VALUE IF YOU ARE UPGRADING A PRE-4.0 CLUSTER
+#   standard : Default value. datacenter name is the standard AWS region name, including the number.
+#       rack name is the region plus the availability zone letter.
+#       Examples: us-west-1a => dc: us-west-1, rack: us-west-1a; us-west-2b => dc: us-west-2, rack: us-west-2b;
+# ec2_naming_scheme=standard

--- a/priam/src/test/resources/conf/jvm-server.options
+++ b/priam/src/test/resources/conf/jvm-server.options
@@ -53,9 +53,6 @@
 # before joining the ring.
 #-Dcassandra.ring_delay_ms=ms
 
-# Set the port for the Thrift RPC service, which is used for client connections. (Default: 9160)
-#-Dcassandra.rpc_port=port
-
 # Set the SSL port for encrypted communication. (Default: 7001)
 #-Dcassandra.ssl_storage_port=port
 


### PR DESCRIPTION
So lots of things have broken in 4.x, most noticeably:
* EC2MRS needs to be tuned by Priam so we can set the legacy option (preventing renaming of racks/dcs)
* Thrift is gone, don't need to have all those options any more
* A few JMX endpoints went away
* jvm-options is a different file now
* InetAddressAndPort broke the seed provider

My plan is to cut a release for 4.0.0-alpha with this branch.