### PR TITLE
Cease requiring the backup to be fully in S3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,9 @@ allprojects {
       compileOnly 'javax.servlet:javax.servlet-api:3.1.0'
       testCompile 'org.jmockit:jmockit:1.31'
       testCompile "org.spockframework:spock-core:1.1-groovy-2.4"
-      testCompile 'junit:junit:4.12'
+      testCompile "com.google.truth:truth:1.0.1"
+      testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
+      testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
     }
 
     sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Make BackupVerificationTask log and emit when there is no verified backup within SLO. Cease requiring the backup to be fully in S3. Plus tidying tweaks.