### PR TITLE
Priam will check gossip info while grabbing pre-assigned token.

### DIFF
--- a/priam/src/main/java/com/netflix/priam/identity/token/TokenRetrieverUtils.java
+++ b/priam/src/main/java/com/netflix/priam/identity/token/TokenRetrieverUtils.java
@@ -1,0 +1,166 @@
+package com.netflix.priam.identity.token;
+
+import com.netflix.priam.identity.PriamInstance;
+import com.netflix.priam.utils.SystemUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Common utilities for token retrieval. */
+public class TokenRetrieverUtils {
+    private static final Logger logger = LoggerFactory.getLogger(TokenRetrieverBase.class);
+    private static final String GOSSIP_INFO_URL_FORMAT =
+            "http://%s:8080/Priam/REST/v1/cassadmin/gossipinfo";
+
+    /**
+     * Utility method to infer the IP of the owner of a token in a given datacenter. This method
+     * uses Cassandra gossip information to find the owner. While it is ideal to check all the nodes
+     * in the ring to see if they agree on the IP to be replaced, in large clusters it may affect
+     * the startup performance. This method picks at most 3 random hosts from the ring and see if
+     * they all agree on the IP to be replaced. If not, it returns null.
+     *
+     * @param allIds
+     * @param token
+     * @param dc
+     * @return IP of the token owner based on gossip information or null if gossip doesn't converge.
+     * @throws GossipParseException when required number of instances are not available to fetch the
+     *     gossip info.
+     */
+    public static String inferTokenOwnerFromGossip(
+            List<PriamInstance> allIds, String token, String dc) throws GossipParseException {
+        // Avoid using dead instance who we are trying to replace (duh!!)
+        // Avoid other regions instances to avoid communication over public ip address.
+        List<PriamInstance> eligibleInstances =
+                allIds.stream()
+                        .filter(priamInstance -> !priamInstance.getToken().equalsIgnoreCase(token))
+                        .filter(priamInstance -> priamInstance.getDC().equalsIgnoreCase(dc))
+                        .collect(Collectors.toList());
+        // We want to get IP from min 1, max 3 instances to ensure we are not relying on
+        // gossip of a single instance.
+        // Good idea to shuffle so we are not talking to same instances every time.
+        Collections.shuffle(eligibleInstances);
+        // Potential issue could be when you have about 50% of your cluster C* DOWN or
+        // trying to be replaced.
+        // Think of a major disaster hitting your cluster. In that scenario chances of
+        // instance hitting DOWN C* are much much higher.
+        // In such a case you should rely on @link{CassandraConfig#setReplacedIp}.
+        int noOfInstancesGossipShouldMatch = Math.max(1, Math.min(3, eligibleInstances.size()));
+
+        // While it is ideal to check all the nodes in the ring to see if they agree on
+        // the IP to be replaced, in large clusters it may affect the startup
+        // performance. So we pick three random hosts from the ring and see if they all
+        // agree on the IP to be replaced. If not, we don't replace.
+        String replaceIp = null;
+        int matchedGossipInstances = 0, reachableInstances = 0;
+        for (PriamInstance instance : eligibleInstances) {
+            logger.info(
+                    "Calling getIp on hostname[{}] and token[{}]", instance.getHostName(), token);
+
+            try {
+                String ip = getIp(instance.getHostName(), token);
+                reachableInstances++;
+
+                if (StringUtils.isEmpty(ip)) {
+                    continue;
+                }
+
+                if (replaceIp == null) {
+                    replaceIp = ip;
+                } else if (!replaceIp.equals(ip)) {
+                    break;
+                }
+
+                matchedGossipInstances++;
+                if (matchedGossipInstances == noOfInstancesGossipShouldMatch) {
+                    return replaceIp;
+                }
+            } catch (GossipParseException e) {
+                logger.warn(e.getMessage());
+            }
+        }
+
+        // Throw exception if we are not able to reach at least minimum required
+        // instances.
+        if (reachableInstances < noOfInstancesGossipShouldMatch) {
+            throw new GossipParseException(
+                    "Unable to reach minimum required instances to fetch gossip information.");
+        }
+
+        logger.warn(
+                "Return null: Unable to find enough instances where gossip match. Required: {}",
+                noOfInstancesGossipShouldMatch);
+        return null;
+    }
+
+    // helper method to get the token owner IP from a Cassandra node.
+    private static String getIp(String host, String token) throws GossipParseException {
+        String response = null;
+        try {
+            response = SystemUtils.getDataFromUrl(String.format(GOSSIP_INFO_URL_FORMAT, host));
+
+            String inputToken = String.format("[%s]", token);
+            JSONParser parser = new JSONParser();
+            JSONArray jsonObject = (JSONArray) parser.parse(response);
+
+            for (Object key : jsonObject) {
+                JSONObject msg = (JSONObject) key;
+
+                // Ensure that we are not trying to replace a NORMAL token and token of that
+                // instance matches what we want to replace.
+                if (msg.get("STATUS") == null
+                        || msg.get("STATUS").toString().equalsIgnoreCase("NORMAL")
+                        || msg.get("TOKENS") == null
+                        || msg.get("PUBLIC_IP") == null
+                        || !msg.get("TOKENS").toString().equals(inputToken)) {
+                    continue;
+                }
+
+                logger.info(
+                        "Using gossip info from host[{}] and token[{}], the replaced address is : [{}]",
+                        host,
+                        token,
+                        msg.get("PUBLIC_IP"));
+                return (String) msg.get("PUBLIC_IP");
+            }
+
+            return null;
+        } catch (RuntimeException e) {
+            throw new GossipParseException(
+                    String.format("Error in reaching out to host: [{}]", host), e);
+        } catch (ParseException e) {
+            throw new GossipParseException(
+                    String.format(
+                            "Error in parsing gossip response [{}] from host: [{}]",
+                            response,
+                            host),
+                    e);
+        }
+    }
+
+    /**
+     * This exception is thrown either when instances are not available or when they return invalid
+     * response.
+     */
+    public static class GossipParseException extends Exception {
+        private static final long serialVersionUID = 1462488371031437486L;
+
+        public GossipParseException() {
+            super();
+        }
+
+        public GossipParseException(String message) {
+            super(message);
+        }
+
+        public GossipParseException(String message, Throwable t) {
+            super(message, t);
+        }
+    }
+}

