### PR TITLE
Enable uploads from SnapshotMetaService in new backup format

### DIFF
--- a/priam/src/main/java/com/netflix/priam/PriamServer.java
+++ b/priam/src/main/java/com/netflix/priam/PriamServer.java
@@ -53,6 +53,7 @@ public class PriamServer {
     private final Sleeper sleeper;
     private final ICassandraProcess cassProcess;
     private final RestoreContext restoreContext;
+    private final SnapshotMetaService snapshotMetaService;
     private static final int CASSANDRA_MONITORING_INITIAL_DELAY = 10;
     private static final Logger logger = LoggerFactory.getLogger(PriamServer.class);
 
@@ -64,7 +65,8 @@ public class PriamServer {
             InstanceIdentity id,
             Sleeper sleeper,
             ICassandraProcess cassProcess,
-            RestoreContext restoreContext) {
+            RestoreContext restoreContext,
+            SnapshotMetaService snapshotMetaService) {
         this.config = config;
         this.backupRestoreConfig = backupRestoreConfig;
         this.scheduler = scheduler;
@@ -72,6 +74,7 @@ public class PriamServer {
         this.sleeper = sleeper;
         this.cassProcess = cassProcess;
         this.restoreContext = restoreContext;
+        this.snapshotMetaService = snapshotMetaService;
     }
 
     private void createDirectories() {
@@ -205,6 +208,10 @@ public class PriamServer {
                     SnapshotMetaService.class,
                     snapshotMetaServiceTimer);
             logger.info("Added SnapshotMetaService Task.");
+
+            // Try to upload previous snapshots, if any which might have been interrupted by Priam
+            // restart.
+            snapshotMetaService.uploadFiles();
         }
     }
 

--- a/priam/src/main/java/com/netflix/priam/aws/S3BackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3BackupPath.java
@@ -41,7 +41,8 @@ public class S3BackupPath extends AbstractBackupPath {
     }
 
     private void parseV2Prefix(Path remoteFilePath) {
-        assert remoteFilePath.getNameCount() >= 3;
+        if (remoteFilePath.getNameCount() < 3)
+            throw new RuntimeException("Not enough no. of elements to parseV2Prefix : " + remoteFilePath);
         baseDir = remoteFilePath.getName(0).toString();
         clusterName = parseAndValidateAppNameWithHash(remoteFilePath.getName(1).toString());
         token = remoteFilePath.getName(2).toString();
@@ -51,7 +52,7 @@ public class S3BackupPath extends AbstractBackupPath {
     can hash the contents better when we have lot of clusters backing up at the same remote location.
     */
     private String getAppNameWithHash() {
-        return (config.getAppName().hashCode() % 10000) + "_" + config.getAppName();
+        return String.format("%d_%s", config.getAppName().hashCode() % 10000, config.getAppName());
     }
 
     private String parseAndValidateAppNameWithHash(String appNameWithHash) {

--- a/priam/src/main/java/com/netflix/priam/aws/S3BackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3BackupPath.java
@@ -42,7 +42,8 @@ public class S3BackupPath extends AbstractBackupPath {
 
     private void parseV2Prefix(Path remoteFilePath) {
         if (remoteFilePath.getNameCount() < 3)
-            throw new RuntimeException("Not enough no. of elements to parseV2Prefix : " + remoteFilePath);
+            throw new RuntimeException(
+                    "Not enough no. of elements to parseV2Prefix : " + remoteFilePath);
         baseDir = remoteFilePath.getName(0).toString();
         clusterName = parseAndValidateAppNameWithHash(remoteFilePath.getName(1).toString());
         token = remoteFilePath.getName(2).toString();

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystemBase.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystemBase.java
@@ -184,7 +184,7 @@ public abstract class S3FileSystemBase extends AbstractFileSystem {
         } catch (AmazonServiceException ase) {
             // Amazon S3 rejected request
             throw new BackupRestoreException(
-                    "AmazonServiceException while checking existense of object: "
+                    "AmazonServiceException while checking existence of object: "
                             + remotePath
                             + ". Error: "
                             + ase.getMessage());

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
@@ -38,9 +38,9 @@ public abstract class AbstractBackup extends Task {
     static final String INCREMENTAL_BACKUP_FOLDER = "backups";
     public static final String SNAPSHOT_FOLDER = "snapshots";
 
-    final Provider<AbstractBackupPath> pathFactory;
+    protected final Provider<AbstractBackupPath> pathFactory;
 
-    private IBackupFileSystem fs;
+    protected IBackupFileSystem fs;
 
     @Inject
     public AbstractBackup(
@@ -71,10 +71,13 @@ public abstract class AbstractBackup extends Task {
      * @param parent Parent dir
      * @param type Type of file (META, SST, SNAP etc)
      * @param async Upload the file(s) in async fashion if enabled.
+     * @param waitForCompletion wait for completion for all files to upload if using async API. If
+     *     `false` it will queue the files and return with no guarantee to upload.
      * @return List of files that are successfully uploaded as part of backup
      * @throws Exception when there is failure in uploading files.
      */
-    List<AbstractBackupPath> upload(final File parent, final BackupFileType type, boolean async)
+    protected List<AbstractBackupPath> upload(
+            final File parent, final BackupFileType type, boolean async, boolean waitForCompletion)
             throws Exception {
         final List<AbstractBackupPath> bps = Lists.newArrayList();
         final List<Future<Path>> futures = Lists.newArrayList();
@@ -108,7 +111,7 @@ public abstract class AbstractBackup extends Task {
         }
 
         // Wait for all files to be uploaded.
-        if (async) {
+        if (async && waitForCompletion) {
             for (Future future : futures)
                 future.get(); // This might throw exception if there is any error
         }

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
@@ -18,15 +18,13 @@ package com.netflix.priam.backup;
 
 import com.google.inject.ImplementedBy;
 import com.netflix.priam.aws.S3BackupPath;
+import com.netflix.priam.compress.ICompression;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.identity.InstanceIdentity;
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.RandomAccessFile;
 import java.text.ParseException;
+import java.time.Instant;
 import java.util.Date;
-import org.apache.cassandra.io.util.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
@@ -46,7 +44,8 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
         SST,
         CL,
         META,
-        META_V2;
+        META_V2,
+        SST_V2;
 
         public static boolean isDataFile(BackupFileType type) {
             return type != BackupFileType.META
@@ -69,50 +68,29 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
     protected final InstanceIdentity instanceIdentity;
     protected final IConfiguration config;
     private File backupFile;
-    private long lastModified = 0;
+    private Instant lastModified;
     private Date uploadedTs;
+    private ICompression.CompressionAlgorithm compression =
+            ICompression.CompressionAlgorithm.SNAPPY;
 
     public AbstractBackupPath(IConfiguration config, InstanceIdentity instanceIdentity) {
         this.instanceIdentity = instanceIdentity;
         this.config = config;
     }
 
+    // TODO: This is so wrong as it completely depends on the timezone where application is running.
+    // Hopefully everyone running Priam has their clocks set to UTC.
     public static String formatDate(Date d) {
         return new DateTime(d).toString(FMT);
     }
 
+    // TODO: This is so wrong as it completely depends on the timezone where application is running.
+    // Hopefully everyone running Priam has their clocks set to UTC.
     public Date parseDate(String s) {
         return DATE_FORMAT.parseDateTime(s).toDate();
     }
 
-    public InputStream localReader() throws IOException {
-        assert backupFile != null;
-        InputStream ret = null;
-
-        while (true) {
-            if (ret != null) {
-                ret.close();
-            }
-
-            lastModified = backupFile.lastModified();
-            ret = new RafInputStream(new RandomAccessFile(backupFile, "r"));
-
-            // Verify that the file hasn't changed since we opened it.
-            // We could avoid this flow by using the fstat() system call,
-            // but I see no way to do that (easily) from the JVM.
-            // The JVM returns the last modified time in milliseconds,
-            // but on Linux systems tested, it appears to be using the
-            // stat.st_mtime result, which is accurate only to seconds.
-            if (backupFile.lastModified() == lastModified) {
-                break;
-            }
-        }
-
-        return ret;
-    }
-
     public void parseLocal(File file, BackupFileType type) throws ParseException {
-        // TODO cleanup.
         this.backupFile = file;
 
         String rpath =
@@ -127,9 +105,17 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
             this.keyspace = elements[0];
             this.columnFamily = elements[1];
         }
+
+        time = new Date(file.lastModified());
+
+        /*
+        1. For old style snapshots, make this value to time at which backup was executed.
+        2. This is to ensure that all the files from the snapshot are uploaded under single directory in remote file system.
+        3. For META file we always override the time field via @link{Metadata#decorateMetaJson}
+        */
         if (type == BackupFileType.SNAP) time = parseDate(elements[3]);
-        if (type == BackupFileType.SST || type == BackupFileType.CL)
-            time = new Date(file.lastModified());
+
+        this.lastModified = Instant.ofEpochMilli(file.lastModified());
         this.fileName = file.getName();
         this.size = file.length();
     }
@@ -230,6 +216,10 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
         return time;
     }
 
+    public void setTime(Date time) {
+        this.time = time;
+    }
+
     /*
     @return original, uncompressed file size
      */
@@ -269,31 +259,20 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
         return this.uploadedTs;
     }
 
-    public long getLastModified() {
+    public Instant getLastModified() {
         return lastModified;
     }
 
-    public static class RafInputStream extends InputStream implements AutoCloseable {
-        private final RandomAccessFile raf;
+    public void setLastModified(Instant instant) {
+        this.lastModified = instant;
+    }
 
-        public RafInputStream(RandomAccessFile raf) {
-            this.raf = raf;
-        }
+    public ICompression.CompressionAlgorithm getCompression() {
+        return compression;
+    }
 
-        @Override
-        public synchronized int read(byte[] bytes, int off, int len) throws IOException {
-            return raf.read(bytes, off, len);
-        }
-
-        @Override
-        public void close() {
-            FileUtils.closeQuietly(raf);
-        }
-
-        @Override
-        public int read() throws IOException {
-            return 0;
-        }
+    public void setCompression(ICompression.CompressionAlgorithm compression) {
+        this.compression = compression;
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/backup/IBackupFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/backup/IBackupFileSystem.java
@@ -145,6 +145,18 @@ public interface IBackupFileSystem {
     long getFileSize(Path remotePath) throws BackupRestoreException;
 
     /**
+     * Checks if the file denoted by remotePath exists on the remote file system. It does not need
+     * check if object was completely uploaded to remote file system.
+     *
+     * @param remotePath location on the remote file system.
+     * @return boolean value indicating presence of the file on remote file system.
+     * @throws BackupRestoreException
+     */
+    default boolean doesRemoteFileExist(Path remotePath) throws BackupRestoreException {
+        return false;
+    }
+
+    /**
      * Get the number of tasks en-queue in the filesystem for upload.
      *
      * @return the total no. of tasks to be executed.

--- a/priam/src/main/java/com/netflix/priam/backup/IncrementalBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/IncrementalBackup.java
@@ -98,7 +98,7 @@ public class IncrementalBackup extends AbstractBackup {
     protected void processColumnFamily(String keyspace, String columnFamily, File backupDir)
             throws Exception {
         List<AbstractBackupPath> uploadedFiles =
-                upload(backupDir, BackupFileType.SST, config.enableAsyncIncremental());
+                upload(backupDir, BackupFileType.SST, config.enableAsyncIncremental(), true);
 
         if (!uploadedFiles.isEmpty()) {
             // format of yyyymmddhhmm (e.g. 201505060901)

--- a/priam/src/main/java/com/netflix/priam/backup/MetaData.java
+++ b/priam/src/main/java/com/netflix/priam/backup/MetaData.java
@@ -87,7 +87,7 @@ public class MetaData {
             throws ParseException {
         AbstractBackupPath backupfile = pathFactory.get();
         backupfile.parseLocal(metafile, BackupFileType.META);
-        backupfile.time = backupfile.parseDate(snapshotName);
+        backupfile.setTime(backupfile.parseDate(snapshotName));
         return backupfile;
     }
 

--- a/priam/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/SnapshotBackup.java
@@ -243,7 +243,7 @@ public class SnapshotBackup extends AbstractBackup {
         findAndMoveForgottenFiles(snapshotDir);
         // Add files to this dir
         abstractBackupPaths.addAll(
-                upload(snapshotDir, BackupFileType.SNAP, config.enableAsyncSnapshot()));
+                upload(snapshotDir, BackupFileType.SNAP, config.enableAsyncSnapshot(), true));
     }
 
     private void findAndMoveForgottenFiles(File snapshotDir) {

--- a/priam/src/main/java/com/netflix/priam/backupv2/FileUploadResult.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/FileUploadResult.java
@@ -38,7 +38,7 @@ public class FileUploadResult {
     // Valid compression technique for now is SNAPPY only. Future we need to support LZ4 and NONE
     private ICompression.CompressionAlgorithm compression =
             ICompression.CompressionAlgorithm.SNAPPY;
-    private Path backupPath;
+    private String backupPath;
 
     public FileUploadResult(
             Path fileName,
@@ -112,11 +112,11 @@ public class FileUploadResult {
         this.compression = compression;
     }
 
-    public Path getBackupPath() {
+    public String getBackupPath() {
         return backupPath;
     }
 
-    public void setBackupPath(Path backupPath) {
+    public void setBackupPath(String backupPath) {
         this.backupPath = backupPath;
     }
 

--- a/priam/src/main/java/com/netflix/priam/backupv2/PrefixGenerator.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/PrefixGenerator.java
@@ -16,74 +16,11 @@
  */
 package com.netflix.priam.backupv2;
 
-import com.netflix.priam.config.IConfiguration;
-import com.netflix.priam.identity.InstanceIdentity;
-import com.netflix.priam.utils.DateUtil;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Instant;
-import javax.inject.Inject;
-
 /**
  * This is a utility class to get the backup location of the SSTables/Meta files with backup version
- * 2.0. TODO: All this functionality will be used when we have BackupUploadDownloadService. Created
- * by aagrawal on 6/5/18.
+ * 2.0.
  */
 public class PrefixGenerator {
-
-    private final IConfiguration configuration;
-    private final InstanceIdentity instanceIdentity;
-
-    @Inject
-    PrefixGenerator(IConfiguration configuration, InstanceIdentity instanceIdentity) {
-        this.configuration = configuration;
-        this.instanceIdentity = instanceIdentity;
-    }
-
-    public Path getPrefix() {
-        return Paths.get(
-                configuration.getBackupLocation(),
-                configuration.getBackupPrefix(),
-                getAppNameReverse(),
-                instanceIdentity.getInstance().getToken());
-    }
-
-    public Path getSSTPrefix() {
-        return getPrefix();
-    }
-
-    public Path getSSTLocation(
-            Instant instant,
-            String keyspaceName,
-            String columnfamilyName,
-            String prefix,
-            String fileName) {
-        return Paths.get(
-                getPrefix().toString(),
-                DateUtil.formatInstant(DateUtil.ddMMyyyyHHmm, instant),
-                keyspaceName,
-                columnfamilyName,
-                prefix,
-                fileName);
-    }
-
-    public Path getMetaPrefix() {
-        return Paths.get(getPrefix().toString(), "META");
-    }
-
-    public Path getMetaLocation(Instant instant, String metaFileName) {
-        return Paths.get(
-                getMetaPrefix().toString(),
-                DateUtil.formatInstant(DateUtil.ddMMyyyyHHmm, instant),
-                metaFileName);
-    }
-
-    private String getAppNameReverse() {
-        return new StringBuilder(configuration.getAppName()).reverse().toString();
-    }
-
-    // e.g. mc-3-big-Data.db or sample_cf-ka-7213-Index.db
-
     /**
      * Gives the prefix (common name) of the sstable components. Returns null if it is not sstable
      * component e.g. mc-3-big-Data.db or ks-cf-ka-7213-Index.db will return mc-3-big or

--- a/priam/src/main/java/com/netflix/priam/config/BackupRestoreConfig.java
+++ b/priam/src/main/java/com/netflix/priam/config/BackupRestoreConfig.java
@@ -26,7 +26,13 @@ public class BackupRestoreConfig implements IBackupRestoreConfig {
         this.config = config;
     }
 
+    @Override
     public String getSnapshotMetaServiceCronExpression() {
         return config.get("priam.snapshot.meta.cron", "-1");
+    }
+
+    @Override
+    public boolean enableV2Backups() {
+        return config.get("priam.enableV2Backups", false);
     }
 }

--- a/priam/src/main/java/com/netflix/priam/config/IBackupRestoreConfig.java
+++ b/priam/src/main/java/com/netflix/priam/config/IBackupRestoreConfig.java
@@ -33,4 +33,14 @@ public interface IBackupRestoreConfig {
     default String getSnapshotMetaServiceCronExpression() {
         return "-1";
     }
+
+    /**
+     * Enable the backup version 2.0 in new format. This will start uploading of backups in new
+     * format. This is to be used for migration from backup version 1.0.
+     *
+     * @return boolean value indicating if backups in version 2.0 should be started.
+     */
+    default boolean enableV2Backups() {
+        return false;
+    }
 }

--- a/priam/src/test/java/com/netflix/priam/aws/TestS3BackupPath.java
+++ b/priam/src/test/java/com/netflix/priam/aws/TestS3BackupPath.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.priam.aws;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import com.netflix.priam.backup.AbstractBackupPath;
+import com.netflix.priam.backup.AbstractBackupPath.BackupFileType;
+import com.netflix.priam.backup.BRTestModule;
+import com.netflix.priam.config.IConfiguration;
+import com.netflix.priam.utils.DateUtil;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.ParseException;
+import java.time.Instant;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Created by aagrawal on 11/23/18. */
+public class TestS3BackupPath {
+    private static final Logger logger = LoggerFactory.getLogger(TestS3BackupPath.class);
+    private Provider<AbstractBackupPath> pathFactory;
+    private IConfiguration configuration;
+
+    public TestS3BackupPath() {
+        Injector injector = Guice.createInjector(new BRTestModule());
+        pathFactory = injector.getProvider(AbstractBackupPath.class);
+        configuration = injector.getInstance(IConfiguration.class);
+    }
+
+    @Test
+    public void testV1BackupPathsSST() throws ParseException {
+        Path path =
+                Paths.get(
+                        configuration.getDataFileLocation(),
+                        "keyspace1",
+                        "columnfamily1",
+                        "backup",
+                        "mc-1234-Data.db");
+        AbstractBackupPath abstractBackupPath = pathFactory.get();
+        abstractBackupPath.parseLocal(path.toFile(), BackupFileType.SST);
+
+        // Verify parse local
+        Assert.assertEquals(
+                0, abstractBackupPath.getLastModified().toEpochMilli()); // File do not exist.
+        Assert.assertEquals("keyspace1", abstractBackupPath.getKeyspace());
+        Assert.assertEquals("columnfamily1", abstractBackupPath.getColumnFamily());
+        Assert.assertEquals(BackupFileType.SST, abstractBackupPath.getType());
+        Assert.assertEquals(path.toFile(), abstractBackupPath.getBackupFile());
+        Assert.assertEquals(
+                0,
+                abstractBackupPath
+                        .getTime()
+                        .toInstant()
+                        .toEpochMilli()); // Since file do not exist.
+
+        // Verify toRemote and parseRemote.
+        String remotePath = abstractBackupPath.getRemotePath();
+        logger.info(remotePath);
+        AbstractBackupPath abstractBackupPath2 = pathFactory.get();
+        abstractBackupPath2.parseRemote(remotePath);
+        Assert.assertEquals(abstractBackupPath, abstractBackupPath2);
+    }
+
+    @Test
+    public void testV1BackupPathsSnap() throws ParseException {
+        Path path =
+                Paths.get(
+                        configuration.getDataFileLocation(),
+                        "keyspace1",
+                        "columnfamily1",
+                        "snapshot",
+                        "201801011201",
+                        "mc-1234-Data.db");
+        AbstractBackupPath abstractBackupPath = pathFactory.get();
+        abstractBackupPath.parseLocal(path.toFile(), BackupFileType.SNAP);
+
+        // Verify parse local
+        Assert.assertEquals(
+                0, abstractBackupPath.getLastModified().toEpochMilli()); // File do not exist.
+        Assert.assertEquals("keyspace1", abstractBackupPath.getKeyspace());
+        Assert.assertEquals("columnfamily1", abstractBackupPath.getColumnFamily());
+        Assert.assertEquals(BackupFileType.SNAP, abstractBackupPath.getType());
+        Assert.assertEquals(path.toFile(), abstractBackupPath.getBackupFile());
+        Assert.assertEquals(
+                "201801011201", AbstractBackupPath.formatDate(abstractBackupPath.getTime()));
+
+        // Verify toRemote and parseRemote.
+        String remotePath = abstractBackupPath.getRemotePath();
+        logger.info(remotePath);
+
+        AbstractBackupPath abstractBackupPath2 = pathFactory.get();
+        abstractBackupPath2.parseRemote(remotePath);
+        Assert.assertEquals(abstractBackupPath, abstractBackupPath2);
+    }
+
+    @Test
+    public void testV1BackupPathsMeta() throws ParseException {
+        Path path = Paths.get(configuration.getDataFileLocation(), "meta.json");
+        AbstractBackupPath abstractBackupPath = pathFactory.get();
+        abstractBackupPath.parseLocal(path.toFile(), BackupFileType.META);
+
+        // Verify parse local
+        Assert.assertEquals(
+                0, abstractBackupPath.getLastModified().toEpochMilli()); // File do not exist.
+        Assert.assertEquals(null, abstractBackupPath.getKeyspace());
+        Assert.assertEquals(null, abstractBackupPath.getColumnFamily());
+        Assert.assertEquals(BackupFileType.META, abstractBackupPath.getType());
+        Assert.assertEquals(path.toFile(), abstractBackupPath.getBackupFile());
+
+        // Verify toRemote and parseRemote.
+        String remotePath = abstractBackupPath.getRemotePath();
+        logger.info(remotePath);
+
+        AbstractBackupPath abstractBackupPath2 = pathFactory.get();
+        abstractBackupPath2.parseRemote(remotePath);
+        Assert.assertEquals(abstractBackupPath, abstractBackupPath2);
+    }
+
+    @Test
+    public void testV2BackupPathSST() throws ParseException {
+        Path path =
+                Paths.get(
+                        configuration.getDataFileLocation(),
+                        "keyspace1",
+                        "columnfamily1",
+                        "backup",
+                        "mc-1234-Data.db");
+        AbstractBackupPath abstractBackupPath = pathFactory.get();
+        abstractBackupPath.parseLocal(path.toFile(), BackupFileType.SST_V2);
+
+        // Verify parse local
+        Assert.assertEquals(
+                0, abstractBackupPath.getLastModified().toEpochMilli()); // File do not exist.
+        Assert.assertEquals("keyspace1", abstractBackupPath.getKeyspace());
+        Assert.assertEquals("columnfamily1", abstractBackupPath.getColumnFamily());
+        Assert.assertEquals(BackupFileType.SST_V2, abstractBackupPath.getType());
+        Assert.assertEquals(path.toFile(), abstractBackupPath.getBackupFile());
+
+        // Verify toRemote and parseRemote.
+        Instant now = DateUtil.getInstant();
+        abstractBackupPath.setLastModified(now);
+        String remotePath = abstractBackupPath.getRemotePath();
+        logger.info(remotePath);
+
+        Assert.assertTrue(remotePath.endsWith(abstractBackupPath.getCompression().toString()));
+
+        AbstractBackupPath abstractBackupPath2 = pathFactory.get();
+        abstractBackupPath2.parseRemote(remotePath);
+        Assert.assertEquals(now, abstractBackupPath2.getLastModified());
+        Assert.assertEquals("mc-1234-Data.db", abstractBackupPath2.getFileName());
+        Assert.assertEquals("keyspace1", abstractBackupPath.getKeyspace());
+        Assert.assertEquals("columnfamily1", abstractBackupPath.getColumnFamily());
+        Assert.assertEquals(BackupFileType.SST_V2, abstractBackupPath.getType());
+    }
+
+    @Test
+    public void testV2BackupPathMeta() throws ParseException {
+        Path path = Paths.get(configuration.getDataFileLocation(), "meta_v2_201801011201.json");
+        AbstractBackupPath abstractBackupPath = pathFactory.get();
+        abstractBackupPath.parseLocal(path.toFile(), BackupFileType.META_V2);
+
+        // Verify parse local
+        Assert.assertEquals(
+                0, abstractBackupPath.getLastModified().toEpochMilli()); // File do not exist.
+        Assert.assertEquals(null, abstractBackupPath.getKeyspace());
+        Assert.assertEquals(null, abstractBackupPath.getColumnFamily());
+        Assert.assertEquals(BackupFileType.META_V2, abstractBackupPath.getType());
+        Assert.assertEquals(path.toFile(), abstractBackupPath.getBackupFile());
+
+        // Verify toRemote and parseRemote.
+        Instant now = DateUtil.getInstant();
+        abstractBackupPath.setLastModified(now);
+        String remotePath = abstractBackupPath.getRemotePath();
+        logger.info(remotePath);
+
+        Assert.assertTrue(remotePath.endsWith(abstractBackupPath.getCompression().toString()));
+
+        AbstractBackupPath abstractBackupPath2 = pathFactory.get();
+        abstractBackupPath2.parseRemote(remotePath);
+        Assert.assertEquals(now, abstractBackupPath2.getLastModified());
+        Assert.assertEquals("meta_v2_201801011201.json", abstractBackupPath2.getFileName());
+        Assert.assertEquals(BackupFileType.META_V2, abstractBackupPath.getType());
+    }
+}

--- a/priam/src/test/java/com/netflix/priam/backup/TestAbstractFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestAbstractFileSystem.java
@@ -117,7 +117,11 @@ public class TestAbstractFileSystem {
         // Dummy upload with compressed size.
         for (File file : files) {
             myFileSystem.uploadFile(
-                    file.toPath(), file.toPath(), getDummyPath(file.toPath()), 2, true);
+                    file.toPath(),
+                    Paths.get(file.toString() + ".tmp"),
+                    getDummyPath(file.toPath()),
+                    2,
+                    true);
             // Verify the success metric for upload is incremented.
             Assert.assertEquals(1, (int) backupMetrics.getValidUploads().actualCount());
 
@@ -142,7 +146,11 @@ public class TestAbstractFileSystem {
         for (File file : files) {
             myFileSystem
                     .asyncUploadFile(
-                            file.toPath(), file.toPath(), getDummyPath(file.toPath()), 2, true)
+                            file.toPath(),
+                            Paths.get(file.toString() + ".tmp"),
+                            getDummyPath(file.toPath()),
+                            2,
+                            true)
                     .get();
             // 1. Verify the success metric for upload is incremented.
             Assert.assertEquals(1, (int) backupMetrics.getValidUploads().actualCount());
@@ -161,7 +169,11 @@ public class TestAbstractFileSystem {
         for (File file : files) {
             futures.add(
                     myFileSystem.asyncUploadFile(
-                            file.toPath(), file.toPath(), getDummyPath(file.toPath()), 2, true));
+                            file.toPath(),
+                            Paths.get(file.toString() + ".tmp"),
+                            getDummyPath(file.toPath()),
+                            2,
+                            true));
         }
 
         // Verify all the work is finished.

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackupFile.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackupFile.java
@@ -117,8 +117,8 @@ public class TestBackupFile {
         String filestr = "cass/data/1234567.meta";
         File bfile = new File(filestr);
         S3BackupPath backupfile = injector.getInstance(S3BackupPath.class);
-        backupfile.time = backupfile.parseDate("201108082320");
         backupfile.parseLocal(bfile, BackupFileType.META);
+        backupfile.setTime(backupfile.parseDate("201108082320"));
         Assert.assertEquals(BackupFileType.META, backupfile.type);
         Assert.assertEquals("1234567", backupfile.token);
         Assert.assertEquals("fake-app", backupfile.clusterName);

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestMetaFileManager.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestMetaFileManager.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.priam.backupv2;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.netflix.priam.backup.BRTestModule;
+import com.netflix.priam.config.IConfiguration;
+import com.netflix.priam.utils.DateUtil;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.temporal.ChronoUnit;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Created by aagrawal on 11/28/18. */
+public class TestMetaFileManager {
+
+    private MetaFileManager metaFileManager;
+    private IConfiguration configuration;
+
+    public TestMetaFileManager() {
+        Injector injector = Guice.createInjector(new BRTestModule());
+        metaFileManager = injector.getInstance(MetaFileManager.class);
+        configuration = injector.getInstance(IConfiguration.class);
+    }
+
+    @After
+    public void cleanup() throws IOException {
+        FileUtils.cleanDirectory(new File(configuration.getDataFileLocation()));
+    }
+
+    @Test
+    public void testCleanupOldMetaFiles() throws IOException {
+        generateDummyMetaFiles();
+        Path dataDir = Paths.get(configuration.getDataFileLocation());
+        Assert.assertEquals(4, dataDir.toFile().listFiles().length);
+
+        // clean the directory
+        metaFileManager.cleanupOldMetaFiles();
+
+        Assert.assertEquals(1, dataDir.toFile().listFiles().length);
+        Path dummy = Paths.get(dataDir.toString(), "dummy.tmp");
+        Assert.assertTrue(dummy.toFile().exists());
+    }
+
+    private void generateDummyMetaFiles() throws IOException {
+        Path dataDir = Paths.get(configuration.getDataFileLocation());
+        FileUtils.write(
+                Paths.get(
+                                configuration.getDataFileLocation(),
+                                MetaFileInfo.getMetaFileName(DateUtil.getInstant()))
+                        .toFile(),
+                "dummy",
+                "UTF-8");
+
+        FileUtils.write(
+                Paths.get(
+                                configuration.getDataFileLocation(),
+                                MetaFileInfo.getMetaFileName(
+                                        DateUtil.getInstant().minus(10, ChronoUnit.MINUTES)))
+                        .toFile(),
+                "dummy",
+                "UTF-8");
+
+        FileUtils.write(
+                Paths.get(
+                                configuration.getDataFileLocation(),
+                                MetaFileInfo.getMetaFileName(DateUtil.getInstant()) + ".tmp")
+                        .toFile(),
+                "dummy",
+                "UTF-8");
+
+        FileUtils.write(
+                Paths.get(configuration.getDataFileLocation(), "dummy.tmp").toFile(),
+                "dummy",
+                "UTF-8");
+    }
+}

--- a/priam/src/test/java/com/netflix/priam/services/TestSnapshotMetaService.java
+++ b/priam/src/test/java/com/netflix/priam/services/TestSnapshotMetaService.java
@@ -82,12 +82,6 @@ public class TestSnapshotMetaService {
     }
 
     @Test
-    public void testPrefix() throws Exception {
-        Assert.assertTrue(prefixGenerator.getPrefix().endsWith("ppa-ekaf/1808575600"));
-        Assert.assertTrue(prefixGenerator.getMetaPrefix().endsWith("ppa-ekaf/1808575600/META"));
-    }
-
-    @Test
     public void testMetaFileName() throws Exception {
         String fileName = MetaFileInfo.getMetaFileName(DateUtil.getInstant());
         Path path = Paths.get(dummyDataDirectoryLocation.toFile().getAbsolutePath(), fileName);


### PR DESCRIPTION
This allows snapshot files to be uploaded from backup version 2.0 in the new format. All the new files are uploaded and the backup file type used is SST_V2. 