### PR TITLE
bypass cassandra streaming

### DIFF
--- a/priam/src/main/java/com/netflix/priam/config/IBackupRestoreConfig.java
+++ b/priam/src/main/java/com/netflix/priam/config/IBackupRestoreConfig.java
@@ -97,4 +97,18 @@ public interface IBackupRestoreConfig {
     default boolean enableV2Restore() {
         return false;
     }
+
+    /**
+     * Build the instance from backups by using restore process in case of an instance replacements.
+     * Note that we prefer this when data size is HUGE. C* streaming is super slow and for instances
+     * with big data size can lead to C* streaming for multiple days. Note that this is a little bit
+     * dangerous as you "will" some of the writes accepted by old instance but not uploaded to
+     * backup file system. Also we do not plan to run local repair on the replaced instance, so data
+     * will be stale. We hope that repair will take care of the inconsistency.
+     *
+     * @return use restore for replacements (bypassing cassandra streaming), if backup is available.
+     */
+    default boolean enableBypassCassandraStreaming() {
+        return true;
+    }
 }

--- a/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
+++ b/priam/src/main/java/com/netflix/priam/identity/InstanceIdentity.java
@@ -345,6 +345,7 @@ public class InstanceIdentity {
     public void setReplacedIp(String replacedIp) {
         this.replacedIp = replacedIp;
         if (!replacedIp.isEmpty()) this.isReplace = true;
+        else this.isReplace = false;
     }
 
     private static boolean isInstanceDummy(PriamInstance instance) {

--- a/priam/src/main/java/com/netflix/priam/restore/AwsCrossAccountCryptographyRestoreStrategy.java
+++ b/priam/src/main/java/com/netflix/priam/restore/AwsCrossAccountCryptographyRestoreStrategy.java
@@ -27,8 +27,6 @@ import com.netflix.priam.cryptography.IFileCryptography;
 import com.netflix.priam.defaultimpl.ICassandraProcess;
 import com.netflix.priam.health.InstanceState;
 import com.netflix.priam.identity.InstanceIdentity;
-import com.netflix.priam.scheduler.SimpleTimer;
-import com.netflix.priam.scheduler.TaskTimer;
 import com.netflix.priam.utils.Sleeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,10 +75,5 @@ public class AwsCrossAccountCryptographyRestoreStrategy extends EncryptedRestore
                 metaData,
                 instanceState,
                 postRestoreHook);
-    }
-
-    /** @return a timer used by the scheduler to determine when "this" should be run. */
-    public static TaskTimer getTimer() {
-        return new SimpleTimer(JOBNAME);
     }
 }

--- a/priam/src/main/java/com/netflix/priam/restore/EncryptedRestoreStrategy.java
+++ b/priam/src/main/java/com/netflix/priam/restore/EncryptedRestoreStrategy.java
@@ -27,8 +27,6 @@ import com.netflix.priam.cryptography.IFileCryptography;
 import com.netflix.priam.defaultimpl.ICassandraProcess;
 import com.netflix.priam.health.InstanceState;
 import com.netflix.priam.identity.InstanceIdentity;
-import com.netflix.priam.scheduler.SimpleTimer;
-import com.netflix.priam.scheduler.TaskTimer;
 import com.netflix.priam.utils.Sleeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,12 +70,5 @@ public class EncryptedRestoreStrategy extends EncryptedRestoreBase {
                 metaData,
                 instanceState,
                 postRestoreHook);
-    }
-
-    /*
-     * @return a timer used by the scheduler to determine when "this" should be run.
-     */
-    public static TaskTimer getTimer() {
-        return new SimpleTimer(JOBNAME);
     }
 }

--- a/priam/src/main/java/com/netflix/priam/restore/GoogleCryptographyRestoreStrategy.java
+++ b/priam/src/main/java/com/netflix/priam/restore/GoogleCryptographyRestoreStrategy.java
@@ -27,8 +27,6 @@ import com.netflix.priam.cryptography.IFileCryptography;
 import com.netflix.priam.defaultimpl.ICassandraProcess;
 import com.netflix.priam.health.InstanceState;
 import com.netflix.priam.identity.InstanceIdentity;
-import com.netflix.priam.scheduler.SimpleTimer;
-import com.netflix.priam.scheduler.TaskTimer;
 import com.netflix.priam.utils.Sleeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,10 +67,5 @@ public class GoogleCryptographyRestoreStrategy extends EncryptedRestoreBase {
                 metaData,
                 instanceState,
                 postRestoreHook);
-    }
-
-    /** @return a timer used by the scheduler to determine when "this" should be run. */
-    public static TaskTimer getTimer() {
-        return new SimpleTimer(JOBNAME);
     }
 }

--- a/priam/src/main/java/com/netflix/priam/restore/IRestoreStrategy.java
+++ b/priam/src/main/java/com/netflix/priam/restore/IRestoreStrategy.java
@@ -17,5 +17,7 @@ package com.netflix.priam.restore;
  * A means to restore C* files from various source types (e.g. Google, AWS bucket whose objects are not owned by the current IAM role), and encrypted / non-encrypted data.
  */
 public interface IRestoreStrategy {
-    // public void restore(Date startTime, Date endTime) throws Exception;
+    void restore() throws Exception;
+
+    String getName();
 }

