### PR TITLE
log and emit when there is no verified backup within SLO

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backupv2/BackupVerificationTask.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/BackupVerificationTask.java
@@ -102,9 +102,8 @@ public class BackupVerificationTask extends Task {
                             backupNotificationMgr.notify(backupVerificationResult);
                         });
 
-        if (!BackupRestoreUtil.getLatestValidMetaPath(
-                        backupVerification.getMetaProxy(BackupVersion.SNAPSHOT_META_SERVICE),
-                        dateRange)
+        if (!backupVerification
+                .verifyBackup(BackupVersion.SNAPSHOT_META_SERVICE, false /* force */, dateRange)
                 .isPresent()) {
             logger.error(
                     "Not able to find any snapshot which is valid in our SLO window: {} hours",


### PR DESCRIPTION
Previously we would log and error and emit metrics when there was no verified backup whose files were fully in S3. We are relaxing that constraint here and will accept verified backups that are in the in-memory cache.