### PR TITLE
CASS-1752 First pass of changes to throw an exception when a node is …

### DIFF
--- a/priam/src/test/java/com/netflix/priam/identity/token/DeadTokenRetrieverTest.java
+++ b/priam/src/test/java/com/netflix/priam/identity/token/DeadTokenRetrieverTest.java
@@ -109,7 +109,7 @@ public class DeadTokenRetrieverTest {
         };
     }
 
-    @Test
+    @Test(expected = TokenRetrieverUtils.TokenAliveException.class)
     // There is a potential slot for dead token but we are unable to replace.
     public void testNoReplacementNoGossipMatch(@Mocked SystemUtils systemUtils) throws Exception {
         List<PriamInstance> allInstances = getInstances(2);
@@ -132,7 +132,6 @@ public class DeadTokenRetrieverTest {
                 new DeadTokenRetriever(
                         factory, membership, configuration, new FakeSleeper(), instanceInfo);
         PriamInstance priamInstance = deadTokenRetriever.get();
-        Assert.assertNull(priamInstance);
         new Verifications() {
             {
                 factory.delete(withAny(instance));

--- a/priam/src/test/java/com/netflix/priam/identity/token/TokenRetrieverUtilsTest.java
+++ b/priam/src/test/java/com/netflix/priam/identity/token/TokenRetrieverUtilsTest.java
@@ -66,7 +66,7 @@ public class TokenRetrieverUtilsTest {
         Assert.assertEquals("127.0.0.4", replaceIp);
     }
 
-    @Test
+    @Test(expected = TokenRetrieverUtils.TokenAliveException.class)
     public void testRetrieveTokenOwnerWhenGossipDisagrees(@Mocked SystemUtils systemUtils)
             throws Exception {
 
@@ -102,10 +102,9 @@ public class TokenRetrieverUtilsTest {
         };
 
         String replaceIp = TokenRetrieverUtils.inferTokenOwnerFromGossip(instances, "4", "us-east");
-        Assert.assertEquals(null, replaceIp);
     }
 
-    @Test
+    @Test(expected = TokenRetrieverUtils.TokenAliveException.class)
     public void testRetrieveTokenOwnerWhenAllHostsInGossipReturnsNull(
             @Mocked SystemUtils systemUtils) throws Exception {
         new Expectations() {
@@ -121,7 +120,9 @@ public class TokenRetrieverUtilsTest {
 
     @Test(expected = TokenRetrieverUtils.GossipParseException.class)
     public void testRetrieveTokenOwnerWhenAllInstancesThrowGossipParseException(
-            @Mocked SystemUtils systemUtils) throws TokenRetrieverUtils.GossipParseException {
+            @Mocked SystemUtils systemUtils)
+            throws TokenRetrieverUtils.GossipParseException,
+                    TokenRetrieverUtils.TokenAliveException {
 
         new Expectations() {
             {


### PR DESCRIPTION
…bootstrapping to an existing token. Per current thoughts this change is going to held as a PR and only committed after the root cause is addressed in Cassandra if any.