### PR TITLE
Provide an overwrite method to force Priam to replace a particular ip

### DIFF
--- a/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -296,6 +296,12 @@ public class InstanceIdentity {
         return replacedIp;
     }
 
+    public void setReplacedIp(String replacedIp) {
+        this.replacedIp = replacedIp;
+        if (!replacedIp.isEmpty())
+            this.isReplace = true;
+    }
+
     private static boolean isInstanceDummy(PriamInstance instance) {
         return instance.getInstanceId().equals(DUMMY_INSTANCE_ID);
     }

--- a/priam/src/main/java/com/netflix/priam/resources/CassandraConfig.java
+++ b/priam/src/main/java/com/netflix/priam/resources/CassandraConfig.java
@@ -25,8 +25,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -109,6 +111,17 @@ public class CassandraConfig {
         }
     }
 
+    @POST
+    @Path("/set_replaced_ip")
+    public Response setReplacedIp(@QueryParam("ip") String ip) {
+        try {
+            priamServer.getId().setReplacedIp(ip);
+            return Response.ok().build();
+        } catch (Exception e) {
+            logger.error("Error while overriding replacement ip", e);
+            return Response.serverError().build();
+        }
+    }
 
     @GET
     @Path("/get_extra_env_params")


### PR DESCRIPTION
This allows us to work around the A->B->C replacement problem where
Priam get's confused about who to replace