### PR TITLE
rolling back the changes to use gossip info while grabbing pre-assign…

### DIFF
--- a/priam/src/main/java/com/netflix/priam/identity/token/DeadTokenRetriever.java
+++ b/priam/src/main/java/com/netflix/priam/identity/token/DeadTokenRetriever.java
@@ -20,7 +20,6 @@ import com.netflix.priam.identity.IMembership;
 import com.netflix.priam.identity.IPriamInstanceFactory;
 import com.netflix.priam.identity.PriamInstance;
 import com.netflix.priam.identity.config.InstanceInfo;
-import com.netflix.priam.identity.token.TokenRetrieverUtils.GossipParseException;
 import com.netflix.priam.utils.Sleeper;
 import java.util.List;
 import java.util.Random;
@@ -112,29 +111,9 @@ public class DeadTokenRetriever extends TokenRetrieverBase implements IDeadToken
             // remove it as we marked it down...
             factory.delete(priamInstance);
 
-            // find the replaced IP
-            try {
-                replacedIp =
-                        TokenRetrieverUtils.inferTokenOwnerFromGossip(
-                                allInstancesWithinCluster,
-                                priamInstance.getToken(),
-                                priamInstance.getDC());
-
-                // Lets not replace the instance if gossip info is not merging!!
-                if (replacedIp == null) return null;
-                logger.info(
-                        "Will try to replace token: {} with replacedIp (from gossip info): {} instead of ip from Token database: {}",
-                        priamInstance.getToken(),
-                        replacedIp,
-                        priamInstance.getHostIP());
-            } catch (GossipParseException e) {
-                // In case of gossip exception, fallback to IP in token database.
-                this.replacedIp = priamInstance.getHostIP();
-                logger.info(
-                        "Will try to replace token: {} with replacedIp from Token database: {}",
-                        priamInstance.getToken(),
-                        priamInstance.getHostIP());
-            }
+            // use entry in the token database always.
+            // this can cause "can't replace live token errors.
+            this.replacedIp = priamInstance.getHostIP();
 
             PriamInstance result;
             try {

--- a/priam/src/main/java/com/netflix/priam/identity/token/TokenRetrieverUtils.java
+++ b/priam/src/main/java/com/netflix/priam/identity/token/TokenRetrieverUtils.java
@@ -36,6 +36,12 @@ public class TokenRetrieverUtils {
     public static String inferTokenOwnerFromGossip(
             List<? extends PriamInstance> allIds, String token, String dc)
             throws GossipParseException {
+        // TODO: Gossip info in some cases doesn't reflect the real C* state.
+        // Not using gossip info for now.
+        if (!useGossipInfo()) {
+            return null;
+        }
+
         // Avoid using dead instance who we are trying to replace (duh!!)
         // Avoid other regions instances to avoid communication over public ip address.
         List<? extends PriamInstance> eligibleInstances =
@@ -98,6 +104,12 @@ public class TokenRetrieverUtils {
                 "Return null: Unable to find enough instances where gossip match. Required: {}",
                 noOfInstancesGossipShouldMatch);
         return null;
+    }
+
+    // TODO: Gossip info in some cases doesn't reflect the real C* state.
+    // Not using gossip info for now.
+    private static boolean useGossipInfo() {
+        return false;
     }
 
     // helper method to get the token owner IP from a Cassandra node.

--- a/priam/src/test/java/com/netflix/priam/identity/token/DeadTokenRetrieverTest.java
+++ b/priam/src/test/java/com/netflix/priam/identity/token/DeadTokenRetrieverTest.java
@@ -94,7 +94,7 @@ public class DeadTokenRetrieverTest {
         };
     }
 
-    @Test
+    // @Test
     // There is a potential slot for dead token but we are unable to replace.
     public void testNoReplacementNoGossipMatch(@Mocked SystemUtils systemUtils) throws Exception {
         List<PriamInstance> allInstances = getInstances(2);
@@ -150,7 +150,7 @@ public class DeadTokenRetrieverTest {
         };
     }
 
-    @Test
+    // @Test
     public void testReplacementGossipMatch(@Mocked SystemUtils systemUtils) throws Exception {
         List<PriamInstance> allInstances = getInstances(6);
         List<String> racMembership = getRacMembership(2);

--- a/priam/src/test/java/com/netflix/priam/identity/token/TokenRetrieverUtilsTest.java
+++ b/priam/src/test/java/com/netflix/priam/identity/token/TokenRetrieverUtilsTest.java
@@ -12,7 +12,6 @@ import java.util.stream.IntStream;
 import junit.framework.Assert;
 import mockit.Expectations;
 import mockit.Mocked;
-import org.junit.Test;
 
 public class TokenRetrieverUtilsTest {
     private static final String APP = "testapp";
@@ -47,7 +46,7 @@ public class TokenRetrieverUtilsTest {
                     .collect(Collectors.toList())
                     .toArray(new String[0]);
 
-    @Test
+    // @Test
     public void testRetrieveTokenOwnerWhenGossipAgrees(@Mocked SystemUtils systemUtils)
             throws Exception {
         // updates instances with new instance owning token 4 as per token database.
@@ -80,7 +79,7 @@ public class TokenRetrieverUtilsTest {
     }
 
     @SuppressWarnings("unchecked")
-    @Test
+    // @Test
     public void testRetrieveTokenOwnerWhenGossipDisagrees(@Mocked SystemUtils systemUtils)
             throws Exception {
         // updates instances with new instance owning token 4 as per token database.
@@ -118,7 +117,7 @@ public class TokenRetrieverUtilsTest {
         Assert.assertEquals(null, replaceIp);
     }
 
-    @Test
+    // @Test
     public void testRetrieveTokenOwnerWhenAllHostsInGossipReturnsNull(
             @Mocked SystemUtils systemUtils) throws Exception {
         // updates instances with new instance owning token 4 as per token database.
@@ -150,7 +149,7 @@ public class TokenRetrieverUtilsTest {
         Assert.assertNull(replaceIp);
     }
 
-    @Test(expected = TokenRetrieverUtils.GossipParseException.class)
+    // @Test(expected = TokenRetrieverUtils.GossipParseException.class)
     public void testRetrieveTokenOwnerWhenAllInstancesThrowGossipParseException(
             @Mocked SystemUtils systemUtils) throws TokenRetrieverUtils.GossipParseException {
         // updates instances with new instance owning token 4 as per token database.


### PR DESCRIPTION
Rolling back the changes to use gossip info while grabbing pre-assigned and dead tokens. Gossip information doesn't seem to reflect the correct state of the cluster always. This is blocking C* nodes from joining the ring. Temporarily rolling back the fix to use Gossip info.