--- a/priam/src/test/java/com/netflix/priam/identity/token/AssignedTokenRetrieverTest.java
+++ b/priam/src/test/java/com/netflix/priam/identity/token/AssignedTokenRetrieverTest.java
@@ -1,0 +1,264 @@
+package com.netflix.priam.identity.token;
+
+import com.netflix.priam.config.IConfiguration;
+import com.netflix.priam.identity.IMembership;
+import com.netflix.priam.identity.IPriamInstanceFactory;
+import com.netflix.priam.identity.InstanceIdentity;
+import com.netflix.priam.identity.PriamInstance;
+import com.netflix.priam.identity.config.InstanceInfo;
+import com.netflix.priam.utils.ITokenManager;
+import com.netflix.priam.utils.Sleeper;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import junit.framework.Assert;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+
+public class AssignedTokenRetrieverTest {
+    public static final String APP = "testapp";
+    public static final String DEAD_APP = "testapp-dead";
+
+    @Test
+    public void grabAssignedTokenStartDbInBootstrapModeWhenGossipAgreesCurrentInstanceIsTokenOwner(
+            @Mocked IPriamInstanceFactory<PriamInstance> factory,
+            @Mocked IConfiguration config,
+            @Mocked IMembership membership,
+            @Mocked Sleeper sleeper,
+            @Mocked ITokenManager tokenManager,
+            @Mocked InstanceInfo instanceInfo,
+            @Mocked TokenRetrieverUtils retrievalUtils)
+            throws Exception {
+        List<PriamInstance> liveHosts = newPriamInstances();
+        Collections.shuffle(liveHosts);
+
+        new Expectations() {
+            {
+                config.getAppName();
+                result = APP;
+
+                factory.getAllIds(DEAD_APP);
+                result = Collections.emptyList();
+
+                factory.getAllIds(APP);
+                result = liveHosts;
+
+                instanceInfo.getInstanceId();
+                result = liveHosts.get(0).getInstanceId();
+
+                TokenRetrieverUtils.inferTokenOwnerFromGossip(
+                        liveHosts, liveHosts.get(0).getToken(), liveHosts.get(0).getDC());
+                result = liveHosts.get(0).getHostIP();
+            }
+        };
+
+        IDeadTokenRetriever deadTokenRetriever =
+                new DeadTokenRetriever(factory, membership, config, sleeper, instanceInfo);
+        IPreGeneratedTokenRetriever preGeneratedTokenRetriever =
+                new PreGeneratedTokenRetriever(factory, membership, config, sleeper, instanceInfo);
+        INewTokenRetriever newTokenRetriever =
+                new NewTokenRetriever(
+                        factory, membership, config, sleeper, tokenManager, instanceInfo);
+        InstanceIdentity instanceIdentity =
+                new InstanceIdentity(
+                        factory,
+                        membership,
+                        config,
+                        sleeper,
+                        tokenManager,
+                        deadTokenRetriever,
+                        preGeneratedTokenRetriever,
+                        newTokenRetriever,
+                        instanceInfo);
+
+        Assert.assertEquals(false, instanceIdentity.isReplace());
+    }
+
+    @Test
+    public void grabAssignedTokenStartDbInReplaceModeWhenGossipAgreesOnPreviousTokenOwner(
+            @Mocked IPriamInstanceFactory<PriamInstance> factory,
+            @Mocked IConfiguration config,
+            @Mocked IMembership membership,
+            @Mocked Sleeper sleeper,
+            @Mocked ITokenManager tokenManager,
+            @Mocked InstanceInfo instanceInfo,
+            @Mocked TokenRetrieverUtils retrievalUtils)
+            throws Exception {
+        List<PriamInstance> liveHosts = newPriamInstances();
+        Collections.shuffle(liveHosts);
+
+        PriamInstance deadInstance = liveHosts.remove(0);
+        PriamInstance newInstance =
+                newMockPriamInstance(
+                        APP,
+                        deadInstance.getDC(),
+                        deadInstance.getRac(),
+                        deadInstance.getId(),
+                        String.format("new-fakeInstance-%d", deadInstance.getId()),
+                        String.format("127.1.1.%d", deadInstance.getId() + 100),
+                        String.format("new-fakeHost-%d", deadInstance.getId()),
+                        deadInstance.getToken());
+
+        // the case we are trying to test is when Priam restarted after it acquired the
+        // token. new instance is already registered with token database.
+        liveHosts.add(newInstance);
+
+        new Expectations() {
+            {
+                config.getAppName();
+                result = APP;
+
+                factory.getAllIds(DEAD_APP);
+                result = Collections.singletonList(deadInstance);
+                factory.getAllIds(APP);
+                result = liveHosts;
+
+                instanceInfo.getInstanceId();
+                result = newInstance.getInstanceId();
+
+                TokenRetrieverUtils.inferTokenOwnerFromGossip(
+                        liveHosts, newInstance.getToken(), newInstance.getDC());
+                result = deadInstance.getHostIP();
+            }
+        };
+
+        IDeadTokenRetriever deadTokenRetriever =
+                new DeadTokenRetriever(factory, membership, config, sleeper, instanceInfo);
+        IPreGeneratedTokenRetriever preGeneratedTokenRetriever =
+                new PreGeneratedTokenRetriever(factory, membership, config, sleeper, instanceInfo);
+        INewTokenRetriever newTokenRetriever =
+                new NewTokenRetriever(
+                        factory, membership, config, sleeper, tokenManager, instanceInfo);
+        InstanceIdentity instanceIdentity =
+                new InstanceIdentity(
+                        factory,
+                        membership,
+                        config,
+                        sleeper,
+                        tokenManager,
+                        deadTokenRetriever,
+                        preGeneratedTokenRetriever,
+                        newTokenRetriever,
+                        instanceInfo);
+
+        Assert.assertEquals(deadInstance.getHostIP(), instanceIdentity.getReplacedIp());
+        Assert.assertEquals(true, instanceIdentity.isReplace());
+    }
+
+    @Test
+    public void grabAssignedTokenStartDbInBootstrapModeWhenGossipDisagreesOnPreviousTokenOwner(
+            @Mocked IPriamInstanceFactory<PriamInstance> factory,
+            @Mocked IConfiguration config,
+            @Mocked IMembership membership,
+            @Mocked Sleeper sleeper,
+            @Mocked ITokenManager tokenManager,
+            @Mocked InstanceInfo instanceInfo,
+            @Mocked TokenRetrieverUtils retrievalUtils)
+            throws Exception {
+        List<PriamInstance> liveHosts = newPriamInstances();
+        Collections.shuffle(liveHosts);
+
+        new Expectations() {
+            {
+                config.getAppName();
+                result = APP;
+
+                factory.getAllIds(DEAD_APP);
+                result = Collections.emptyList();
+                factory.getAllIds(APP);
+                result = liveHosts;
+
+                instanceInfo.getInstanceId();
+                result = liveHosts.get(0).getInstanceId();
+
+                TokenRetrieverUtils.inferTokenOwnerFromGossip(
+                        liveHosts, liveHosts.get(0).getToken(), liveHosts.get(0).getDC());
+                result = null;
+            }
+        };
+
+        IDeadTokenRetriever deadTokenRetriever =
+                new DeadTokenRetriever(factory, membership, config, sleeper, instanceInfo);
+        IPreGeneratedTokenRetriever preGeneratedTokenRetriever =
+                new PreGeneratedTokenRetriever(factory, membership, config, sleeper, instanceInfo);
+        INewTokenRetriever newTokenRetriever =
+                new NewTokenRetriever(
+                        factory, membership, config, sleeper, tokenManager, instanceInfo);
+        InstanceIdentity instanceIdentity =
+                new InstanceIdentity(
+                        factory,
+                        membership,
+                        config,
+                        sleeper,
+                        tokenManager,
+                        deadTokenRetriever,
+                        preGeneratedTokenRetriever,
+                        newTokenRetriever,
+                        instanceInfo);
+
+        Assert.assertTrue(StringUtils.isEmpty(instanceIdentity.getReplacedIp()));
+        Assert.assertEquals(false, instanceIdentity.isReplace());
+    }
+
+    private List<PriamInstance> newPriamInstances() {
+        List<PriamInstance> instances = new ArrayList<>();
+
+        instances.addAll(newPriamInstances("eu-west", "1a", 0, "127.3.1.%d"));
+        instances.addAll(newPriamInstances("eu-west", "1b", 3, "127.3.2.%d"));
+        instances.addAll(newPriamInstances("eu-west", "1c", 6, "127.3.3.%d"));
+
+        instances.addAll(newPriamInstances("us-east", "1c", 1, "127.1.3.%d"));
+        instances.addAll(newPriamInstances("us-east", "1a", 4, "127.1.1.%d"));
+        instances.addAll(newPriamInstances("us-east", "1b", 7, "127.1.2.%d"));
+
+        instances.addAll(newPriamInstances("us-west-2", "2a", 2, "127.2.1.%d"));
+        instances.addAll(newPriamInstances("us-west-2", "2b", 5, "127.2.2.%d"));
+        instances.addAll(newPriamInstances("us-west-2", "2c", 8, "127.2.3.%d"));
+
+        return instances;
+    }
+
+    private List<PriamInstance> newPriamInstances(
+            String dc, String rack, int seqNo, String ipRanges) {
+        return IntStream.range(0, 3)
+                .map(e -> seqNo + (e * 9))
+                .<PriamInstance>mapToObj(
+                        e ->
+                                newMockPriamInstance(
+                                        APP,
+                                        dc,
+                                        rack,
+                                        e,
+                                        String.format("fakeInstance-%d", e),
+                                        String.format(ipRanges, e),
+                                        String.format("fakeHost-%d", e),
+                                        Integer.toString(e)))
+                .collect(Collectors.toList());
+    }
+
+    private PriamInstance newMockPriamInstance(
+            String app,
+            String dc,
+            String rack,
+            int id,
+            String instanceId,
+            String hostIp,
+            String hostName,
+            String token) {
+        PriamInstance priamInstance = new PriamInstance();
+        priamInstance.setApp(app);
+        priamInstance.setDC(dc);
+        priamInstance.setRac(rack);
+        priamInstance.setId(id);
+        priamInstance.setInstanceId(instanceId);
+        priamInstance.setHost(hostName);
+        priamInstance.setHostIP(hostIp);
+        priamInstance.setToken(token);
+
+        return priamInstance;
+    }
+}

