### PR TITLE
Support configure/tune complex parameters in cassandra.yaml.

### DIFF
--- a/priam/src/main/java/com/netflix/priam/tuner/StandardTuner.java
+++ b/priam/src/main/java/com/netflix/priam/tuner/StandardTuner.java
@@ -20,6 +20,7 @@ import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.identity.config.InstanceInfo;
 import com.netflix.priam.restore.Restore;
 import java.io.*;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -246,12 +247,30 @@ public class StandardTuner implements ICassandraTuner {
             String priamKey = pair[0];
             String cassKey = pair[1];
             String cassVal = config.getCassYamlVal(priamKey);
-            logger.info(
-                    "Updating yaml: Priamkey[{}], CassKey[{}], Val[{}]",
-                    priamKey,
-                    cassKey,
-                    cassVal);
-            map.put(cassKey, cassVal);
+
+            if (!StringUtils.isBlank(cassKey) && !StringUtils.isBlank(cassVal)) {
+                if (!cassKey.contains(".")) {
+                    logger.info(
+                            "Updating yaml: PriamKey: [{}], Key: [{}], OldValue: [{}], NewValue: [{}]",
+                            priamKey,
+                            cassKey,
+                            map.get(cassKey),
+                            cassVal);
+                    map.put(cassKey, cassVal);
+                } else {
+                    // split the cassandra key. We will get the group and get the key name.
+                    String[] cassKeySplit = cassKey.split("\\.");
+                    Map cassKeyMap = ((Map) map.getOrDefault(cassKeySplit[0], new HashMap()));
+                    map.putIfAbsent(cassKeySplit[0], cassKeyMap);
+                    logger.info(
+                            "Updating yaml: PriamKey: [{}], Key: [{}], OldValue: [{}], NewValue: [{}]",
+                            priamKey,
+                            cassKey,
+                            cassKeyMap.get(cassKeySplit[1]),
+                            cassVal);
+                    cassKeyMap.put(cassKeySplit[1], cassVal);
+                }
+            }
         }
     }
 }

--- a/priam/src/test/java/com/netflix/priam/tuner/StandardTunerTest.java
+++ b/priam/src/test/java/com/netflix/priam/tuner/StandardTunerTest.java
@@ -22,8 +22,19 @@ import static org.junit.Assert.assertEquals;
 import com.google.common.io.Files;
 import com.google.inject.Guice;
 import com.netflix.priam.backup.BRTestModule;
+import com.netflix.priam.config.FakeConfiguration;
+import com.netflix.priam.identity.config.InstanceInfo;
 import java.io.File;
+import java.io.FileInputStream;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
 
 public class StandardTunerTest {
     /* note: these are, more or less, arbitrary partitioner class names. as long as the tests exercise the code, all is good */
@@ -33,9 +44,13 @@ public class StandardTunerTest {
     private static final String BOP_PARTITIONER = "org.apache.cassandra.dht.ByteOrderedPartitioner";
 
     private final StandardTuner tuner;
+    private final InstanceInfo instanceInfo;
+    private final File target = new File("/tmp/priam_test.yaml");
 
     public StandardTunerTest() {
         this.tuner = Guice.createInjector(new BRTestModule()).getInstance(StandardTuner.class);
+        this.instanceInfo =
+                Guice.createInjector(new BRTestModule()).getInstance(InstanceInfo.class);
     }
 
     @Test
@@ -74,12 +89,81 @@ public class StandardTunerTest {
         assertEquals(BOP_PARTITIONER, partitioner);
     }
 
+    @Before
+    @After
+    public void cleanup() {
+        FileUtils.deleteQuietly(target);
+    }
+
     @Test
     public void dump() throws Exception {
-        String target = "/tmp/priam_test.yaml";
-        Files.copy(
-                new File("src/main/resources/incr-restore-cassandra.yaml"),
-                new File("/tmp/priam_test.yaml"));
-        tuner.writeAllProperties(target, "your_host", "YourSeedProvider");
+        Files.copy(new File("src/main/resources/incr-restore-cassandra.yaml"), target);
+        tuner.writeAllProperties(target.getAbsolutePath(), "your_host", "YourSeedProvider");
+    }
+
+    @Test
+    public void addExtraParams() throws Exception {
+        String cassParamName1 = "client_encryption_options.optional";
+        String priamKeyName1 = "Priam.client_encryption.optional";
+        String cassParamName2 = "client_encryption_options.keystore_password";
+        String priamKeyName2 = "Priam.client_encryption.keystore_password";
+        String cassParamName3 = "randomKey";
+        String priamKeyName3 = "Priam.randomKey";
+        String cassParamName4 = "randomGroup.randomKey";
+        String priamKeyName4 = "Priam.randomGroup.randomKey";
+
+        String extraConfigParam =
+                String.format(
+                        "%s=%s,%s=%s,%s=%s,%s=%s",
+                        priamKeyName1,
+                        cassParamName1,
+                        priamKeyName2,
+                        cassParamName2,
+                        priamKeyName3,
+                        cassParamName3,
+                        priamKeyName4,
+                        cassParamName4);
+        Map extraParamValues = new HashMap();
+        extraParamValues.put(priamKeyName1, true);
+        extraParamValues.put(priamKeyName2, "test");
+        extraParamValues.put(priamKeyName3, "randomKeyValue");
+        extraParamValues.put(priamKeyName4, "randomGroupValue");
+        StandardTuner tuner =
+                new StandardTuner(
+                        new TunerConfiguration(extraConfigParam, extraParamValues), instanceInfo);
+        Files.copy(new File("src/main/resources/incr-restore-cassandra.yaml"), target);
+        tuner.writeAllProperties(target.getAbsolutePath(), "your_host", "YourSeedProvider");
+
+        // Read the tuned file and verify
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        Yaml yaml = new Yaml(options);
+        Map map = yaml.load(new FileInputStream(target));
+        Assert.assertEquals("your_host", map.get("listen_address"));
+        Assert.assertEquals("true", ((Map) map.get("client_encryption_options")).get("optional"));
+        Assert.assertEquals(
+                "test", ((Map) map.get("client_encryption_options")).get("keystore_password"));
+        Assert.assertEquals("randomKeyValue", map.get("randomKey"));
+        Assert.assertEquals("randomGroupValue", ((Map) map.get("randomGroup")).get("randomKey"));
+    }
+
+    private class TunerConfiguration extends FakeConfiguration {
+        String extraConfigParams;
+        Map extraParamValues;
+
+        TunerConfiguration(String extraConfigParam, Map<String, String> extraParamValues) {
+            this.extraConfigParams = extraConfigParam;
+            this.extraParamValues = extraParamValues;
+        }
+
+        @Override
+        public String getCassYamlVal(String priamKey) {
+            return extraParamValues.getOrDefault(priamKey, "").toString();
+        }
+
+        @Override
+        public String getExtraConfigParams() {
+            return extraConfigParams;
+        }
     }
 }


### PR DESCRIPTION
Generic way to configure complex cassandra yaml parameters. e.g. setting "priam.extra.params" to value of "Priam.client_optional=client_encryption_options.optional" and creating a property called "Priam.client_optional" and setting its value to "true". 