### PR TITLE
Move forgotten files to lost_found directory 

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
@@ -249,7 +249,7 @@ public class SnapshotBackup extends AbstractBackup {
             final Path destDir = Paths.get(columnfamilyDir.getAbsolutePath(), "lost+found");
             for (File file : columnfamilyFiles) {
                 logger.warn("Forgotten file: {} found for CF: {}", file.getAbsolutePath(), columnfamilyDir.getName());
-                if (config.shouldMoveForgottenFiles()) {
+                if (config.isForgottenFileMoveEnabled()) {
                     try {
                         FileUtils.moveFileToDirectory(file, destDir.toFile(), true);
                     } catch (IOException e) {

--- a/priam/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
@@ -38,6 +38,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -126,6 +128,7 @@ public class SnapshotBackup extends AbstractBackup {
 
         } catch (Exception e) {
             logger.error("Exception occurred while taking snapshot: {}. Exception: {}", snapshotName, e.getLocalizedMessage());
+            e.printStackTrace();
             snapshotStatusMgr.failed(backupMetadata);
             throw e;
         } finally {
@@ -238,11 +241,17 @@ public class SnapshotBackup extends AbstractBackup {
             if (columnfamilyFiles.size() == 0)
                 return;
 
-            columnfamilyFiles.parallelStream().forEach(file -> logger.info("Forgotten file: {} found for CF: {}", file.getAbsolutePath(), columnfamilyDir.getName()));
-
-            //TODO: The eventual plan is to move the forgotten files to a lost+found directory and clean the directory after 'x' amount of time. This behavior should be configurable. 
-            backupMetrics.incrementForgottenFiles(columnfamilyFiles.size());
             logger.warn("# of forgotten files: {} found for CF: {}", columnfamilyFiles.size(), columnfamilyDir.getName());
+            backupMetrics.incrementForgottenFiles(columnfamilyFiles.size());
+
+            //Move the files to lost_found directory if configured.
+            final Path destDir = Paths.get(columnfamilyDir.getAbsolutePath(), "lost_found");
+            for (File file : columnfamilyFiles) {
+                logger.info("Forgotten file: {} found for CF: {}", file.getAbsolutePath(), columnfamilyDir.getName());
+                if (config.shouldMoveForgottenFiles())
+                    FileUtils.moveFileToDirectory(file, destDir.toFile(), true);
+            }
+
         } catch (Exception e) {
             //Eat the exception, if there, for any reason. This should not stop the snapshot for any reason.
             logger.error("Exception occurred while trying to find forgottenFile. Ignoring the error and continuing with remaining backup", e);

--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -926,7 +926,7 @@ public interface IConfiguration {
      * at later time at the same time ensuring that Cassandra does not resurrect data.
      * @return true if Priam should move forgotten file to "lost_found" directory of that CF.
      */
-    default boolean shouldMoveForgottenFiles() { return false; }
+    default boolean isForgottenFileMoveEnabled() { return false; }
 
     /**
      * A method for allowing access to outside programs to Priam configuration when paired with the Priam configuration

--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -919,6 +919,16 @@ public interface IConfiguration {
     }
 
     /**
+     * If any forgotten file is found in Cassandra, it is usually good practice to move/delete them so when cassandra
+     * restarts, it does not load old data which should be removed else you may run into data resurrection issues.
+     * This behavior is fixed in 3.x.
+     * This configuration will allow Priam to move the forgotten files to a "lost_found" directory for user to review
+     * at later time at the same time ensuring that Cassandra does not resurrect data.
+     * @return true if Priam should move forgotten file to "lost_found" directory of that CF.
+     */
+    default boolean shouldMoveForgottenFiles() { return false; }
+
+    /**
      * A method for allowing access to outside programs to Priam configuration when paired with the Priam configuration
      * HTTP endpoint at /v1/config/structured/all/property
      * @param group The group of configuration options to return, currently just returns everything no matter what

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -1097,11 +1097,11 @@ public class PriamConfiguration implements IConfiguration {
 
     @Override
     public int getForgottenFileGracePeriodDays() {
-        return config.get(PRIAM_PRE + ".forgotten.file.grace.period", 1);
+        return config.get(PRIAM_PRE + ".forgottenFileGracePeriodDays", 1);
     }
 
     @Override
-    public boolean shouldMoveForgottenFiles() {
-        return config.get(PRIAM_PRE + ".forgotten.file.move.enable", false);
+    public boolean isForgottenFileMoveEnabled() {
+        return config.get(PRIAM_PRE + ".forgottenFileMoveEnabled", false);
     }
 }

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -258,10 +258,10 @@ public class PriamConfiguration implements IConfiguration {
     public void initialize() {
         try {
             if (this.insEnvIdentity.isClassic()) {
-                this.instanceDataRetriever =  (InstanceDataRetriever) Class.forName("com.netflix.priam.identity.config.AwsClassicInstanceDataRetriever").newInstance();
+                this.instanceDataRetriever = (InstanceDataRetriever) Class.forName("com.netflix.priam.identity.config.AwsClassicInstanceDataRetriever").newInstance();
 
             } else if (this.insEnvIdentity.isNonDefaultVpc()) {
-                this.instanceDataRetriever =  (InstanceDataRetriever) Class.forName("com.netflix.priam.identity.config.AWSVpcInstanceDataRetriever").newInstance();
+                this.instanceDataRetriever = (InstanceDataRetriever) Class.forName("com.netflix.priam.identity.config.AWSVpcInstanceDataRetriever").newInstance();
             } else {
                 throw new IllegalStateException("Unable to determine environemt (vpc, classic) for running instance.");
             }
@@ -284,8 +284,8 @@ public class PriamConfiguration implements IConfiguration {
         SystemUtils.createDirs(getDataFileLocation());
     }
 
-    public InstanceDataRetriever getInstanceDataRetriever()  {
-       return instanceDataRetriever;
+    public InstanceDataRetriever getInstanceDataRetriever() {
+        return instanceDataRetriever;
     }
 
     private void setupEnvVars() {
@@ -369,7 +369,7 @@ public class PriamConfiguration implements IConfiguration {
         config.set(CONFIG_REGION_NAME, REGION);
     }
 
-    public String getInstanceName(){
+    public String getInstanceName() {
         return INSTANCE_ID;
     }
 
@@ -616,7 +616,7 @@ public class PriamConfiguration implements IConfiguration {
     }
 
     @Override
-    public boolean isRestoreEncrypted(){
+    public boolean isRestoreEncrypted() {
         return config.get(PRIAM_PRE + ".encrypted.restore.enabled", false);
     }
 
@@ -1036,7 +1036,7 @@ public class PriamConfiguration implements IConfiguration {
 
     @Override
     public String getBackupStatusFileLoc() {
-        return config.get(CONFIG_BACKUP_STATUS_FILE_LOCATION,  getDataFileLocation() + File.separator + "backup.status");
+        return config.get(CONFIG_BACKUP_STATUS_FILE_LOCATION, getDataFileLocation() + File.separator + "backup.status");
     }
 
     @Override
@@ -1085,8 +1085,7 @@ public class PriamConfiguration implements IConfiguration {
     }
 
     @Override
-    public String getProperty(String key, String defaultValue)
-    {
+    public String getProperty(String key, String defaultValue) {
         return config.get(key, defaultValue);
     }
 
@@ -1094,5 +1093,15 @@ public class PriamConfiguration implements IConfiguration {
     public String getMergedConfigurationCronExpression() {
         // Every minute on the top of the minute.
         return config.get(PRIAM_PRE + ".configMerge.cron", "0 * * * * ? *");
+    }
+
+    @Override
+    public int getForgottenFileGracePeriodDays() {
+        return config.get(PRIAM_PRE + ".forgotten.file.grace.period", 1);
+    }
+
+    @Override
+    public boolean shouldMoveForgottenFiles() {
+        return config.get(PRIAM_PRE + ".forgotten.file.move.enable", false);
     }
 }


### PR DESCRIPTION
* Configuration: `priam.forgotten.file.move.enable`. Default: false. 
This will create the 'lost_found' directory in the column family and move any files Priam finds to be forgotten by Cassandra (and is at least a day old). 