### PR TITLE
Hotfix: TTL for backup version 2.

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystemBase.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystemBase.java
@@ -258,7 +258,7 @@ public abstract class S3FileSystemBase extends AbstractFileSystem {
     }
 
     @Override
-    public void deleteRemoteFiles(List<Path> remotePaths) throws BackupRestoreException {
+    public void deleteFiles(List<Path> remotePaths) throws BackupRestoreException {
         if (remotePaths.isEmpty()) return;
 
         try {
@@ -274,7 +274,10 @@ public abstract class S3FileSystemBase extends AbstractFileSystem {
                     new DeleteObjectsRequest(getShard()).withKeys(keys).withQuiet(true));
             logger.info("Deleted {} objects from S3", remotePaths.size());
         } catch (Exception e) {
-            logger.error("Error while trying to delete the objects from S3: {}", e.getMessage());
+            logger.error(
+                    "Error while trying to delete [{}]  the objects from S3: {}",
+                    remotePaths.size(),
+                    e.getMessage());
             throw new BackupRestoreException(e + " while trying to delete the objects");
         }
     }

--- a/priam/src/main/java/com/netflix/priam/backupv2/ForgottenFilesManager.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/ForgottenFilesManager.java
@@ -109,7 +109,7 @@ public class ForgottenFilesManager {
         IOFileFilter tmpFileFilter = FileFilterUtils.or(tmpFileFilter1, tmpFileFilter2);
         /*
         Here we are allowing files which were more than
-        @link{IConfiguration#getForgottenFileGracePeriodDaysForCompaction}. We do this to allow cassandra
+        @link{IConfiguration#getGracePeriodDaysForCompaction}. We do this to allow cassandra
         to have files which were generated as part of long running compaction.
         Refer to https://issues.apache.org/jira/browse/CASSANDRA-6756 and
         https://issues.apache.org/jira/browse/CASSANDRA-7066
@@ -118,9 +118,7 @@ public class ForgottenFilesManager {
         IOFileFilter ageFilter =
                 FileFilterUtils.ageFileFilter(
                         snapshotInstant
-                                .minus(
-                                        config.getForgottenFileGracePeriodDaysForCompaction(),
-                                        ChronoUnit.DAYS)
+                                .minus(config.getGracePeriodDaysForCompaction(), ChronoUnit.DAYS)
                                 .toEpochMilli());
         IOFileFilter fileFilter =
                 FileFilterUtils.and(

--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -956,14 +956,18 @@ public interface IConfiguration {
     }
 
     /**
-     * Grace period in days for the file that 'could' be considered to be forgotten by cassandra,
-     * but actually may be output of a long-running compaction job. Note that cassandra creates
-     * output of the compaction as non-tmp-link files (whole SSTable) but are still not part of the
-     * final "view" and thus not part of a snapshot. Only required for cassandra 2.x. Default: 5
+     * Grace period in days for the file that 'could' be output of a long-running compaction job.
+     * Note that cassandra creates output of the compaction as non-tmp-link files (whole SSTable)
+     * but are still not part of the final "view" and thus not part of a snapshot. Another common
+     * issue is "index.db" published "way" before other component files. Thus index file has
+     * modification time before other files .
+     *
+     * <p>This value is used to TTL the backups and to consider file which are forgotten by
+     * Cassandra. Default: 5
      *
      * @return grace period for the compaction output forgotten files.
      */
-    default int getForgottenFileGracePeriodDaysForCompaction() {
+    default int getGracePeriodDaysForCompaction() {
         return 5;
     }
 

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -722,7 +722,7 @@ public class PriamConfiguration implements IConfiguration {
     }
 
     @Override
-    public int getForgottenFileGracePeriodDaysForCompaction() {
+    public int getGracePeriodDaysForCompaction() {
         return config.get(PRIAM_PRE + ".forgottenFileGracePeriodDaysForCompaction", 5);
     }
 

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -723,7 +723,7 @@ public class PriamConfiguration implements IConfiguration {
 
     @Override
     public int getGracePeriodDaysForCompaction() {
-        return config.get(PRIAM_PRE + ".forgottenFileGracePeriodDaysForCompaction", 5);
+        return config.get(PRIAM_PRE + ".gracePeriodDaysForCompaction", 5);
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/google/GoogleEncryptedFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/google/GoogleEncryptedFileSystem.java
@@ -243,7 +243,7 @@ public class GoogleEncryptedFileSystem extends AbstractFileSystem {
     }
 
     @Override
-    public void deleteRemoteFiles(List<Path> remotePaths) throws BackupRestoreException {
+    public void deleteFiles(List<Path> remotePaths) throws BackupRestoreException {
         // TODO: Delete implementation
     }
 

--- a/priam/src/test/java/com/netflix/priam/backup/FakeBackupFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/FakeBackupFileSystem.java
@@ -124,7 +124,7 @@ public class FakeBackupFileSystem extends AbstractFileSystem {
     }
 
     @Override
-    public void deleteRemoteFiles(List<Path> remotePaths) throws BackupRestoreException {
+    public void deleteFiles(List<Path> remotePaths) throws BackupRestoreException {
         remotePaths
                 .stream()
                 .forEach(

--- a/priam/src/test/java/com/netflix/priam/backup/NullBackupFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/NullBackupFileSystem.java
@@ -48,7 +48,7 @@ public class NullBackupFileSystem extends AbstractFileSystem {
     }
 
     @Override
-    public void deleteRemoteFiles(List<Path> remotePaths) throws BackupRestoreException {
+    public void deleteFiles(List<Path> remotePaths) throws BackupRestoreException {
         // Do nothing.
     }
 

--- a/priam/src/test/java/com/netflix/priam/backup/TestS3FileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestS3FileSystem.java
@@ -112,6 +112,26 @@ public class TestS3FileSystem {
     }
 
     @Test
+    public void testFileUploadDeleteExists() throws Exception {
+        MockS3PartUploader.setup();
+        IBackupFileSystem fs = injector.getInstance(NullBackupFileSystem.class);
+        RemoteBackupPath backupfile = injector.getInstance(RemoteBackupPath.class);
+        backupfile.parseLocal(new File(FILE_PATH), BackupFileType.SST_V2);
+        fs.uploadFile(
+                Paths.get(backupfile.getBackupFile().getAbsolutePath()),
+                Paths.get(backupfile.getRemotePath()),
+                backupfile,
+                0,
+                false);
+        Assert.assertTrue(fs.checkObjectExists(Paths.get(backupfile.getRemotePath())));
+        // Lets delete the file now.
+        List<Path> deleteFiles = Lists.newArrayList();
+        deleteFiles.add(Paths.get(backupfile.getRemotePath()));
+        fs.deleteRemoteFiles(deleteFiles);
+        Assert.assertFalse(fs.checkObjectExists(Paths.get(backupfile.getRemotePath())));
+    }
+
+    @Test
     public void testFileUploadFailures() throws Exception {
         MockS3PartUploader.setup();
         MockS3PartUploader.partFailure = true;

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestBackupTTLTask.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestBackupTTLTask.java
@@ -68,7 +68,10 @@ public class TestBackupTTLTask {
         List<String> allFiles = new ArrayList<>();
         metas = new Path[3];
 
-        Instant time = current.minus(daysForSnapshot + 1, ChronoUnit.DAYS);
+        Instant time =
+                current.minus(
+                        daysForSnapshot + configuration.getGracePeriodDaysForCompaction() + 1,
+                        ChronoUnit.DAYS);
         String file1 = testBackupUtils.createFile("mc-1-Data.db", time);
         String file2 =
                 testBackupUtils.createFile("mc-2-Data.db", time.plus(10, ChronoUnit.MINUTES));
@@ -152,7 +155,7 @@ public class TestBackupTTLTask {
         List<String> remoteFiles = getAllFiles();
 
         // Confirm the files.
-        Assert.assertEquals(7, remoteFiles.size());
+        Assert.assertEquals(8, remoteFiles.size());
         Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-4-Data.db")));
         Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-5-Data.db")));
         Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-6-Data.db")));
@@ -160,9 +163,10 @@ public class TestBackupTTLTask {
         Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-1-Data.db")));
         Assert.assertTrue(remoteFiles.contains(allFilesMap.get("META1")));
         Assert.assertTrue(remoteFiles.contains(allFilesMap.get("META2")));
+        // Remains because of GRACE PERIOD.
+        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-3-Data.db")));
 
         Assert.assertFalse(remoteFiles.contains(allFilesMap.get("mc-2-Data.db")));
-        Assert.assertFalse(remoteFiles.contains(allFilesMap.get("mc-3-Data.db")));
         Assert.assertFalse(remoteFiles.contains(allFilesMap.get("META0")));
     }
 
@@ -174,18 +178,18 @@ public class TestBackupTTLTask {
         backupTTLService.execute();
 
         List<String> remoteFiles = getAllFiles();
-        System.out.println(remoteFiles);
         // Confirm the files.
-        Assert.assertEquals(4, remoteFiles.size());
+        Assert.assertEquals(6, remoteFiles.size());
         Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-4-Data.db")));
         Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-6-Data.db")));
         Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-7-Data.db")));
         Assert.assertTrue(remoteFiles.contains(allFilesMap.get("META2")));
+        // GRACE PERIOD files.
+        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-3-Data.db")));
+        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-5-Data.db")));
 
         Assert.assertFalse(remoteFiles.contains(allFilesMap.get("mc-1-Data.db")));
         Assert.assertFalse(remoteFiles.contains(allFilesMap.get("mc-2-Data.db")));
-        Assert.assertFalse(remoteFiles.contains(allFilesMap.get("mc-3-Data.db")));
-        Assert.assertFalse(remoteFiles.contains(allFilesMap.get("mc-5-Data.db")));
         Assert.assertFalse(remoteFiles.contains(allFilesMap.get("META0")));
         Assert.assertFalse(remoteFiles.contains(allFilesMap.get("META1")));
     }


### PR DESCRIPTION
Cassandra can flush files on file system like Index.db first and other component files later (like 30 mins). If there is a snapshot in between, then this "single" component file would not be part of the snapshot as SSTable is still not part of Cassandra's "view". Only if Cassandra could provide strong guarantees on the file system such that  -
1. All component will be flushed to disk as real SSTables only if they are part of the view. Until that happens all the files will be "tmp" files.
2. All component flushed will have the same "last modified" file. i.e. on the first flush. Stats.db can change over time and that is OK.

Since this is not the case, the TTL may end up deleting this file even though the file is part of the next snapshot. To avoid, this we add grace period (based on how long compaction can run) when we delete the files.