### PR TITLE
Backport Configuring JVM Options for Cassandra using jvm.options

### DIFF
--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -19,6 +19,8 @@ package com.netflix.priam.config;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.ImplementedBy;
+import com.netflix.priam.scheduler.UnsupportedTypeException;
+import com.netflix.priam.tuner.GCType;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
@@ -39,6 +41,41 @@ public interface IConfiguration {
     /** @return Location to `cassandra.yaml`. */
     default String getYamlLocation() {
         return getCassHome() + "/conf/cassandra.yaml";
+    }
+
+    /**
+     * @return if Priam should tune the jvm.options file Note that Cassandra 2.1 OSS doesn't have
+     *     this file by default, but if someone has added it we can tune it.
+     */
+    default boolean supportsTuningJVMOptionsFile() {
+        return false;
+    }
+
+    /**
+     * @return Path to jvm.options file. This is used to pass JVM options to Cassandra. Note that
+     *     Cassandra 2.1 doesn't by default have this file, but if you add it We will allow you to
+     *     tune it.
+     */
+    default String getJVMOptionsFileLocation() {
+        return getCassHome() + "/conf/jvm.options";
+    }
+
+    /**
+     * @return Type of garbage collection mechanism to use for Cassandra. Supported values are
+     *     CMS,G1GC
+     */
+    default GCType getGCType() throws UnsupportedTypeException {
+        return GCType.CMS;
+    }
+
+    /** @return Set of JVM options to exclude/comment. */
+    default String getJVMExcludeSet() {
+        return StringUtils.EMPTY;
+    }
+
+    /** @return Set of JMV options to add/upsert */
+    default String getJVMUpsertSet() {
+        return StringUtils.EMPTY;
     }
 
     /** @return Path to Cassandra startup script */

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -21,6 +21,8 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.priam.configSource.IConfigSource;
 import com.netflix.priam.identity.config.InstanceInfo;
+import com.netflix.priam.scheduler.UnsupportedTypeException;
+import com.netflix.priam.tuner.GCType;
 import java.io.File;
 import java.util.HashMap;
 import java.util.List;
@@ -211,6 +213,22 @@ public class PriamConfiguration implements IConfiguration {
     }
 
     @Override
+    public GCType getGCType() throws UnsupportedTypeException {
+        String gcType = config.get(PRIAM_PRE + ".gc.type", GCType.CMS.getGcType());
+        return GCType.lookup(gcType);
+    }
+
+    @Override
+    public String getJVMExcludeSet() {
+        return config.get(PRIAM_PRE + ".jvm.options.exclude");
+    }
+
+    @Override
+    public String getJVMUpsertSet() {
+        return config.get(PRIAM_PRE + ".jvm.options.upsert");
+    }
+
+    @Override
     public String getFlushCronExpression() {
         return config.get(PRIAM_PRE + ".flush.cron", "-1");
     }
@@ -387,6 +405,16 @@ public class PriamConfiguration implements IConfiguration {
 
     public String getYamlLocation() {
         return config.get(PRIAM_PRE + ".yamlLocation", getCassHome() + "/conf/cassandra.yaml");
+    }
+
+    @Override
+    public boolean supportsTuningJVMOptionsFile() {
+        return config.get(PRIAM_PRE + ".jvm.options.supported", false);
+    }
+
+    @Override
+    public String getJVMOptionsFileLocation() {
+        return config.get(PRIAM_PRE + ".jvm.options.location", getCassHome() + "/conf/jvm.options");
     }
 
     public String getAuthenticator() {

--- a/priam/src/main/java/com/netflix/priam/defaultimpl/CassandraProcessManager.java
+++ b/priam/src/main/java/com/netflix/priam/defaultimpl/CassandraProcessManager.java
@@ -50,8 +50,13 @@ public class CassandraProcessManager implements ICassandraProcess {
     }
 
     protected void setEnv(Map<String, String> env) {
-        env.put("HEAP_NEWSIZE", config.getHeapNewSize());
-        env.put("MAX_HEAP_SIZE", config.getHeapSize());
+        // If we can tune a jvm.options file instead of setting these
+        // environment variables we prefer to set heap sizes that way
+        if (!config.supportsTuningJVMOptionsFile()) {
+            env.put("HEAP_NEWSIZE", config.getHeapNewSize());
+            env.put("MAX_HEAP_SIZE", config.getHeapSize());
+        }
+
         env.put("DATA_DIR", config.getDataFileLocation());
         env.put("COMMIT_LOG_DIR", config.getCommitLogLocation());
         env.put("LOCAL_BACKUP_DIR", config.getBackupLocation());

--- a/priam/src/main/java/com/netflix/priam/tuner/GCTuner.java
+++ b/priam/src/main/java/com/netflix/priam/tuner/GCTuner.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.priam.tuner;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import javax.inject.Singleton;
+
+/**
+ * List of Garbage collection parameters for CMS/G1GC. This list is used to automatically
+ * enable/disable configurations, if found in jvm.options. Created by aagrawal on 8/23/17.
+ */
+@Singleton
+public class GCTuner {
+    private static final Set<String> cmsOptions =
+            new HashSet<>(
+                    Arrays.asList(
+                            "-XX:+UseConcMarkSweepGC",
+                            "-XX:+UseParNewGC",
+                            "-XX:+UseParallelGC",
+                            "-XX:+CMSConcurrentMTEnabled",
+                            "-XX:CMSInitiatingOccupancyFraction",
+                            "-XX:+UseCMSInitiatingOccupancyOnly",
+                            "-XX:+CMSClassUnloadingEnabled",
+                            "-XX:+CMSIncrementalMode",
+                            "-XX:+CMSPermGenSweepingEnabled",
+                            "-XX:+ExplicitGCInvokesConcurrent",
+                            "-XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses",
+                            "-XX:+DisableExplicitGC",
+                            "-XX:+CMSParallelRemarkEnabled",
+                            "-XX:SurvivorRatio",
+                            "-XX:MaxTenuringThreshold",
+                            "-XX:CMSWaitDuration",
+                            "-XX:+CMSParallelInitialMarkEnabled",
+                            "-XX:+CMSEdenChunksRecordAlways"));
+
+    private static final Set<String> g1gcOptions =
+            new HashSet<>(
+                    Arrays.asList(
+                            "-XX:+UseG1GC",
+                            "-XX:G1HeapRegionSize",
+                            "-XX:MaxGCPauseMillis",
+                            "-XX:G1NewSizePercent",
+                            "-XX:G1MaxNewSizePercent",
+                            "-XX:-ResizePLAB",
+                            "-XX:InitiatingHeapOccupancyPercent",
+                            "-XX:G1MixedGCLiveThresholdPercent",
+                            "-XX:G1HeapWastePercent",
+                            "-XX:G1MixedGCCountTarget",
+                            "-XX:G1OldCSetRegionThresholdPercent",
+                            "-XX:G1ReservePercent",
+                            "-XX:SoftRefLRUPolicyMSPerMB",
+                            "-XX:G1ConcRefinementThreads",
+                            "-XX:MaxGCPauseMillis",
+                            "-XX:+UnlockExperimentalVMOptions",
+                            "-XX:NewRatio",
+                            "-XX:G1RSetUpdatingPauseTimePercent"));
+
+    static final GCType getGCType(String option) {
+        if (cmsOptions.contains(option)) return GCType.CMS;
+
+        if (g1gcOptions.contains(option)) return GCType.G1GC;
+
+        return null;
+    }
+
+    static final GCType getGCType(JVMOption jvmOption) {
+        return getGCType(jvmOption.getJvmOption());
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/tuner/GCType.java
+++ b/priam/src/main/java/com/netflix/priam/tuner/GCType.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.priam.tuner;
+
+import com.netflix.priam.scheduler.UnsupportedTypeException;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Garbage collection types supported by Priam for Cassandra (CMS/G1GC). Created by aagrawal on
+ * 8/24/17.
+ */
+public enum GCType {
+    CMS("CMS"),
+    G1GC("G1GC");
+
+    private static final Logger logger = LoggerFactory.getLogger(GCType.class);
+    private final String gcType;
+
+    GCType(String gcType) {
+        this.gcType = gcType.toUpperCase();
+    }
+
+    /*
+     * Helper method to find the garbage colleciton type - case insensitive as user may put value which are not right case.
+     * This returns the GCType if one is found. Refer to table below to understand the use-case.
+     *
+     * GCTypeValue|acceptNullorEmpty|acceptIllegalValue|Result
+     * Valid value       |NA               |NA                |GCType
+     * Empty string      |True             |NA                |NULL
+     * NULL              |True             |NA                |NULL
+     * Empty string      |False            |NA                |UnsupportedTypeException
+     * NULL              |False            |NA                |UnsupportedTypeException
+     * Illegal value     |NA               |True              |NULL
+     * Illegal value     |NA               |False             |UnsupportedTypeException
+     */
+
+    public static GCType lookup(
+            String gcType, boolean acceptNullOrEmpty, boolean acceptIllegalValue)
+            throws UnsupportedTypeException {
+        if (StringUtils.isEmpty(gcType))
+            if (acceptNullOrEmpty) return null;
+            else {
+                String message =
+                        String.format(
+                                "%s is not a supported GC Type. Supported values are %s",
+                                gcType, getSupportedValues());
+                logger.error(message);
+                throw new UnsupportedTypeException(message);
+            }
+
+        try {
+            return GCType.valueOf(gcType.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            String message =
+                    String.format(
+                            "%s is not a supported GCType. Supported values are %s",
+                            gcType, getSupportedValues());
+
+            if (acceptIllegalValue) {
+                message =
+                        message
+                                + ". Since acceptIllegalValue is set to True, returning NULL instead.";
+                logger.error(message);
+                return null;
+            }
+
+            logger.error(message);
+            throw new UnsupportedTypeException(message, ex);
+        }
+    }
+
+    private static String getSupportedValues() {
+        StringBuilder supportedValues = new StringBuilder();
+        boolean first = true;
+        for (GCType type : GCType.values()) {
+            if (!first) supportedValues.append(",");
+            supportedValues.append(type);
+            first = false;
+        }
+
+        return supportedValues.toString();
+    }
+
+    public static GCType lookup(String gcType) throws UnsupportedTypeException {
+        return lookup(gcType, false, false);
+    }
+
+    public String getGcType() {
+        return gcType;
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/tuner/ICassandraTuner.java
+++ b/priam/src/main/java/com/netflix/priam/tuner/ICassandraTuner.java
@@ -22,4 +22,6 @@ public interface ICassandraTuner {
             throws Exception;
 
     void updateAutoBootstrap(String yamlLocation, boolean autobootstrap) throws IOException;
+
+    default void updateJVMOptions() throws Exception {};
 }

--- a/priam/src/main/java/com/netflix/priam/tuner/JVMOption.java
+++ b/priam/src/main/java/com/netflix/priam/tuner/JVMOption.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.priam.tuner;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+
+/** POJO to parse and store the JVM option from jvm.options file. Created by aagrawal on 8/28/17. */
+public class JVMOption {
+    private String jvmOption;
+    private String value;
+    private boolean isCommented;
+    private boolean isHeapJVMOption;
+    private static final Pattern pattern = Pattern.compile("(#)*(-[^=]+)=?(.*)?");
+    // A new pattern is required because heap do not separate JVM key,value with "=".
+    private static final Pattern heapPattern =
+            Pattern.compile(
+                    "(#)*(-Xm[x|s|n])([0-9]+[K|M|G])?"); // Pattern.compile("(#)*-(Xm[x|s|n])([0-9]+)(K|M|G)?");
+
+    public JVMOption(String jvmOption) {
+        this.jvmOption = jvmOption;
+    }
+
+    public JVMOption(String jvmOption, String value, boolean isCommented, boolean isHeapJVMOption) {
+        this.jvmOption = jvmOption;
+        this.value = value;
+        this.isCommented = isCommented;
+        this.isHeapJVMOption = isHeapJVMOption;
+    }
+
+    public String toJVMOptionString() {
+        final StringBuilder sb = new StringBuilder();
+        if (isCommented) sb.append("#");
+        sb.append(jvmOption);
+        if (value != null) {
+            if (!isHeapJVMOption) sb.append("=");
+            sb.append(value);
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        JVMOption jvmOption1 = (JVMOption) o;
+        return isCommented == jvmOption1.isCommented
+                && isHeapJVMOption == jvmOption1.isHeapJVMOption
+                && Objects.equals(jvmOption, jvmOption1.jvmOption)
+                && Objects.equals(value, jvmOption1.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(jvmOption, value, isCommented, isHeapJVMOption);
+    }
+
+    public String getJvmOption() {
+
+        return jvmOption;
+    }
+
+    public JVMOption setJvmOption(String jvmOption) {
+        this.jvmOption = jvmOption.trim();
+        return this;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public JVMOption setValue(String value) {
+        if (!StringUtils.isEmpty(value)) this.value = value;
+        return this;
+    }
+
+    public boolean isCommented() {
+        return isCommented;
+    }
+
+    public JVMOption setCommented(boolean commented) {
+        isCommented = commented;
+        return this;
+    }
+
+    public boolean isHeapJVMOption() {
+        return isHeapJVMOption;
+    }
+
+    public JVMOption setHeapJVMOption(boolean heapJVMOption) {
+        isHeapJVMOption = heapJVMOption;
+        return this;
+    }
+
+    public static JVMOption parse(String line) {
+        JVMOption result = null;
+
+        // See if it is heap JVM option.
+        Matcher matcher = heapPattern.matcher(line);
+        if (matcher.matches()) {
+            boolean isCommented = (matcher.group(1) != null);
+            return new JVMOption(matcher.group(2))
+                    .setCommented(isCommented)
+                    .setValue(matcher.group(3))
+                    .setHeapJVMOption(true);
+        }
+
+        // See if other heap option.
+        matcher = pattern.matcher(line);
+        if (matcher.matches()) {
+            boolean isCommented = (matcher.group(1) != null);
+            return new JVMOption(matcher.group(2))
+                    .setCommented(isCommented)
+                    .setValue(matcher.group(3));
+        }
+
+        return result;
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/tuner/JVMOptionsTuner.java
+++ b/priam/src/main/java/com/netflix/priam/tuner/JVMOptionsTuner.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.priam.tuner;
+
+import com.google.inject.Inject;
+import com.netflix.priam.config.IConfiguration;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is to tune the jvm.options file introduced in Cassandra 3.x to pass JVM parameters to
+ * Cassandra. It supports configuring GC type (CMS/G1GC) where it automatically activates default
+ * properties as provided in jvm.options file. Note that this will not "add" any GC options.
+ *
+ * <p>Created by aagrawal on 8/23/17.
+ */
+public class JVMOptionsTuner {
+    private static final Logger logger = LoggerFactory.getLogger(JVMOptionsTuner.class);
+    protected final IConfiguration config;
+
+    @Inject
+    public JVMOptionsTuner(IConfiguration config) {
+        this.config = config;
+    }
+
+    /**
+     * Update the JVM options file and save to a file for cassandra by updating/removing JVM options
+     * {@link IConfiguration#getJVMExcludeSet()} and {@link IConfiguration#getJVMUpsertSet()},
+     * configuring GC {@link IConfiguration#getGCType()}etc.
+     *
+     * @param outputFile File name with which this configured JVM options should be written.
+     * @throws Exception when encountered with invalid configured GC type. {@link
+     *     IConfiguration#getGCType()}
+     */
+    public void updateAndSaveJVMOptions(final String outputFile) throws Exception {
+        List<String> configuredJVMOptions = updateJVMOptions();
+
+        if (logger.isInfoEnabled()) {
+            StringBuffer buffer = new StringBuffer("\n");
+            configuredJVMOptions.stream().forEach(line -> buffer.append(line).append("\n"));
+            logger.info("Updating jvm.options with following values: " + buffer.toString());
+        }
+
+        // Verify we can write to output file and it is not directory.
+        File file = new File(outputFile);
+        if (file.exists() && !file.canWrite()) {
+            throw new Exception("Not enough permissions to write to file: " + outputFile);
+        }
+
+        // Write jvm.options back to override defaults.
+        Files.write(new File(outputFile).toPath(), configuredJVMOptions);
+    }
+
+    /**
+     * Update the JVM options file for cassandra by updating/removing JVM options {@link
+     * IConfiguration#getJVMExcludeSet()} and {@link IConfiguration#getJVMUpsertSet()}, configuring
+     * GC {@link IConfiguration#getGCType()}etc.
+     *
+     * @return List of Configuration as String after reading the configuration from jvm.options
+     * @throws Exception when encountered with invalid configured GC type. {@link
+     *     IConfiguration#getGCType()}
+     */
+    protected List<String> updateJVMOptions() throws Exception {
+        File jvmOptionsFile = new File(config.getJVMOptionsFileLocation());
+        validate(jvmOptionsFile);
+        final GCType configuredGC = config.getGCType();
+
+        final Map<String, JVMOption> excludeSet =
+                JVMOptionsTuner.parseJVMOptions(config.getJVMExcludeSet());
+
+        // Make a copy of upsertSet, so we can delete the entries as we process them.
+        Map<String, JVMOption> upsertSet =
+                JVMOptionsTuner.parseJVMOptions(config.getJVMUpsertSet());
+
+        // Don't use streams for processing as upsertSet jvm options needs to be removed if we find
+        // them
+        // already in jvm.options file.
+        List<String> optionsFromFile =
+                Files.lines(jvmOptionsFile.toPath()).collect(Collectors.toList());
+        List<String> configuredOptions = new LinkedList<>();
+        for (String line : optionsFromFile) {
+            configuredOptions.add(
+                    updateConfigurationValue(line, configuredGC, upsertSet, excludeSet));
+        }
+
+        // Add all the upserts(inserts only left) from config.
+        if (upsertSet != null && !upsertSet.isEmpty()) {
+
+            configuredOptions.add("#################");
+            configuredOptions.add("# USER PROVIDED CUSTOM JVM CONFIGURATIONS #");
+            configuredOptions.add("#################");
+
+            configuredOptions.addAll(
+                    upsertSet
+                            .values()
+                            .stream()
+                            .map(JVMOption::toJVMOptionString)
+                            .collect(Collectors.toList()));
+        }
+
+        return configuredOptions;
+    }
+
+    private void setHeapSetting(String configuredValue, JVMOption option) {
+        if (!StringUtils.isEmpty(configuredValue))
+            option.setCommented(false).setValue(configuredValue);
+    }
+
+    /**
+     * @param line a line as read from jvm.options file.
+     * @param configuredGC GCType configured by user for Cassandra.
+     * @param upsertSet configured upsert set of JVM properties as provided by user for Cassandra.
+     * @param excludeSet configured exclude set of JVM properties as provided by user for Cassandra.
+     * @return the "comment" as is, if not a valid JVM option. Else, a string representation of JVM
+     *     option
+     */
+    private String updateConfigurationValue(
+            final String line,
+            GCType configuredGC,
+            Map<String, JVMOption> upsertSet,
+            Map<String, JVMOption> excludeSet) {
+
+        JVMOption option = JVMOption.parse(line);
+        if (option == null) return line;
+
+        // Is parameter for heap setting.
+        if (option.isHeapJVMOption()) {
+            String configuredValue;
+            switch (option.getJvmOption()) {
+                    // Special handling for heap new size ("Xmn")
+                case "-Xmn":
+                    configuredValue = config.getHeapNewSize();
+                    break;
+                    // Set min and max heap size to same value
+                default:
+                    configuredValue = config.getHeapSize();
+                    break;
+            }
+            setHeapSetting(configuredValue, option);
+        }
+
+        // We don't want Xmn with G1GC, allow the GC to determine optimal young gen
+        if (option.getJvmOption().equals("-Xmn") && configuredGC == GCType.G1GC)
+            option.setCommented(true);
+
+        // Is parameter for GC.
+        GCType gcType = GCTuner.getGCType(option);
+        if (gcType != null) {
+            option.setCommented(gcType != configuredGC);
+        }
+
+        // See if option is in upsert list.
+        if (upsertSet != null && upsertSet.containsKey(option.getJvmOption())) {
+            JVMOption configuration = upsertSet.get(option.getJvmOption());
+            option.setCommented(false);
+            option.setValue(configuration.getValue());
+            upsertSet.remove(option.getJvmOption());
+        }
+
+        // See if option is in exclude list.
+        if (excludeSet != null && excludeSet.containsKey(option.getJvmOption()))
+            option.setCommented(true);
+
+        return option.toJVMOptionString();
+    }
+
+    private void validate(File jvmOptionsFile) throws Exception {
+        if (!jvmOptionsFile.exists())
+            throw new Exception(
+                    "JVM Option File does not exist: " + jvmOptionsFile.getAbsolutePath());
+
+        if (jvmOptionsFile.isDirectory())
+            throw new Exception(
+                    "JVM Option File is a directory: " + jvmOptionsFile.getAbsolutePath());
+
+        if (!jvmOptionsFile.canRead() || !jvmOptionsFile.canWrite())
+            throw new Exception(
+                    "JVM Option File does not have right permission: "
+                            + jvmOptionsFile.getAbsolutePath());
+    }
+
+    /**
+     * Util function to parse comma separated list of jvm options to a Map (jvmOptionName,
+     * JVMOption). It will ignore anything which is not a valid JVM option.
+     *
+     * @param property comma separated list of JVM options.
+     * @return Map of (jvmOptionName, JVMOption).
+     */
+    public static final Map<String, JVMOption> parseJVMOptions(String property) {
+        if (StringUtils.isEmpty(property)) return null;
+        return new HashSet<>(Arrays.asList(property.split(",")))
+                .stream()
+                .map(JVMOption::parse)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(JVMOption::getJvmOption, jvmOption -> jvmOption));
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/tuner/StandardTuner.java
+++ b/priam/src/main/java/com/netflix/priam/tuner/StandardTuner.java
@@ -235,6 +235,15 @@ public class StandardTuner implements ICassandraTuner {
         yaml.dump(map, new FileWriter(yamlFile));
     }
 
+    @Override
+    public final void updateJVMOptions() throws Exception {
+        if (config.supportsTuningJVMOptionsFile()) {
+            JVMOptionsTuner tuner = new JVMOptionsTuner(config);
+            // Overwrite default jvm.options file.
+            tuner.updateAndSaveJVMOptions(config.getJVMOptionsFileLocation());
+        }
+    }
+
     public void addExtraCassParams(Map map) {
         String params = config.getExtraConfigParams();
         if (StringUtils.isEmpty(params)) {

--- a/priam/src/main/java/com/netflix/priam/tuner/TuneCassandra.java
+++ b/priam/src/main/java/com/netflix/priam/tuner/TuneCassandra.java
@@ -49,6 +49,7 @@ public class TuneCassandra extends Task {
             try {
                 tuner.writeAllProperties(
                         config.getYamlLocation(), null, config.getSeedProviderName());
+                tuner.updateJVMOptions();
                 isDone = true;
                 instanceState.setYmlWritten(true);
             } catch (IOException e) {

--- a/priam/src/test/groovy/com.netflix.priam.tuner/JVMOptionParserTest.groovy
+++ b/priam/src/test/groovy/com.netflix.priam.tuner/JVMOptionParserTest.groovy
@@ -1,0 +1,52 @@
+package com.netflix.priam.tuner
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ Created by aagrawal on 8/28/17.
+ */
+@Unroll
+class JVMOptionParserTest extends Specification{
+
+    def "JMVOptionParsing.toJVMString() for value #jvmOption is #result"() {
+        expect:
+        JVMOption.parse(jvmOption).toJVMOptionString() == result
+
+        where:
+        jvmOption || result
+        "#-XX:+PrintGCDetails" || "#-XX:+PrintGCDetails"
+        "#-XX:NumberOfGCLogFiles=10" || "#-XX:NumberOfGCLogFiles=10"
+        "-XX+UseCMSInitiatingOccupancyOnly" || "-XX+UseCMSInitiatingOccupancyOnly"
+        "#-Dcassandra.available_processors=number_of_processors" || "#-Dcassandra.available_processors=number_of_processors"
+        "###-XX:+PrintGCDetails" || "#-XX:+PrintGCDetails"
+        "#-Dcassandra.join_ring=true|false" || "#-Dcassandra.join_ring=true|false"
+    }
+
+    def "JMVOptionParsing for value #jvmOption is #result"(){
+        expect:
+        JVMOption.parse(jvmOption) == result
+
+        where:
+        jvmOption || result
+        "### Debug options" || null
+        "-XX+UseCMSInitiatingOccupancyOnly" || new JVMOption("-XX+UseCMSInitiatingOccupancyOnly")
+        "#-XX:NumberOfGCLogFiles=10" || new JVMOption("-XX:NumberOfGCLogFiles", "10", true, false)
+        "-Xms20G" || new JVMOption("-Xms", "20G", false, true)
+    }
+
+    def "Heap JVM for value #jvmOption is #result"() {
+        expect:
+        JVMOption.parse(jvmOption).isHeapJVMOption() == result
+
+        where:
+        jvmOption || result
+        "#-Xms20G" || true
+        "#-Xmx20G" || true
+        "#-Xmn20G" || true
+        "-Xms20G" || true
+        "-Xmx20G" || true
+        "-Xmn20G" || true
+        "#-Xmdf20G" || false
+    }
+}

--- a/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
@@ -142,6 +142,11 @@ public class FakeConfiguration implements IConfiguration {
     }
 
     @Override
+    public String getJVMOptionsFileLocation() {
+        return "src/test/resources/conf/jvm.options";
+    }
+
+    @Override
     public String getCommitLogBackupPropsFile() {
         return getCassHome() + "/conf/commitlog_archiving.properties";
     }

--- a/priam/src/test/java/com/netflix/priam/tuner/JVMOptionTunerTest.java
+++ b/priam/src/test/java/com/netflix/priam/tuner/JVMOptionTunerTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.priam.tuner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.netflix.priam.config.FakeConfiguration;
+import com.netflix.priam.config.IConfiguration;
+import com.netflix.priam.scheduler.UnsupportedTypeException;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+/** Created by aagrawal on 8/29/17. */
+public class JVMOptionTunerTest {
+    private IConfiguration config;
+    JVMOptionsTuner tuner;
+
+    @Test
+    public void testCMS() throws Exception {
+        config = new GCConfiguration(GCType.CMS, null, null, null, null);
+        List<JVMOption> jvmOptionMap = getConfiguredJVMOptions(config);
+        // Validate that all CMS options should be uncommented.
+        long failedVerification =
+                jvmOptionMap
+                        .stream()
+                        .map(
+                                jvmOption -> {
+                                    GCType gcType = GCTuner.getGCType(jvmOption);
+                                    if (gcType != null && gcType != GCType.CMS) {
+                                        return 1;
+                                    }
+                                    return 0;
+                                })
+                        .filter(returncode -> (returncode != 0))
+                        .count();
+
+        if (failedVerification > 0) throw new Exception("Failed validation for CMS");
+    }
+
+    @Test
+    public void testG1GC() throws Exception {
+        config = new GCConfiguration(GCType.G1GC, null, null, null, null);
+        List<JVMOption> jvmOptionMap = getConfiguredJVMOptions(config);
+        // Validate that all G1GC options should be uncommented.
+        long failedVerification =
+                jvmOptionMap
+                        .stream()
+                        .map(
+                                jvmOption -> {
+                                    GCType gcType = GCTuner.getGCType(jvmOption);
+                                    if (gcType != null && gcType != GCType.G1GC) {
+                                        return 1;
+                                    }
+                                    return 0;
+                                })
+                        .filter(returncode -> (returncode != 0))
+                        .count();
+
+        if (failedVerification > 0) throw new Exception("Failed validation for G1GC");
+    }
+
+    @Test
+    public void testCMSUpsert() throws Exception {
+        JVMOption option1 = new JVMOption("-Dsample");
+        JVMOption option2 = new JVMOption("-Dsample2", "10", false, false);
+        JVMOption option3 = new JVMOption("-XX:NumberOfGCLogFiles", "20", false, false);
+
+        JVMOption xmnOption = new JVMOption("-Xmn", "3G", false, true);
+        JVMOption xmxOption = new JVMOption("-Xmx", "20G", false, true);
+        JVMOption xmsOption = new JVMOption("-Xms", "20G", false, true);
+
+        StringBuffer buffer =
+                new StringBuffer(
+                        option1.toJVMOptionString()
+                                + ","
+                                + option2.toJVMOptionString()
+                                + ","
+                                + option3.toJVMOptionString());
+        config =
+                new GCConfiguration(
+                        GCType.CMS,
+                        null,
+                        buffer.toString(),
+                        xmnOption.getValue(),
+                        xmxOption.getValue());
+        List<JVMOption> jvmOptions = getConfiguredJVMOptions(config);
+
+        // Verify all the options do exist.
+        assertTrue(jvmOptions.contains(option3));
+        assertTrue(jvmOptions.contains(option2));
+        assertTrue(jvmOptions.contains(option1));
+
+        // Verify heap options exist with the value provided.
+        assertTrue(jvmOptions.contains(xmnOption));
+        assertTrue(jvmOptions.contains(xmxOption));
+        assertTrue(jvmOptions.contains(xmsOption));
+    }
+
+    @Test
+    public void testCMSExclude() throws Exception {
+        JVMOption youngHeap = new JVMOption("-Xmn", "3G", false, true);
+        JVMOption maxHeap = new JVMOption("-Xmx", "12G", false, true);
+
+        JVMOption option1 = new JVMOption("-XX:+UseParNewGC");
+        JVMOption option2 = new JVMOption("-XX:NumberOfGCLogFiles", "20", false, false);
+        JVMOption option3 = new JVMOption("-XX:+UseG1GC", null, false, false);
+
+        StringBuffer buffer =
+                new StringBuffer(
+                        option1.toJVMOptionString()
+                                + ","
+                                + option2.toJVMOptionString()
+                                + ","
+                                + option3.toJVMOptionString());
+        config = new GCConfiguration(GCType.CMS, buffer.toString(), null, "3G", "12G");
+        List<JVMOption> jvmOptions = getConfiguredJVMOptions(config);
+
+        // Verify all the options do not exist.
+        assertFalse(jvmOptions.contains(option3));
+        assertFalse(jvmOptions.contains(option2));
+        assertFalse(jvmOptions.contains(option1));
+
+        // Verify that Xmn is present since CMS needs tuning of young gen heap
+        assertTrue(jvmOptions.contains(maxHeap));
+        assertTrue(jvmOptions.contains(youngHeap));
+    }
+
+    @Test
+    public void testG1GCUpsertExclude() throws Exception {
+        JVMOption youngHeap = new JVMOption("-Xmn", "3G", true, true);
+        JVMOption maxHeap = new JVMOption("-Xmx", "12G", false, true);
+
+        JVMOption option1 = new JVMOption("-Dsample");
+        JVMOption option2 = new JVMOption("-Dsample2", "10", false, false);
+        JVMOption option3 = new JVMOption("-XX:NumberOfGCLogFiles", "20", false, false);
+        StringBuffer upsert =
+                new StringBuffer(
+                        option1.toJVMOptionString()
+                                + ","
+                                + option2.toJVMOptionString()
+                                + ","
+                                + option3.toJVMOptionString());
+
+        JVMOption option4 = new JVMOption("-XX:NumberOfGCLogFiles", null, false, false);
+        JVMOption option5 = new JVMOption("-XX:+UseG1GC", null, false, false);
+        StringBuffer exclude =
+                new StringBuffer(option4.toJVMOptionString() + "," + option5.toJVMOptionString());
+
+        config =
+                new GCConfiguration(
+                        GCType.G1GC, exclude.toString(), upsert.toString(), "3G", "12G");
+        List<JVMOption> jvmOptions = getConfiguredJVMOptions(config);
+
+        // Verify upserts exist
+        assertTrue(jvmOptions.contains(option1));
+        assertTrue(jvmOptions.contains(option2));
+
+        // Verify exclude exist. This is to prove that if an element is in EXCLUDE, it will always
+        // be excluded.
+        assertFalse(jvmOptions.contains(option3));
+        assertFalse(jvmOptions.contains(option4));
+        assertFalse(jvmOptions.contains(option5));
+
+        // Verify that Xmn is not present since G1GC autotunes the young gen heap
+        assertTrue(jvmOptions.contains(maxHeap));
+        assertFalse(jvmOptions.contains(youngHeap));
+
+        List<JVMOption> allJVMOptions = getConfiguredJVMOptions(config, false);
+        assertTrue(allJVMOptions.contains(youngHeap));
+    }
+
+    private List<JVMOption> getConfiguredJVMOptions(IConfiguration config) throws Exception {
+        return getConfiguredJVMOptions(config, true);
+    }
+
+    private List<JVMOption> getConfiguredJVMOptions(IConfiguration config, boolean filter)
+            throws Exception {
+        tuner = new JVMOptionsTuner(config);
+        List<String> configuredJVMOptions = tuner.updateJVMOptions();
+        if (filter) {
+            return configuredJVMOptions
+                    .stream()
+                    .map(JVMOption::parse)
+                    .filter(jvmOption -> (jvmOption != null))
+                    .filter(jvmOption -> !jvmOption.isCommented())
+                    .collect(Collectors.toList());
+        } else {
+            return configuredJVMOptions.stream().map(JVMOption::parse).collect(Collectors.toList());
+        }
+    }
+
+    private class GCConfiguration extends FakeConfiguration {
+        private GCType gcType;
+        private String configuredJVMExclude;
+        private String configuredJVMUpsert;
+        private String configuredHeapNewSize;
+        private String configuredHeapSize;
+
+        GCConfiguration(
+                GCType gcType,
+                String configuredJVMExclude,
+                String configuredJVMUpsert,
+                String configuredHeapNewSize,
+                String configuredHeapSize) {
+            this.gcType = gcType;
+            this.configuredJVMExclude = configuredJVMExclude;
+            this.configuredJVMUpsert = configuredJVMUpsert;
+            this.configuredHeapNewSize = configuredHeapNewSize;
+            this.configuredHeapSize = configuredHeapSize;
+        }
+
+        @Override
+        public GCType getGCType() throws UnsupportedTypeException {
+            return gcType;
+        }
+
+        @Override
+        public String getJVMExcludeSet() {
+            return configuredJVMExclude;
+        }
+
+        @Override
+        public String getHeapSize() {
+            return configuredHeapSize;
+        }
+
+        @Override
+        public String getHeapNewSize() {
+            return configuredHeapNewSize;
+        }
+
+        @Override
+        public String getJVMUpsertSet() {
+            return configuredJVMUpsert;
+        }
+    }
+}

--- a/priam/src/test/resources/conf/jvm.options
+++ b/priam/src/test/resources/conf/jvm.options
@@ -1,0 +1,245 @@
+###########################################################################
+#                             jvm.options                                 #
+#                                                                         #
+# - all flags defined here will be used by cassandra to startup the JVM   #
+# - one flag should be specified per line                                 #
+# - lines that do not start with '-' will be ignored                      #
+# - only static flags are accepted (no variables or parameters)           #
+# - dynamic flags will be appended to these on cassandra-env              #
+###########################################################################
+
+######################
+# STARTUP PARAMETERS #
+######################
+
+# Uncomment any of the following properties to enable specific startup parameters
+
+# In a multi-instance deployment, multiple Cassandra instances will independently assume that all
+# CPU processors are available to it. This setting allows you to specify a smaller set of processors
+# and perhaps have affinity.
+#-Dcassandra.available_processors=number_of_processors
+
+# The directory location of the cassandra.yaml file.
+#-Dcassandra.config=directory
+
+# Sets the initial partitioner token for a node the first time the node is started.
+#-Dcassandra.initial_token=token
+
+# Set to false to start Cassandra on a node but not have the node join the cluster.
+#-Dcassandra.join_ring=true|false
+
+# Set to false to clear all gossip state for the node on restart. Use when you have changed node
+# information in cassandra.yaml (such as listen_address).
+#-Dcassandra.load_ring_state=true|false
+
+# Enable pluggable metrics reporter. See Pluggable metrics reporting in Cassandra 2.0.2.
+#-Dcassandra.metricsReporterConfigFile=file
+
+# Set the port on which the CQL native transport listens for clients. (Default: 9042)
+#-Dcassandra.native_transport_port=port
+
+# Overrides the partitioner. (Default: org.apache.cassandra.dht.Murmur3Partitioner)
+#-Dcassandra.partitioner=partitioner
+
+# To replace a node that has died, restart a new node in its place specifying the address of the
+# dead node. The new node must not have any data in its data directory, that is, it must be in the
+# same state as before bootstrapping.
+#-Dcassandra.replace_address=listen_address or broadcast_address of dead node
+
+# Allow restoring specific tables from an archived commit log.
+#-Dcassandra.replayList=table
+
+# Allows overriding of the default RING_DELAY (1000ms), which is the amount of time a node waits
+# before joining the ring.
+#-Dcassandra.ring_delay_ms=ms
+
+# Set the port for the Thrift RPC service, which is used for client connections. (Default: 9160)
+#-Dcassandra.rpc_port=port
+
+# Set the SSL port for encrypted communication. (Default: 7001)
+#-Dcassandra.ssl_storage_port=port
+
+# Enable or disable the native transport server. See start_native_transport in cassandra.yaml.
+# cassandra.start_native_transport=true|false
+
+# Enable or disable the Thrift RPC server. (Default: true)
+#-Dcassandra.start_rpc=true/false
+
+# Set the port for inter-node communication. (Default: 7000)
+#-Dcassandra.storage_port=port
+
+# Set the default location for the trigger JARs. (Default: conf/triggers)
+#-Dcassandra.triggers_dir=directory
+
+# For testing new compaction and compression strategies. It allows you to experiment with different
+# strategies and benchmark write performance differences without affecting the production workload.
+#-Dcassandra.write_survey=true
+
+# To disable configuration via JMX of auth caches (such as those for credentials, permissions and
+# roles). This will mean those config options can only be set (persistently) in cassandra.yaml
+# and will require a restart for new values to take effect.
+#-Dcassandra.disable_auth_caches_remote_configuration=true
+
+# To disable dynamic calculation of the page size used when indexing an entire partition (during
+# initial index build/rebuild). If set to true, the page size will be fixed to the default of
+# 10000 rows per page.
+#-Dcassandra.force_default_indexing_page_size=true
+
+########################
+# GENERAL JVM SETTINGS #
+########################
+
+# enable assertions. highly suggested for correct application functionality.
+-ea
+
+# enable thread priorities, primarily so we can give periodic tasks
+# a lower priority to avoid interfering with client workload
+-XX:+UseThreadPriorities
+
+# allows lowering thread priority without being root on linux - probably
+# not necessary on Windows but doesn't harm anything.
+# see http://tech.stolsvik.com/2010/01/linux-java-thread-priorities-workar
+-XX:ThreadPriorityPolicy=42
+
+# Enable heap-dump if there's an OOM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# Per-thread stack size.
+-Xss256k
+
+# Larger interned string table, for gossip's benefit (CASSANDRA-6410)
+-XX:StringTableSize=1000003
+
+# Make sure all memory is faulted and zeroed on startup.
+# This helps prevent soft faults in containers and makes
+# transparent hugepage allocation more effective.
+-XX:+AlwaysPreTouch
+
+# Disable biased locking as it does not benefit Cassandra.
+-XX:-UseBiasedLocking
+
+# Enable thread-local allocation blocks and allow the JVM to automatically
+# resize them at runtime.
+-XX:+UseTLAB
+-XX:+ResizeTLAB
+-XX:+UseNUMA
+
+# http://www.evanjones.ca/jvm-mmap-pause.html
+-XX:+PerfDisableSharedMem
+
+# Prefer binding to IPv4 network intefaces (when net.ipv6.bindv6only=1). See
+# http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6342561 (short version:
+# comment out this entry to enable IPv6 support).
+-Djava.net.preferIPv4Stack=true
+
+### Debug options
+
+# uncomment to enable flight recorder
+#-XX:+UnlockCommercialFeatures
+#-XX:+FlightRecorder
+
+# uncomment to have Cassandra JVM listen for remote debuggers/profilers on port 1414
+#-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1414
+
+# uncomment to have Cassandra JVM log internal method compilation (developers only)
+#-XX:+UnlockDiagnosticVMOptions
+#-XX:+LogCompilation
+
+#################
+# HEAP SETTINGS #
+#################
+
+# Heap size is automatically calculated by cassandra-env based on this
+# formula: max(min(1/2 ram, 1024MB), min(1/4 ram, 8GB))
+# That is:
+# - calculate 1/2 ram and cap to 1024MB
+# - calculate 1/4 ram and cap to 8192MB
+# - pick the max
+#
+# For production use you may wish to adjust this for your environment.
+# If that's the case, uncomment the -Xmx and Xms options below to override the
+# automatic calculation of JVM heap memory.
+#
+# It is recommended to set min (-Xms) and max (-Xmx) heap sizes to
+# the same value to avoid stop-the-world GC pauses during resize, and
+# so that we can lock the heap in memory on startup to prevent any
+# of it from being swapped out.
+#-Xms4G
+#-Xmx4G
+
+# Young generation size is automatically calculated by cassandra-env
+# based on this formula: min(100 * num_cores, 1/4 * heap size)
+#
+# The main trade-off for the young generation is that the larger it
+# is, the longer GC pause times will be. The shorter it is, the more
+# expensive GC will be (usually).
+#
+# It is not recommended to set the young generation size if using the
+# G1 GC, since that will override the target pause-time goal.
+# More info: http://www.oracle.com/technetwork/articles/java/g1gc-1984535.html
+#
+# The example below assumes a modern 8-core+ machine for decent
+# times. If in doubt, and if you do not particularly want to tweak, go
+# 100 MB per physical CPU core.
+#-Xmn800M
+
+#################
+#  GC SETTINGS  #
+#################
+
+### CMS Settings
+
+-XX:+UseParNewGC
+-XX:+UseConcMarkSweepGC
+-XX:+CMSParallelRemarkEnabled
+-XX:SurvivorRatio=8
+-XX:MaxTenuringThreshold=1
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+-XX:CMSWaitDuration=10000
+-XX:+CMSParallelInitialMarkEnabled
+-XX:+CMSEdenChunksRecordAlways
+# some JVMs will fill up their heap when accessed via JMX, see CASSANDRA-6541
+-XX:+CMSClassUnloadingEnabled
+
+### G1 Settings (experimental, comment previous section and uncomment section below to enable)
+
+## Use the Hotspot garbage-first collector.
+#-XX:+UseG1GC
+#
+## Have the JVM do less remembered set work during STW, instead
+## preferring concurrent GC. Reduces p99.9 latency.
+#-XX:G1RSetUpdatingPauseTimePercent=5
+#
+## Main G1GC tunable: lowering the pause target will lower throughput and vise versa.
+## 200ms is the JVM default and lowest viable setting
+## 1000ms increases throughput. Keep it smaller than the timeouts in cassandra.yaml.
+#-XX:MaxGCPauseMillis=500
+
+## Optional G1 Settings
+
+# Save CPU time on large (>= 16GB) heaps by delaying region scanning
+# until the heap is 70% full. The default in Hotspot 8u40 is 40%.
+#-XX:InitiatingHeapOccupancyPercent=70
+
+# For systems with > 8 cores, the default ParallelGCThreads is 5/8 the number of logical cores.
+# Otherwise equal to the number of cores when 8 or less.
+# Machines with > 10 cores should try setting these to <= full cores.
+#-XX:ParallelGCThreads=16
+# By default, ConcGCThreads is 1/4 of ParallelGCThreads.
+# Setting both to the same value can reduce STW durations.
+#-XX:ConcGCThreads=16
+
+### GC logging options -- uncomment to enable
+
+-XX:+PrintGCDetails
+-XX:+PrintGCDateStamps
+-XX:+PrintHeapAtGC
+-XX:+PrintTenuringDistribution
+-XX:+PrintGCApplicationStoppedTime
+-XX:+PrintPromotionFailure
+#-XX:PrintFLSStatistics=1
+#-Xloggc:/var/log/cassandra/gc.log
+-XX:+UseGCLogFileRotation
+-XX:NumberOfGCLogFiles=10
+-XX:GCLogFileSize=10M


### PR DESCRIPTION
This backports the Priam functionality for tuning jvm.options files to
this branch. By default we don't use it, but if your version of
Cassandra 2.1 happens to have jvm.options support, we can use that here.

Commit message from 3.11 Priam branch:

Cassandra 3.x added a new way to configure heap sizes and pass other JVM
parameters (via jvm.options). Priam now supports configuring common
options like heap setting and choosing Garbage Collection type
(G1GC/CMS) natively. Default being CMS. It logs jvm.options after tuning
them.