--- a/priam/src/main/java/com/netflix/priam/restore/Restore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/Restore.java
@@ -27,8 +27,6 @@ import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.defaultimpl.ICassandraProcess;
 import com.netflix.priam.health.InstanceState;
 import com.netflix.priam.identity.InstanceIdentity;
-import com.netflix.priam.scheduler.SimpleTimer;
-import com.netflix.priam.scheduler.TaskTimer;
 import com.netflix.priam.utils.Sleeper;
 import java.io.File;
 import java.nio.file.Path;
@@ -74,10 +72,6 @@ public class Restore extends AbstractRestore {
             final AbstractBackupPath path, final File restoreLocation) throws Exception {
         return fs.asyncDownloadFile(
                 Paths.get(path.getRemotePath()), Paths.get(restoreLocation.getAbsolutePath()), 5);
-    }
-
-    public static TaskTimer getTimer() {
-        return new SimpleTimer(JOBNAME);
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/tuner/dse/DseTuner.java
+++ b/priam/src/main/java/com/netflix/priam/tuner/dse/DseTuner.java
@@ -19,6 +19,7 @@ import static org.apache.cassandra.locator.SnitchProperties.RACKDC_PROPERTY_FILE
 import com.google.inject.Inject;
 import com.netflix.priam.config.IBackupRestoreConfig;
 import com.netflix.priam.config.IConfiguration;
+import com.netflix.priam.health.InstanceState;
 import com.netflix.priam.identity.config.InstanceInfo;
 import com.netflix.priam.tuner.StandardTuner;
 import java.io.FileReader;
@@ -46,8 +47,9 @@ public class DseTuner extends StandardTuner {
             IBackupRestoreConfig backupRestoreConfig,
             IDseConfiguration dseConfig,
             IAuditLogTuner auditLogTuner,
-            InstanceInfo instanceInfo) {
-        super(config, backupRestoreConfig, instanceInfo);
+            InstanceInfo instanceInfo,
+            InstanceState instanceState) {
+        super(config, backupRestoreConfig, instanceInfo, instanceState);
         this.dseConfig = dseConfig;
         this.auditLogTuner = auditLogTuner;
     }

--- a/priam/src/main/resources/Priam.properties
+++ b/priam/src/main/resources/Priam.properties
@@ -1,4 +1,1 @@
 priam.clustername=cass_cluster
-priam.direct.memory.size.m1.large=1G
-priam.heap.newgen.size.m1.large=2G
-priam.heap.size.m1.large=4G

--- a/priam/src/test/java/com/netflix/priam/tuner/StandardTunerTest.java
+++ b/priam/src/test/java/com/netflix/priam/tuner/StandardTunerTest.java
@@ -21,10 +21,12 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.common.io.Files;
 import com.google.inject.Guice;
+import com.google.inject.Injector;
 import com.netflix.priam.backup.BRTestModule;
 import com.netflix.priam.config.BackupRestoreConfig;
 import com.netflix.priam.config.FakeConfiguration;
 import com.netflix.priam.config.IBackupRestoreConfig;
+import com.netflix.priam.health.InstanceState;
 import com.netflix.priam.identity.config.InstanceInfo;
 import java.io.File;
 import java.io.FileInputStream;
@@ -47,15 +49,16 @@ public class StandardTunerTest {
 
     private final StandardTuner tuner;
     private final InstanceInfo instanceInfo;
+    private final InstanceState instanceState;
     private final IBackupRestoreConfig backupRestoreConfig;
     private final File target = new File("/tmp/priam_test.yaml");
 
     public StandardTunerTest() {
-        this.tuner = Guice.createInjector(new BRTestModule()).getInstance(StandardTuner.class);
-        this.instanceInfo =
-                Guice.createInjector(new BRTestModule()).getInstance(InstanceInfo.class);
-        this.backupRestoreConfig =
-                Guice.createInjector(new BRTestModule()).getInstance(BackupRestoreConfig.class);
+        Injector injector = Guice.createInjector(new BRTestModule());
+        this.tuner = injector.getInstance(StandardTuner.class);
+        this.instanceInfo = injector.getInstance(InstanceInfo.class);
+        this.backupRestoreConfig = injector.getInstance(BackupRestoreConfig.class);
+        this.instanceState = injector.getInstance(InstanceState.class);
     }
 
     @Test
@@ -137,7 +140,8 @@ public class StandardTunerTest {
                 new StandardTuner(
                         new TunerConfiguration(extraConfigParam, extraParamValues),
                         backupRestoreConfig,
-                        instanceInfo);
+                        instanceInfo,
+                        instanceState);
         Files.copy(new File("src/main/resources/incr-restore-cassandra.yaml"), target);
         tuner.writeAllProperties(target.getAbsolutePath(), "your_host", "YourSeedProvider");
 


### PR DESCRIPTION
Build the instance from backups by using the restore process in case of an instance replacement. Note that we prefer this when data size is HUGE. C* streaming is super slow, and for instances with big data size can lead to C* streaming for multiple days. Note that this is a little bit dangerous as you "will" lose writes accepted by the old instance but not uploaded to the backup file system. Also, we do not plan to run a local repair on the replaced instance, so data will be stale. We hope that the repair service will take care of the inconsistency. Clusters with LOCAL_QUORUM for reads and writes may see little to no impact.  If the restore fails, then we fall back to use "streaming". 