--- a/priam/src/test/java/com/netflix/priam/identity/token/DeadTokenRetrieverTest.java
+++ b/priam/src/test/java/com/netflix/priam/identity/token/DeadTokenRetrieverTest.java
@@ -36,14 +36,14 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /** Created by aagrawal on 3/1/19. */
-public class TestDeadTokenRetriever {
-    @Mocked private IPriamInstanceFactory factory;
+public class DeadTokenRetrieverTest {
+    @Mocked private IPriamInstanceFactory<PriamInstance> factory;
     @Mocked private IMembership membership;
     private IDeadTokenRetriever deadTokenRetriever;
     private InstanceInfo instanceInfo;
     private IConfiguration configuration;
 
-    public TestDeadTokenRetriever() {
+    public DeadTokenRetrieverTest() {
         Injector injector = Guice.createInjector(new BRTestModule());
         if (instanceInfo == null) instanceInfo = injector.getInstance(InstanceInfo.class);
         if (configuration == null) configuration = injector.getInstance(IConfiguration.class);
@@ -108,8 +108,9 @@ public class TestDeadTokenRetriever {
                 result = allInstances;
                 membership.getRacMembership();
                 result = racMembership;
-                systemUtils.getDataFromUrl(anyString);
-                result = null;
+                SystemUtils.getDataFromUrl(anyString);
+                result =
+                        "[{\"TOKENS\":\"[1]\",\"PUBLIC_IP\":\"\",\"RACK\":\"az1\",\"STATUS\":\"NORMAL\",\"DC\":\"us-east-1\"},{\"TOKENS\":\"[2]\",\"PUBLIC_IP\":\"\",\"RACK\":\"az1\",\"STATUS\":\"NORMAL\",\"DC\":\"us-east-1\"}]";
                 times = 1;
             }
         };
@@ -134,7 +135,7 @@ public class TestDeadTokenRetriever {
                 result = allInstances;
                 membership.getRacMembership();
                 result = racMembership;
-                systemUtils.getDataFromUrl(anyString);
+                SystemUtils.getDataFromUrl(anyString);
                 result = gossipInfo;
                 times = 1;
             }
@@ -156,14 +157,13 @@ public class TestDeadTokenRetriever {
         racMembership.add(instanceInfo.getInstanceId());
         String gossipResponse =
                 "[{\"TOKENS\":\"[1]\",\"PUBLIC_IP\":\"127.0.0.1\",\"RACK\":\"az1\",\"STATUS\":\"NORMAL\",\"DC\":\"us-east-1\"},{\"TOKENS\":\"[2]\",\"PUBLIC_IP\":\"127.0.0.2\",\"RACK\":\"az1\",\"STATUS\":\"NORMAL\",\"DC\":\"us-east-1\"},{\"TOKENS\":\"[3]\",\"PUBLIC_IP\":\"127.0.0.3\",\"RACK\":\"az1\",\"STATUS\":\"shutdown\",\"DC\":\"us-east-1\"},{\"TOKENS\":\"[4]\",\"PUBLIC_IP\":\"127.0.0.4\",\"RACK\":\"az2\",\"STATUS\":\"NORMAL\",\"DC\":\"us-east-1\"},{\"TOKENS\":\"[5]\",\"PUBLIC_IP\":\"127.0.0.5\",\"RACK\":\"az2\",\"STATUS\":\"NORMAL\",\"DC\":\"us-east-1\"},{\"TOKENS\":\"[6]\",\"PUBLIC_IP\":\"127.0.0.6\",\"RACK\":\"az2\",\"STATUS\":\"NORMAL\",\"DC\":\"us-east-1\"}]";
-        PriamInstance instance = null;
         new Expectations() {
             {
                 factory.getAllIds(anyString);
                 result = allInstances;
                 membership.getRacMembership();
                 result = racMembership;
-                systemUtils.getDataFromUrl(anyString);
+                SystemUtils.getDataFromUrl(anyString);
                 returns(gossipResponse, gossipResponse, null, gossipResponse);
             }
         };

--- a/priam/src/test/java/com/netflix/priam/identity/token/TokenRetrieverUtilsTest.java
+++ b/priam/src/test/java/com/netflix/priam/identity/token/TokenRetrieverUtilsTest.java
@@ -1,0 +1,209 @@
+package com.netflix.priam.identity.token;
+
+import static org.hamcrest.core.AllOf.allOf;
+import static org.hamcrest.core.IsNot.not;
+
+import com.netflix.priam.identity.PriamInstance;
+import com.netflix.priam.utils.SystemUtils;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import junit.framework.Assert;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Test;
+
+public class TokenRetrieverUtilsTest {
+    private static final String APP = "testapp";
+    private static final String GOSSIP_INFO_URL_FORMAT =
+            "http://%s:8080/Priam/REST/v1/cassadmin/gossipinfo";
+
+    private List<PriamInstance> instances =
+            IntStream.range(0, 6)
+                    .<PriamInstance>mapToObj(
+                            e ->
+                                    newMockPriamInstance(
+                                            APP,
+                                            "us-east",
+                                            (e < 3) ? "az1" : "az2",
+                                            e,
+                                            String.format("fakeInstance-%d", e),
+                                            String.format("127.0.0.%d", e),
+                                            String.format("fakeHost-%d", e),
+                                            String.valueOf(e)))
+                    .collect(Collectors.toList());
+
+    private String[] gossipInfos =
+            IntStream.range(0, 6)
+                    .<String>mapToObj(
+                            e ->
+                                    newGossipRecord(
+                                            e,
+                                            String.format("127.0.0.%d", e),
+                                            "us-east-1",
+                                            (e < 3) ? "az1" : "az2",
+                                            "NORMAL"))
+                    .collect(Collectors.toList())
+                    .toArray(new String[0]);
+
+    @Test
+    public void testRetrieveTokenOwnerWhenGossipAgrees(@Mocked SystemUtils systemUtils)
+            throws Exception {
+        // updates instances with new instance owning token 4 as per token database.
+        List<PriamInstance> newInstances =
+                instances.stream().filter(e -> e.getId() != 4).collect(Collectors.toList());
+        newInstances.add(
+                newMockPriamInstance(
+                        APP,
+                        "us-east",
+                        "az2",
+                        4,
+                        "fakeHost-400",
+                        "127.0.0.400",
+                        "fakeHost-400",
+                        "4"));
+
+        // mark previous instance with tokenNumber 4 as down in gossip.
+        String[] newGossipInfos = Arrays.copyOf(gossipInfos, gossipInfos.length);
+        newGossipInfos[4] = newGossipRecord(4, "127.0.0.4", "us-east-1", "az2", "shutdown");
+
+        new Expectations() {
+            {
+                SystemUtils.getDataFromUrl(anyString);
+                result = Arrays.toString(newGossipInfos);
+            }
+        };
+
+        String replaceIp = TokenRetrieverUtils.inferTokenOwnerFromGossip(instances, "4", "us-east");
+        Assert.assertEquals("127.0.0.4", replaceIp);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testRetrieveTokenOwnerWhenGossipDisagrees(@Mocked SystemUtils systemUtils)
+            throws Exception {
+        // updates instances with new instance owning token 4 as per token database.
+        List<PriamInstance> newInstances =
+                instances.stream().filter(e -> e.getId() != 4).collect(Collectors.toList());
+
+        // mark previous instance as token owner for tokenNumber 4 in the gossip.
+        String[] gossipInfoSetOne = Arrays.copyOf(gossipInfos, gossipInfos.length);
+        gossipInfoSetOne[4] = newGossipRecord(4, "127.0.0.4", "us-east-1", "az2", "shutdown");
+
+        // mark empty as token owner for tokenNumber 4 in the gossip.
+        String[] gossipInfoSetTwo = Arrays.copyOf(gossipInfos, gossipInfos.length);
+        gossipInfoSetTwo[4] = newGossipRecord(4, "", "us-east-1", "az2", "shutdown");
+
+        new Expectations() {
+            {
+                SystemUtils.getDataFromUrl(
+                        withArgThat(
+                                allOf(
+                                        not(String.format(GOSSIP_INFO_URL_FORMAT, "fakeHost-0")),
+                                        not(String.format(GOSSIP_INFO_URL_FORMAT, "fakeHost-5")))));
+                result = Arrays.toString(gossipInfoSetTwo);
+
+                SystemUtils.getDataFromUrl(String.format(GOSSIP_INFO_URL_FORMAT, "fakeHost-0"));
+                result = Arrays.toString(gossipInfoSetOne);
+                minTimes = 0;
+                SystemUtils.getDataFromUrl(String.format(GOSSIP_INFO_URL_FORMAT, "fakeHost-5"));
+                result = Arrays.toString(gossipInfoSetOne);
+                minTimes = 0;
+            }
+        };
+
+        String replaceIp =
+                TokenRetrieverUtils.inferTokenOwnerFromGossip(newInstances, "4", "us-east");
+        Assert.assertEquals(null, replaceIp);
+    }
+
+    @Test
+    public void testRetrieveTokenOwnerWhenAllHostsInGossipReturnsNull(
+            @Mocked SystemUtils systemUtils) throws Exception {
+        // updates instances with new instance owning token 4 as per token database.
+        List<PriamInstance> newInstances =
+                instances.stream().filter(e -> e.getId() != 4).collect(Collectors.toList());
+        newInstances.add(
+                newMockPriamInstance(
+                        APP,
+                        "us-east",
+                        "az2",
+                        4,
+                        "fakeInstance-400",
+                        "127.0.0.400",
+                        "fakeHost-400",
+                        "4"));
+
+        // mark empty as token owner for tokenNumber 4 in the gossip.
+        String[] gossipInfo = Arrays.copyOf(gossipInfos, gossipInfos.length);
+        gossipInfo[4] = newGossipRecord(4, "", "us-east-1", "az2", "shutdown");
+
+        new Expectations() {
+            {
+                SystemUtils.getDataFromUrl(anyString);
+                result = Arrays.toString(gossipInfo);
+            }
+        };
+
+        String replaceIp = TokenRetrieverUtils.inferTokenOwnerFromGossip(instances, "4", "us-east");
+        Assert.assertNull(replaceIp);
+    }
+
+    @Test(expected = TokenRetrieverUtils.GossipParseException.class)
+    public void testRetrieveTokenOwnerWhenAllInstancesThrowGossipParseException(
+            @Mocked SystemUtils systemUtils) throws TokenRetrieverUtils.GossipParseException {
+        // updates instances with new instance owning token 4 as per token database.
+        List<PriamInstance> newInstances =
+                instances.stream().filter(e -> e.getId() != 4).collect(Collectors.toList());
+        newInstances.add(
+                newMockPriamInstance(
+                        APP,
+                        "us-east",
+                        "az2",
+                        4,
+                        "fakeInstance-400",
+                        "127.0.0.400",
+                        "fakeHost-400",
+                        "4"));
+
+        new Expectations() {
+            {
+                SystemUtils.getDataFromUrl(anyString);
+                result = new TokenRetrieverUtils.GossipParseException();
+            }
+        };
+
+        String replaceIp = TokenRetrieverUtils.inferTokenOwnerFromGossip(instances, "4", "us-east");
+        Assert.assertNull(replaceIp);
+    }
+
+    private String newGossipRecord(
+            int tokenNumber, String ip, String dc, String rack, String status) {
+        return String.format(
+                "{\"TOKENS\":\"[%d]\",\"PUBLIC_IP\":\"%s\",\"RACK\":\"%s\",\"STATUS\":\"%s\",\"DC\":\"%s\"}",
+                tokenNumber, ip, dc, status, rack);
+    }
+
+    private PriamInstance newMockPriamInstance(
+            String app,
+            String dc,
+            String rack,
+            int id,
+            String instanceId,
+            String hostIp,
+            String hostName,
+            String token) {
+        PriamInstance priamInstance = new PriamInstance();
+        priamInstance.setApp(app);
+        priamInstance.setDC(dc);
+        priamInstance.setRac(rack);
+        priamInstance.setId(id);
+        priamInstance.setInstanceId(instanceId);
+        priamInstance.setHost(hostName);
+        priamInstance.setHostIP(hostIp);
+        priamInstance.setToken(token);
+
+        return priamInstance;
+    }
+}


### PR DESCRIPTION
Priam will check Cassandra gossip information while grabbing pre-assigned token to decide if it should start Cassandra in bootstrap mode or in replace mode. Moved token owner inferring logic based on Cassandra gossip into a util class. Refactored InstanceIdentity.init() method.