### PR TITLE
Expose Priam config via HTTP

### DIFF
--- a/priam/src/main/java/com/netflix/priam/PriamServer.java
+++ b/priam/src/main/java/com/netflix/priam/PriamServer.java
@@ -29,6 +29,7 @@ import com.netflix.priam.cluster.management.Flush;
 import com.netflix.priam.cluster.management.IClusterManagement;
 import com.netflix.priam.config.IBackupRestoreConfig;
 import com.netflix.priam.config.IConfiguration;
+import com.netflix.priam.config.PriamConfigurationPersister;
 import com.netflix.priam.defaultimpl.ICassandraProcess;
 import com.netflix.priam.identity.InstanceIdentity;
 import com.netflix.priam.restore.RestoreContext;
@@ -133,21 +134,30 @@ public class PriamServer {
         scheduler.addTaskWithDelay(CassandraMonitor.JOBNAME, CassandraMonitor.class, CassandraMonitor.getTimer(), CASSANDRA_MONITORING_INITIAL_DELAY);
 
 
-        //Set cleanup
+        // Set cleanup
         scheduler.addTask(UpdateCleanupPolicy.JOBNAME, UpdateCleanupPolicy.class, UpdateCleanupPolicy.getTimer());
 
-        //Set up nodetool flush task
+        // Set up nodetool flush task
         TaskTimer flushTaskTimer = Flush.getTimer(config);
         if (flushTaskTimer != null) {
             scheduler.addTask(IClusterManagement.Task.FLUSH.name(), Flush.class, flushTaskTimer);
             logger.info("Added nodetool flush task.");
         }
 
-        //Set up compaction task
+        // Set up compaction task
         TaskTimer compactionTimer = Compaction.getTimer(config);
         if (compactionTimer != null) {
             scheduler.addTask(IClusterManagement.Task.COMPACTION.name(), Compaction.class, compactionTimer);
             logger.info("Added compaction task.");
+        }
+
+        // Set up the background configuration dumping thread
+        TaskTimer configurationPersisterTimer = PriamConfigurationPersister.getTimer(config);
+        if (configurationPersisterTimer != null) {
+            scheduler.addTask(PriamConfigurationPersister.NAME, PriamConfigurationPersister.class, configurationPersisterTimer);
+            logger.info("Added configuration persister task with schedule [{}]", configurationPersisterTimer.getCronExpression());
+        } else {
+            logger.warn("Priam configuration persister disabled!");
         }
 
         //Set up the SnapshotService

--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -825,7 +825,7 @@ public interface IConfiguration {
      *
      * Default: every minute
      *
-     * @return Cron expression for flush
+     * @return Cron expression for merged configuration writing
      * @see <a href="http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html">quartz-scheduler</a>
      * @see <a href="http://www.cronmaker.com">http://www.cronmaker.com</a> To build new cron timer
      */

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfigurationPersister.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfigurationPersister.java
@@ -1,0 +1,95 @@
+package com.netflix.priam.config;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.netflix.priam.scheduler.CronTimer;
+import com.netflix.priam.scheduler.Task;
+import com.netflix.priam.scheduler.TaskTimer;
+
+/**
+ * Task that persists structured and merged priam configuration to disk.
+ */
+@Singleton
+public class PriamConfigurationPersister extends Task
+{
+    public static final String NAME = "PriamConfigurationPersister";
+
+    private static final Logger logger = LoggerFactory.getLogger(PriamConfigurationPersister.class);
+
+    private final Path mergedConfigDirectory;
+    private final Path structuredPath;
+
+    @Inject
+    public PriamConfigurationPersister(IConfiguration config) {
+        super(config);
+
+        mergedConfigDirectory = Paths.get(config.getMergedConfigurationDirectory());
+        structuredPath = Paths.get(config.getMergedConfigurationDirectory(), "structured.json");
+    }
+
+    private synchronized void ensurePaths() throws IOException
+    {
+        File directory = mergedConfigDirectory.toFile();
+
+        if (directory.mkdirs()) {
+            Files.setPosixFilePermissions(mergedConfigDirectory, PosixFilePermissions.fromString("rwx------"));
+            logger.info("Set up PriamConfigurationPersister directory successfully");
+        }
+    }
+
+
+    @Override
+    public void execute() throws Exception
+    {
+        ensurePaths();
+
+        File output = File.createTempFile(structuredPath.getFileName().toString(), ".tmp", mergedConfigDirectory.toFile());
+
+        // The configuration might contain sensitive information, so ... don't let non Priam users read it
+        // Theoretically createTempFile creates the file with the right permissions, but I want to be explicit
+        Files.setPosixFilePermissions(output.toPath(), PosixFilePermissions.fromString("rw-------"));
+
+        Map<String, Object> structuredConfiguration = config.getStructuredConfiguration("all");
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectWriter structuredPathTmpWriter = mapper.writer(new MinimalPrettyPrinter());
+        structuredPathTmpWriter.writeValue(output, structuredConfiguration);
+
+        // Atomically swap out the new config for the old config.
+        if (!output.renameTo(structuredPath.toFile())) {
+            logger.error("Failed to persist structured Priam configuration");
+            output.delete();
+        }
+    }
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    /**
+     * Timer to be used for configuration writing.
+     *
+     * @param config {@link IConfiguration} to get configuration details from priam.
+     * @return the timer to be used for Configuration Persisting from {@link IConfiguration#getMergedConfigurationCronExpression()}
+     */
+    public static TaskTimer getTimer(IConfiguration config) {
+        return CronTimer.getCronTimer(NAME, config.getMergedConfigurationCronExpression());
+    }
+
+}

--- a/priam/src/main/java/com/netflix/priam/resources/PriamConfig.java
+++ b/priam/src/main/java/com/netflix/priam/resources/PriamConfig.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.priam.resources;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.netflix.priam.PriamServer;
+
+/**
+ * This servlet will provide the configuration API service for use by external scripts and tooling
+ */
+@Path("/v1/config")
+@Produces(MediaType.APPLICATION_JSON)
+public class PriamConfig
+{
+    private static final Logger logger = LoggerFactory.getLogger(PriamConfig.class);
+    private PriamServer priamServer;
+
+    @Inject
+    public PriamConfig(PriamServer server) {
+        this.priamServer = server;
+    }
+
+    private Response doGetPriamConfig(String group, String name) {
+        try {
+            final Map<String, Object> result = new HashMap<>();
+            final Map<String, Object> value = priamServer.getConfiguration().getStructuredConfiguration(group);
+            if (name != null && value.containsKey(name)) {
+                result.put(name, value.get(name));
+                return Response.ok(result, MediaType.APPLICATION_JSON).build();
+            } else if (name != null) {
+                result.put("message", String.format("No such structured config: [%s]", name));
+                logger.error(String.format("No such structured config: [%s]", name));
+                return Response.status(404).entity(result).type(MediaType.APPLICATION_JSON).build();
+            } else {
+                result.putAll(value);
+                return Response.ok(result, MediaType.APPLICATION_JSON).build();
+            }
+        } catch (Exception e) {
+            logger.error("Error while executing getPriamConfig", e);
+            return Response.serverError().build();
+        }
+    }
+
+
+    @GET
+    @Path("/structured/{group}")
+    public Response getPriamConfig(@PathParam("group") String group, @PathParam("name") String name) {
+        return doGetPriamConfig(group, null);
+    }
+
+    @GET
+    @Path("/structured/{group}/{name}")
+    public Response getPriamConfigByName(@PathParam("group") String group, @PathParam("name") String name) {
+        return doGetPriamConfig(group, name);
+    }
+
+    @GET
+    @Path("/unstructured/{name}")
+    public Response getProperty(@PathParam("name") String name, @QueryParam("default") String defaultValue) {
+        Map<String, Object> result = new HashMap<>();
+        try {
+            String value = priamServer.getConfiguration().getProperty(name, defaultValue);
+            if (value != null) {
+                result.put(name, value);
+                return Response.ok(result, MediaType.APPLICATION_JSON).build();
+            } else {
+                result.put("message", String.format("No such property: [%s]", name));
+                logger.error(String.format("No such property: [%s]", name));
+                return Response.status(404).entity(result).type(MediaType.APPLICATION_JSON).build();
+            }
+        } catch (Exception e) {
+            logger.error("Error while executing getPriamConfig", e);
+            return Response.serverError().build();
+        }
+    }
+}

--- a/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
@@ -26,8 +26,10 @@ import com.netflix.priam.scheduler.UnsupportedTypeException;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Singleton
 public class FakeConfiguration implements IConfiguration {
@@ -39,6 +41,9 @@ public class FakeConfiguration implements IConfiguration {
     public String zone;
     public String instance_id;
     private String restorePrefix;
+
+    public Map<String, String> fakeProperties = new HashMap<>();
+
 
     public FakeConfiguration() {
         this(FAKE_REGION, "my_fake_cluster", "my_zone", "i-01234567");
@@ -785,5 +790,17 @@ public class FakeConfiguration implements IConfiguration {
     @Override
     public int getPostRestoreHookTimeOutInDays() {
         return 2;
+    }
+
+    @Override
+    public String getProperty(String key, String defaultValue)
+    {
+        return fakeProperties.getOrDefault(key, defaultValue);
+    }
+
+    @Override
+    public String getMergedConfigurationDirectory()
+    {
+        return fakeProperties.getOrDefault("priam_test_config", "/tmp/priam_test_config");
     }
 }

--- a/priam/src/test/java/com/netflix/priam/config/PriamConfigurationPersisterTest.java
+++ b/priam/src/test/java/com/netflix/priam/config/PriamConfigurationPersisterTest.java
@@ -1,0 +1,66 @@
+package com.netflix.priam.config;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.netflix.priam.TestModule;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+public class PriamConfigurationPersisterTest
+{
+    private static PriamConfigurationPersister persister;
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private FakeConfiguration fakeConfiguration;
+
+    @Before
+    public void setUp() {
+        Injector injector = Guice.createInjector(new TestModule());
+        fakeConfiguration = (FakeConfiguration) injector.getInstance(IConfiguration.class);
+        fakeConfiguration.fakeProperties.put("priam_test_config", folder.getRoot().getPath());
+
+        if (persister == null)
+            persister = injector.getInstance(PriamConfigurationPersister.class);
+    }
+
+    @After
+    public void cleanUp() {
+        fakeConfiguration.fakeProperties.clear();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void execute() throws Exception
+    {
+        Path structuredJson = Paths.get(folder.getRoot().getPath(), "structured.json");
+
+        persister.execute();
+        assertTrue(structuredJson.toFile().exists());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> myMap = objectMapper.readValue(Files.readAllBytes(structuredJson), HashMap.class);
+        assertEquals(myMap.get("backupLocation"), fakeConfiguration.getBackupLocation());
+    }
+
+    @Test
+    public void getTimer()
+    {
+        assertEquals("0 * * * * ? *", PriamConfigurationPersister.getTimer(fakeConfiguration).getCronExpression());
+    }
+}

--- a/priam/src/test/java/com/netflix/priam/resources/PriamConfigTest.java
+++ b/priam/src/test/java/com/netflix/priam/resources/PriamConfigTest.java
@@ -1,0 +1,85 @@
+package com.netflix.priam.resources;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.core.Response;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.inject.Inject;
+import com.netflix.priam.PriamServer;
+import com.netflix.priam.config.FakeConfiguration;
+import com.netflix.priam.config.IConfiguration;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+
+import static org.junit.Assert.*;
+
+@RunWith(JMockit.class)
+public class PriamConfigTest
+{
+    private @Mocked PriamServer priamServer;
+
+    private PriamConfig resource;
+
+    private FakeConfiguration fakeConfiguration;
+
+    @Before
+    public void setUp() {
+        resource = new PriamConfig(priamServer);
+        fakeConfiguration = new FakeConfiguration("test", "cass_test", "test", "12345");
+        fakeConfiguration.fakeProperties.put("test.prop", "test_value");
+    }
+
+
+    @Test
+    public void getPriamConfig()
+    {
+        final Map<String, String> expected = new HashMap<>();
+        expected.put("backupLocation", "casstestbackup");
+        new Expectations() {
+            {
+                priamServer.getConfiguration();
+                result = fakeConfiguration;
+                times = 2;
+            }
+        };
+
+        Response response = resource.getPriamConfigByName("all", "backupLocation");
+        assertEquals(200, response.getStatus());
+        assertEquals(expected, response.getEntity());
+
+        Response badResponse = resource.getPriamConfigByName("all", "getUnrealThing");
+        assertEquals(404, badResponse.getStatus());
+    }
+
+    @Test
+    public void getProperty()
+    {
+        final Map<String, String> expected = new HashMap<>();
+        expected.put("test.prop", "test_value");
+        new Expectations() {
+            {
+                priamServer.getConfiguration();
+                result = fakeConfiguration;
+                times = 3;
+            }
+        };
+
+        Response response = resource.getProperty("test.prop", null);
+        assertEquals(200, response.getStatus());
+        assertEquals(expected, response.getEntity());
+
+        Response defaultResponse = resource.getProperty("not.a.property", "NOVALUE");
+        expected.clear();
+        expected.put("not.a.property", "NOVALUE");
+        assertEquals(200, defaultResponse.getStatus());
+        assertEquals(expected, defaultResponse.getEntity());
+
+        Response badResponse = resource.getProperty("not.a.property", null);
+        assertEquals(404, badResponse.getStatus());
+    }
+}


### PR DESCRIPTION
    Expose Priam config via HTTP and persist to disk
    
    This provides two new HTTP APIs for external tools to access Priam
    configuration. These APIs allow external tools to work with Priam to
    manage Cassandra while still using Priam's flat configuration as a
    source of truth for the Cassandra instance
    
    GET /v1/config/structured/all -> returns all Priam IConfiguration fields
    
    GET /v1/config/unstructured/X?default=Y -> returns the property X, or Y if
    it is not found (404 will be raised if no default and the value doesn't
    exist)
    
    In addition to the HTTP apis there is also now a persister thread which
    makes it so that every minute (by default) configuration is written out
    to a directory in tmp by Priam. This way tools can access config even if
    Priam is dead. The file permissions are 600 so that only the Priam user
    can access it.
