### PR TITLE
Provide an overwrite method to force Priam to replace a particular ip

### DIFF
--- a/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -319,6 +319,12 @@ public class InstanceIdentity {
         return replacedIp;
     }
 
+    public void setReplacedIp(String replacedIp) {
+        this.replacedIp = replacedIp;
+        if (!replacedIp.isEmpty())
+            this.isReplace = true;
+    }
+
     private static boolean isInstanceDummy(PriamInstance instance) {
         return instance.getInstanceId().equals(DUMMY_INSTANCE_ID);
     }

--- a/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -321,8 +321,7 @@ public class InstanceIdentity {
 
     public void setReplacedIp(String replacedIp) {
         this.replacedIp = replacedIp;
-        if (!replacedIp.isEmpty())
-            this.isReplace = true;
+        if (!replacedIp.isEmpty()) this.isReplace = true;
     }
 
     private static boolean isInstanceDummy(PriamInstance instance) {

--- a/priam/src/main/java/com/netflix/priam/resources/CassandraConfig.java
+++ b/priam/src/main/java/com/netflix/priam/resources/CassandraConfig.java
@@ -25,8 +25,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
@@ -112,6 +114,18 @@ public class CassandraConfig {
                     .build();
         } catch (Exception e) {
             logger.error("Error while executing get_replaced_ip", e);
+            return Response.serverError().build();
+        }
+    }
+
+    @POST
+    @Path("/set_replaced_ip")
+    public Response setReplacedIp(@QueryParam("ip") String ip) {
+        try {
+            priamServer.getInstanceIdentity().setReplacedIp(ip);
+            return Response.ok().build();
+        } catch (Exception e) {
+            logger.error("Error while overriding replacement ip", e);
             return Response.serverError().build();
         }
     }

--- a/priam/src/main/java/com/netflix/priam/resources/CassandraConfig.java
+++ b/priam/src/main/java/com/netflix/priam/resources/CassandraConfig.java
@@ -31,6 +31,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import org.apache.commons.lang3.StringUtils;
 import org.json.simple.JSONValue;
 import org.slf4j.Logger;
@@ -121,6 +122,8 @@ public class CassandraConfig {
     @POST
     @Path("/set_replaced_ip")
     public Response setReplacedIp(@QueryParam("ip") String ip) {
+        if (StringUtils.isEmpty(ip)) return Response.status(Status.BAD_REQUEST).build();
+
         try {
             priamServer.getInstanceIdentity().setReplacedIp(ip);
             return Response.ok().build();

--- a/priam/src/test/java/com/netflix/priam/resources/CassandraConfigTest.java
+++ b/priam/src/test/java/com/netflix/priam/resources/CassandraConfigTest.java
@@ -18,6 +18,7 @@
 package com.netflix.priam.resources;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
@@ -44,11 +45,14 @@ public class CassandraConfigTest {
     private @Mocked PriamServer priamServer;
     private @Mocked DoubleRing doubleRing;
     private CassandraConfig resource;
+    private InstanceIdentity instanceIdentity;
 
     @Before
     public void setUp() {
         CassMonitorMetrics cassMonitorMetrics =
                 Guice.createInjector(new BRTestModule()).getInstance(CassMonitorMetrics.class);
+        instanceIdentity =
+                Guice.createInjector(new BRTestModule()).getInstance(InstanceIdentity.class);
         resource = new CassandraConfig(priamServer, doubleRing, cassMonitorMetrics);
     }
 
@@ -211,6 +215,24 @@ public class CassandraConfigTest {
         Response response = resource.getReplacedIp();
         assertEquals(200, response.getStatus());
         assertEquals(replacedIp, response.getEntity());
+    }
+
+    @Test
+    public void setReplacedIp() {
+        new Expectations() {
+            {
+                priamServer.getInstanceIdentity();
+                result = instanceIdentity;
+            }
+        };
+
+        Response response = resource.setReplacedIp("127.0.0.1");
+        assertEquals(200, response.getStatus());
+        assertEquals("127.0.0.1", instanceIdentity.getReplacedIp());
+        assertTrue(instanceIdentity.isReplace());
+
+        response = resource.setReplacedIp(null);
+        assertEquals(400, response.getStatus());
     }
 
     @Test


### PR DESCRIPTION
This allows us to work around the A->B->C replacement problem where Priam gets confused about who to replace. 