### PR TITLE
Put a cache in front of remote file system call of objectExist.

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backup/IBackupFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/backup/IBackupFileSystem.java
@@ -180,10 +180,8 @@ public interface IBackupFileSystem {
      *
      * @param remotePath location on the remote file system.
      * @return boolean value indicating presence of the file on remote file system.
-     * @throws BackupRestoreException in case of failure to identify if object exists on the remote
-     *     file system.
      */
-    default boolean doesRemoteFileExist(Path remotePath) throws BackupRestoreException {
+    default boolean checkObjectExists(Path remotePath) {
         return false;
     }
 

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaV2Proxy.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaV2Proxy.java
@@ -222,17 +222,10 @@ public class MetaV2Proxy implements IMetaProxy {
             for (ColumnfamilyResult.SSTableResult ssTableResult :
                     columnfamilyResult.getSstables()) {
                 for (FileUploadResult fileUploadResult : ssTableResult.getSstableComponents()) {
-                    try {
-                        if (fs.doesRemoteFileExist(Paths.get(fileUploadResult.getBackupPath()))) {
-                            verificationResult.filesMatched++;
-                        } else {
-                            verificationResult.filesInMetaOnly.add(
-                                    fileUploadResult.getBackupPath());
-                        }
-                    } catch (BackupRestoreException e) {
-                        // For any error, mark that file is not available.
-                        verificationResult.valid = false;
-                        break;
+                    if (fs.checkObjectExists(Paths.get(fileUploadResult.getBackupPath()))) {
+                        verificationResult.filesMatched++;
+                    } else {
+                        verificationResult.filesInMetaOnly.add(fileUploadResult.getBackupPath());
                     }
                 }
             }

--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -456,6 +456,16 @@ public interface IConfiguration {
         return -1;
     }
 
+    /**
+     * Get the throttle limit for API call of remote file system - get object exist. Default: 10.
+     * Use value of -1 to disable this.
+     *
+     * @return throttle limit for get object exist API call.
+     */
+    default int getRemoteFileSystemObjectExistsThrottle() {
+        return -1;
+    }
+
     /** @return true if Priam should local config file for tokens and seeds */
     default boolean isLocalBootstrapEnabled() {
         return false;

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -339,6 +339,11 @@ public class PriamConfiguration implements IConfiguration {
     }
 
     @Override
+    public int getRemoteFileSystemObjectExistsThrottle() {
+        return config.get(PRIAM_PRE + ".remoteFileSystemObjectExistThrottle", -1);
+    }
+
+    @Override
     public boolean isLocalBootstrapEnabled() {
         return config.get(PRIAM_PRE + ".localbootstrap.enable", false);
     }

--- a/priam/src/main/java/com/netflix/priam/google/GoogleEncryptedFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/google/GoogleEncryptedFileSystem.java
@@ -212,6 +212,12 @@ public class GoogleEncryptedFileSystem extends AbstractFileSystem {
     }
 
     @Override
+    protected boolean doesRemoteFileExist(Path remotePath) {
+        // TODO: Implement based on GCS. Since this is only used for upload, leaving it empty
+        return false;
+    }
+
+    @Override
     public Iterator<String> listFileSystem(String prefix, String delimiter, String marker) {
         return new GoogleFileIterator(constructGcsStorageHandle(), prefix, null);
     }

--- a/priam/src/main/java/com/netflix/priam/services/SnapshotMetaService.java
+++ b/priam/src/main/java/com/netflix/priam/services/SnapshotMetaService.java
@@ -340,7 +340,7 @@ public class SnapshotMetaService extends AbstractBackup {
                     abstractBackupPath.parseLocal(file, AbstractBackupPath.BackupFileType.SST_V2);
                     fileUploadResult.setBackupPath(abstractBackupPath.getRemotePath());
                     fileUploadResult.setUploaded(
-                            fs.doesRemoteFileExist(Paths.get(fileUploadResult.getBackupPath())));
+                            fs.checkObjectExists(Paths.get(fileUploadResult.getBackupPath())));
                 } catch (Exception e) {
                     logger.error(
                             "Error while setting the remoteLocation or checking if file exists. Ignoring them as they are not fatal.",

--- a/priam/src/test/java/com/netflix/priam/backup/FakeBackupFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/FakeBackupFileSystem.java
@@ -116,7 +116,7 @@ public class FakeBackupFileSystem extends AbstractFileSystem {
     }
 
     @Override
-    public boolean doesRemoteFileExist(Path remotePath) throws BackupRestoreException {
+    public boolean doesRemoteFileExist(Path remotePath) {
         for (AbstractBackupPath abstractBackupPath : flist) {
             if (abstractBackupPath.getRemotePath().equalsIgnoreCase(remotePath.toString()))
                 return true;

--- a/priam/src/test/java/com/netflix/priam/backup/NullBackupFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/NullBackupFileSystem.java
@@ -67,6 +67,11 @@ public class NullBackupFileSystem extends AbstractFileSystem {
             throws BackupRestoreException {}
 
     @Override
+    protected boolean doesRemoteFileExist(Path remotePath) {
+        return false;
+    }
+
+    @Override
     protected long uploadFileImpl(Path localPath, Path remotePath) throws BackupRestoreException {
         return 0;
     }


### PR DESCRIPTION
Add a rate limiter to s3 objectExist so we don't get slow down from S3.