### PR TITLE
Fix 3.11 Bootstrap

### DIFF
--- a/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -67,7 +67,7 @@ public class InstanceIdentity {
             if (config.getAutoBoostrap()) {
                 // auto_bootstrap = true indicates that the cluster is up and running normally, in such a case
                 // we cannot provide the local instance as a seed otherwise we can bootstrap nodes with no data
-                return (!instance.getInstanceId().equalsIgnoreCase(DUMMY_INSTANCE_ID) && !instance.getHostIP().equals(myInstance.getHostIP()));
+                return (!instance.getInstanceId().equalsIgnoreCase(DUMMY_INSTANCE_ID) && !instance.getHostName().equals(myInstance.getHostName()));
             } else {
                 // auto_bootstrap = false indicates a freshly provisioned cluster. Some nodes in such a cluster must
                 // provide itself as a seed due to the changes in CASSANDRA-10134 which made it so the cluster would

--- a/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -307,6 +307,12 @@ public class InstanceIdentity {
         return replacedIp;
     }
 
+    public void setReplacedIp(String replacedIp) {
+        this.replacedIp = replacedIp;
+        if (!replacedIp.isEmpty())
+            this.isReplace = true;
+    }
+
     private static boolean isInstanceDummy(PriamInstance instance) {
         return instance.getInstanceId().equals(DUMMY_INSTANCE_ID);
     }

--- a/priam/src/main/java/com/netflix/priam/resources/CassandraConfig.java
+++ b/priam/src/main/java/com/netflix/priam/resources/CassandraConfig.java
@@ -25,8 +25,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -109,6 +111,17 @@ public class CassandraConfig {
         }
     }
 
+    @POST
+    @Path("/set_replaced_ip")
+    public Response setReplacedIp(@QueryParam("ip") String ip) {
+        try {
+            priamServer.getId().setReplacedIp(ip);
+            return Response.ok().build();
+        } catch (Exception e) {
+            logger.error("Error while overriding replacement ip", e);
+            return Response.serverError().build();
+        }
+    }
 
     @GET
     @Path("/get_extra_env_params")

--- a/priam/src/test/java/com/netflix/priam/backup/identity/InstanceIdentityTest.java
+++ b/priam/src/test/java/com/netflix/priam/backup/identity/InstanceIdentityTest.java
@@ -26,6 +26,8 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class InstanceIdentityTest extends InstanceTestUtils
 {
@@ -66,11 +68,34 @@ public class InstanceIdentityTest extends InstanceTestUtils
     }
     
     @Test
-    public void testGetSeeds() throws Exception
+    public void testGetSeedsAutobootstrapTrue() throws Exception
     {
-        createInstances();
-        identity = createInstanceIdentity("az1", "fakeinstance1");
-        assertEquals(3, identity.getSeeds().size());
+        boolean previous = (Boolean) config.getFakeConfig("auto_bootstrap");
+        try {
+            config.setFakeConfig("auto_bootstrap", true);
+            createInstances();
+            identity = createInstanceIdentity("az1", "fakeinstance1");
+            assertEquals(3, identity.getSeeds().size());
+            assertFalse(identity.getSeeds().contains("fakeinstance1"));
+        } finally {
+            config.setFakeConfig("auto_bootstrap", previous);
+        }
+
+    }
+
+    @Test
+    public void testGetSeedsAutobootstrapFalse() throws Exception
+    {
+        boolean previous = (Boolean) config.getFakeConfig("auto_bootstrap");
+        try {
+            config.setFakeConfig("auto_bootstrap", false);
+            createInstances();
+            identity = createInstanceIdentity("az1", "fakeinstance1");
+            assertEquals(3, identity.getSeeds().size());
+            assertTrue(identity.getSeeds().contains("fakeinstance1"));
+        } finally {
+            config.setFakeConfig("auto_bootstrap", previous);
+        }
     }
 
     @Test

--- a/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
@@ -19,9 +19,7 @@ package com.netflix.priam.config;
 
 import com.google.common.collect.Lists;
 import com.google.inject.Singleton;
-import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.tuner.JVMOption;
-import com.netflix.priam.config.PriamConfiguration;
 import com.netflix.priam.tuner.GCType;
 import com.netflix.priam.identity.config.InstanceDataRetriever;
 import com.netflix.priam.identity.config.LocalInstanceDataRetriever;
@@ -30,6 +28,7 @@ import com.netflix.priam.scheduler.UnsupportedTypeException;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -44,6 +43,7 @@ public class FakeConfiguration implements IConfiguration
     public String zone;
     public String instance_id;
     public String restorePrefix;
+    public Map<String, Object> fakeConfig;
 
     public FakeConfiguration()
     {
@@ -57,6 +57,16 @@ public class FakeConfiguration implements IConfiguration
         this.zone = zone;
         this.instance_id = ins_id;
         this.restorePrefix  = "";
+        fakeConfig = new HashMap<>();
+        fakeConfig.put("auto_bootstrap", false);
+    }
+
+    public Object getFakeConfig(String key) {
+        return fakeConfig.get(key);
+    }
+
+    public void setFakeConfig(String key, Object value) {
+        fakeConfig.put(key, value);
     }
 
     @Override
@@ -673,8 +683,7 @@ public class FakeConfiguration implements IConfiguration
 
     @Override
     public boolean getAutoBoostrap() {
-        // TODO Auto-generated method stub
-        return false;
+        return (Boolean) fakeConfig.getOrDefault("auto_bootstrap", false);
     }
 
     @Override

--- a/priam/src/test/java/com/netflix/priam/identity/FakePriamInstanceFactory.java
+++ b/priam/src/test/java/com/netflix/priam/identity/FakePriamInstanceFactory.java
@@ -39,7 +39,9 @@ public class FakePriamInstanceFactory implements IPriamInstanceFactory<PriamInst
     @Override
     public List<PriamInstance> getAllIds(String appName)
     {
-        return new ArrayList<PriamInstance>(instances.values());
+        List<PriamInstance> result = new ArrayList<>(instances.values());
+        sort(result);
+        return result;
     }
     
     @Override


### PR DESCRIPTION
Previously we would provide the local node as a seed even if `auto_bootstrap` was set to true, which meant that when doubling we could potentially stream no data. Providing the local node as a seed was added to work around the (imo buggy) behavior introduced in CASSANDRA-10134 where the shadow round fails unless the node is a seed which even if `auto_bootstrap` was turned off.

I also added a way to fix the A->B->C Priam replacement issue via manual override of replaceIp.