### PR TITLE
Update to latest alpha and fix hostname in VPCs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,7 @@ allprojects {
       compile 'com.googlecode.json-simple:json-simple:1.1.1'
       compile 'org.xerial.snappy:snappy-java:1.1.2.6'
       compile 'org.yaml:snakeyaml:1.19'
-      // Until Cassandra releases cassandra-all jars for 4.0
-      compile files(project.rootDir.getPath() + '/libs/apache-cassandra-4.0-SNAPSHOT.jar')
-      //compile 'org.apache.cassandra:cassandra-all:3.0.17'
+      compile 'org.apache.cassandra:cassandra-all:4.0-alpha3'
       compile 'javax.ws.rs:jsr311-api:1.1.1'
       compile 'joda-time:joda-time:2.9.9'
       compile 'org.apache.commons:commons-configuration2:2.1.1'

--- a/priam/src/main/java/com/netflix/priam/identity/config/AWSVpcInstanceDataRetriever.java
+++ b/priam/src/main/java/com/netflix/priam/identity/config/AWSVpcInstanceDataRetriever.java
@@ -41,4 +41,15 @@ public class AWSVpcInstanceDataRetriever extends InstanceDataRetrieverBase{
         return vpcId;
     }
 
+  /** @return either the public hostname if we have one, otherwise the vpc local hostname */
+  @Override
+  public String getPublicHostname() {
+        try {
+            return SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/public-hostname");
+        } catch (RuntimeException error) {
+            // If we can't retrieve a public hostname, retrieve a VPC local one.
+            return SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/local-hostname");
+        }
+    }
+
 }


### PR DESCRIPTION
* Switch from the checked in cassandra-all library to the released jars now that they exist
* Allow local hostnames in VPC clusters that have only internal ips. 