### PR TITLE
Skip backup compression based on configuration

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/RemoteBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/aws/RemoteBackupPath.java
@@ -29,7 +29,10 @@ import com.netflix.priam.utils.DateUtil;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents location of an object on the remote file system. All the objects will be keyed with a

--- a/priam/src/main/java/com/netflix/priam/aws/RemoteBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/aws/RemoteBackupPath.java
@@ -16,6 +16,7 @@
  */
 package com.netflix.priam.aws;
 
+import com.google.api.client.util.Lists;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -28,9 +29,7 @@ import com.netflix.priam.utils.DateUtil;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Represents location of an object on the remote file system. All the objects will be keyed with a
@@ -103,16 +102,23 @@ public class RemoteBackupPath extends AbstractBackupPath {
         type = BackupFileType.valueOf(remotePath.getName(index++).toString());
         String lastModified = remotePath.getName(index++).toString();
         setLastModified(Instant.ofEpochMilli(Long.parseLong(lastModified)));
+        List<String> parts = Lists.newArrayListWithCapacity(4);
         if (BackupFileType.isDataFile(type)) {
             keyspace = remotePath.getName(index++).toString();
             columnFamily = remotePath.getName(index++).toString();
+            parts.add(keyspace);
+            parts.add(columnFamily);
         }
         if (type == BackupFileType.SECONDARY_INDEX_V2) {
             indexDir = remotePath.getName(index++).toString();
+            parts.add(indexDir);
         }
         setCompression(CompressionAlgorithm.valueOf(remotePath.getName(index++).toString()));
         setEncryption(remotePath.getName(index++).toString());
         fileName = remotePath.getName(index).toString();
+        parts.add(fileName);
+        this.backupFile =
+                Paths.get(config.getDataFileLocation(), parts.toArray(new String[] {})).toFile();
     }
 
     private String getV1Location() {

--- a/priam/src/main/java/com/netflix/priam/aws/RemoteBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/aws/RemoteBackupPath.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import com.netflix.priam.backup.AbstractBackupPath;
+import com.netflix.priam.compress.CompressionAlgorithm;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.identity.InstanceIdentity;
 import com.netflix.priam.utils.DateUtil;
@@ -109,7 +110,7 @@ public class RemoteBackupPath extends AbstractBackupPath {
         if (type == BackupFileType.SECONDARY_INDEX_V2) {
             indexDir = remotePath.getName(index++).toString();
         }
-        setCompression(remotePath.getName(index++).toString());
+        setCompression(CompressionAlgorithm.valueOf(remotePath.getName(index++).toString()));
         setEncryption(remotePath.getName(index++).toString());
         fileName = remotePath.getName(index).toString();
     }

--- a/priam/src/main/java/com/netflix/priam/aws/RemoteBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/aws/RemoteBackupPath.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import com.netflix.priam.backup.AbstractBackupPath;
-import com.netflix.priam.compress.CompressionAlgorithm;
+import com.netflix.priam.compress.CompressionType;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.identity.InstanceIdentity;
 import com.netflix.priam.utils.DateUtil;
@@ -116,7 +116,7 @@ public class RemoteBackupPath extends AbstractBackupPath {
             indexDir = remotePath.getName(index++).toString();
             parts.add(indexDir);
         }
-        setCompression(CompressionAlgorithm.valueOf(remotePath.getName(index++).toString()));
+        setCompression(CompressionType.valueOf(remotePath.getName(index++).toString()));
         setEncryption(remotePath.getName(index++).toString());
         fileName = remotePath.getName(index).toString();
         parts.add(fileName);

--- a/priam/src/main/java/com/netflix/priam/aws/S3EncryptedFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3EncryptedFileSystem.java
@@ -26,6 +26,7 @@ import com.google.inject.name.Named;
 import com.netflix.priam.backup.AbstractBackupPath;
 import com.netflix.priam.backup.BackupRestoreException;
 import com.netflix.priam.backup.RangeReadInputStream;
+import com.netflix.priam.compress.ChunkedStream;
 import com.netflix.priam.compress.ICompression;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.cred.ICredential;
@@ -122,7 +123,8 @@ public class S3EncryptedFileSystem extends S3FileSystemBase {
         try (InputStream in = new FileInputStream(localPath.toFile());
                 BufferedOutputStream compressedBos =
                         new BufferedOutputStream(new FileOutputStream(compressedDstFile))) {
-            Iterator<byte[]> compressedChunks = this.compress.compress(in, chunkSize);
+            Iterator<byte[]> compressedChunks =
+                    new ChunkedStream(in, chunkSize, path.getCompression());
             while (compressedChunks.hasNext()) {
                 byte[] compressedChunk = compressedChunks.next();
                 compressedBos.write(compressedChunk);

--- a/priam/src/main/java/com/netflix/priam/aws/S3EncryptedFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3EncryptedFileSystem.java
@@ -35,6 +35,7 @@ import com.netflix.priam.merics.BackupMetrics;
 import com.netflix.priam.notification.BackupNotificationMgr;
 import java.io.*;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
@@ -69,14 +70,14 @@ public class S3EncryptedFileSystem extends S3FileSystemBase {
     }
 
     @Override
-    protected void downloadFileImpl(Path remotePath, Path localPath) throws BackupRestoreException {
+    protected void downloadFileImpl(AbstractBackupPath path, String suffix)
+            throws BackupRestoreException {
+        String remotePath = path.getRemotePath();
+        Path localPath = Paths.get(path.newRestoreFile().getAbsolutePath() + suffix);
         try (OutputStream os = new FileOutputStream(localPath.toFile());
                 RangeReadInputStream rris =
                         new RangeReadInputStream(
-                                s3Client,
-                                getShard(),
-                                super.getFileSize(remotePath),
-                                remotePath.toString())) {
+                                s3Client, getShard(), super.getFileSize(remotePath), remotePath)) {
             /*
              * To handle use cases where decompression should be done outside of the download.  For example, the file have been compressed and then encrypted.
              * Hence, decompressing it here would compromise the decryption.

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -29,7 +29,7 @@ import com.netflix.priam.backup.AbstractBackupPath;
 import com.netflix.priam.backup.BackupRestoreException;
 import com.netflix.priam.backup.RangeReadInputStream;
 import com.netflix.priam.compress.ChunkedStream;
-import com.netflix.priam.compress.CompressionAlgorithm;
+import com.netflix.priam.compress.CompressionType;
 import com.netflix.priam.compress.ICompression;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.identity.config.InstanceInfo;
@@ -84,7 +84,7 @@ public class S3FileSystem extends S3FileSystemBase {
                                 bufferSize);
                 BufferedOutputStream os =
                         new BufferedOutputStream(new FileOutputStream(localFile))) {
-            if (path.getCompression() == CompressionAlgorithm.NONE) {
+            if (path.getCompression() == CompressionType.NONE) {
                 IOUtils.copyLarge(is, os);
             } else {
                 compress.decompressAndClose(is, os);

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class S3FileSystem extends S3FileSystemBase {
     private static final Logger logger = LoggerFactory.getLogger(S3FileSystem.class);
+    private static final long MAX_BUFFER_SIZE = 5 * 1024 * 1024;
 
     @Inject
     public S3FileSystem(
@@ -72,10 +73,7 @@ public class S3FileSystem extends S3FileSystemBase {
             RangeReadInputStream rris =
                     new RangeReadInputStream(
                             s3Client, getShard(), remoteFileSize, remotePath.toString());
-            final long bufSize =
-                    MAX_BUFFERED_IN_STREAM_SIZE > remoteFileSize
-                            ? remoteFileSize
-                            : MAX_BUFFERED_IN_STREAM_SIZE;
+            final long bufSize = Math.min(MAX_BUFFER_SIZE, remoteFileSize);
             compress.decompressAndClose(
                     new BufferedInputStream(rris, (int) bufSize),
                     new BufferedOutputStream(new FileOutputStream(localPath.toFile())));

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -68,16 +68,18 @@ public class S3FileSystem extends S3FileSystemBase {
     }
 
     @Override
-    protected void downloadFileImpl(Path remotePath, Path localPath) throws BackupRestoreException {
-        String remotePathName = remotePath.toString();
+    protected void downloadFileImpl(AbstractBackupPath path, String suffix)
+            throws BackupRestoreException {
+        String remotePath = path.getRemotePath();
+        File localFile = new File(path.newRestoreFile().getAbsolutePath() + suffix);
         try {
             long size = super.getFileSize(remotePath);
             RangeReadInputStream rris =
-                    new RangeReadInputStream(s3Client, getShard(), size, remotePathName);
+                    new RangeReadInputStream(s3Client, getShard(), size, remotePath);
             final long bufferSize = Math.min(MAX_BUFFER_SIZE, size);
             compress.decompressAndClose(
                     new BufferedInputStream(rris, (int) bufferSize),
-                    new BufferedOutputStream(new FileOutputStream(localPath.toFile())));
+                    new BufferedOutputStream(new FileOutputStream(localFile)));
         } catch (Exception e) {
             String err =
                     String.format(

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,7 +123,7 @@ public class S3FileSystem extends S3FileSystemBase {
                         config.getBackupPrefix(),
                         remotePath.toString(),
                         initResponse.getUploadId());
-        List<PartETag> partETags = Collections.synchronizedList(new ArrayList<PartETag>());
+        List<PartETag> partETags = Collections.synchronizedList(new ArrayList<>());
 
         try (InputStream in = new FileInputStream(localPath.toFile())) {
             Iterator<byte[]> chunks = compress.compress(in, chunkSize);
@@ -147,7 +146,7 @@ public class S3FileSystem extends S3FileSystemBase {
                         new S3PartUploader(s3Client, dp, partETags, partsUploaded);
                 compressedFileSize += chunk.length;
                 // TODO: Get the future over here and create a new arraylist.
-                Future<Void> future = executor.submit(partUploader);
+                executor.submit(partUploader);
             }
 
             // TODO: Instead of waiting for executor thread to be empty we should wait for all the
@@ -231,7 +230,7 @@ public class S3FileSystem extends S3FileSystemBase {
                 PutObjectResult upload =
                         new BoundedExponentialRetryCallable<PutObjectResult>(1000, 10000, 5) {
                             @Override
-                            public PutObjectResult retriableCall() throws Exception {
+                            public PutObjectResult retriableCall() {
                                 return s3Client.putObject(putObjectRequest);
                             }
                         }.call();

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystemBase.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystemBase.java
@@ -46,7 +46,6 @@ import org.slf4j.LoggerFactory;
 
 public abstract class S3FileSystemBase extends AbstractFileSystem {
     private static final int MAX_CHUNKS = 10000;
-    static final long MAX_BUFFERED_IN_STREAM_SIZE = 5 * 1024 * 1024;
     private static final Logger logger = LoggerFactory.getLogger(S3FileSystemBase.class);
     AmazonS3 s3Client;
     final IConfiguration config;

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystemBase.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystemBase.java
@@ -281,10 +281,7 @@ public abstract class S3FileSystemBase extends AbstractFileSystem {
         }
     }
 
-    final long getChunkSize(Path localPath) {
-        long chunkSize = config.getBackupChunkSize();
-        long proposedChunkSize = localPath.toFile().length() / (MAX_CHUNKS - 5);
-        if (proposedChunkSize > chunkSize) return proposedChunkSize;
-        return chunkSize;
+    final long getChunkSize(Path path) {
+        return Math.max(path.toFile().length() / (MAX_CHUNKS - 5), config.getBackupChunkSize());
     }
 }

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystemBase.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystemBase.java
@@ -225,8 +225,8 @@ public abstract class S3FileSystemBase extends AbstractFileSystem {
     }
 
     @Override
-    public long getFileSize(Path remotePath) throws BackupRestoreException {
-        return s3Client.getObjectMetadata(getShard(), remotePath.toString()).getContentLength();
+    public long getFileSize(String remotePath) throws BackupRestoreException {
+        return s3Client.getObjectMetadata(getShard(), remotePath).getContentLength();
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystemBase.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystemBase.java
@@ -45,7 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class S3FileSystemBase extends AbstractFileSystem {
-    private static final int MAX_CHUNKS = 10000;
+    private static final int MAX_CHUNKS = 9995; // 10K is AWS limit, minus a small buffer
     private static final Logger logger = LoggerFactory.getLogger(S3FileSystemBase.class);
     AmazonS3 s3Client;
     final IConfiguration config;
@@ -282,6 +282,6 @@ public abstract class S3FileSystemBase extends AbstractFileSystem {
     }
 
     final long getChunkSize(Path path) {
-        return Math.max(path.toFile().length() / (MAX_CHUNKS - 5), config.getBackupChunkSize());
+        return Math.max(path.toFile().length() / MAX_CHUNKS, config.getBackupChunkSize());
     }
 }

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
@@ -125,7 +125,7 @@ public abstract class AbstractBackup extends Task {
                 return CompressionAlgorithm.NONE;
             case ALL:
                 return CompressionAlgorithm.SNAPPY;
-            case UNCOMPRESSED:
+            case IF_REQUIRED:
                 int splitIndex = file.lastIndexOf('-');
                 return splitIndex >= 0 && compressedFiles.contains(file.substring(0, splitIndex))
                         ? CompressionAlgorithm.NONE

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
@@ -28,7 +28,6 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.text.ParseException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -56,13 +55,7 @@ public abstract class AbstractBackup extends Task {
         this.fs = backupFileSystemCtx.getFileStrategy(config);
     }
 
-    /** A means to override the type of backup strategy chosen via BackupFileSystemContext */
-    protected void setFileSystem(IBackupFileSystem fs) {
-        this.fs = fs;
-    }
-
-    private AbstractBackupPath getAbstractBackupPath(final File file, final BackupFileType type)
-            throws ParseException {
+    private AbstractBackupPath getAbstractBackupPath(final File file, final BackupFileType type) {
         final AbstractBackupPath bp = pathFactory.get();
         bp.parseLocal(file, type);
         return bp;

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.netflix.priam.backup.AbstractBackupPath.BackupFileType;
-import com.netflix.priam.compress.CompressionAlgorithm;
+import com.netflix.priam.compress.CompressionType;
 import com.netflix.priam.config.BackupsToCompress;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.scheduler.Task;
@@ -113,23 +113,23 @@ public abstract class AbstractBackup extends Task {
         return bps.build();
     }
 
-    private CompressionAlgorithm getCorrectCompressionAlgorithm(
+    private CompressionType getCorrectCompressionAlgorithm(
             AbstractBackupPath path, Set<String> compressedFiles) {
         if (!BackupFileType.isV2(path.getType())) {
-            return CompressionAlgorithm.SNAPPY;
+            return CompressionType.SNAPPY;
         }
         String file = path.getFileName();
         BackupsToCompress which = config.getBackupsToCompress();
         switch (which) {
             case NONE:
-                return CompressionAlgorithm.NONE;
+                return CompressionType.NONE;
             case ALL:
-                return CompressionAlgorithm.SNAPPY;
+                return CompressionType.SNAPPY;
             case IF_REQUIRED:
                 int splitIndex = file.lastIndexOf('-');
                 return splitIndex >= 0 && compressedFiles.contains(file.substring(0, splitIndex))
-                        ? CompressionAlgorithm.NONE
-                        : CompressionAlgorithm.SNAPPY;
+                        ? CompressionType.NONE
+                        : CompressionType.SNAPPY;
             default:
                 throw new IllegalArgumentException("NONE, ALL, UNCOMPRESSED only. Saw: " + which);
         }

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
@@ -107,13 +107,18 @@ public abstract class AbstractBackup extends Task {
         for (File file : files) {
             final AbstractBackupPath bp = pathFactory.get();
             bp.parseLocal(file, type);
-            bp.setCompression(getCompressionAlgorithm(file.getName(), compressedFilePrefixes));
+            bp.setCompression(getCorrectCompressionAlgorithm(bp, compressedFilePrefixes));
             bps.add(bp);
         }
         return bps.build();
     }
 
-    private CompressionAlgorithm getCompressionAlgorithm(String file, Set<String> compressedFiles) {
+    private CompressionAlgorithm getCorrectCompressionAlgorithm(
+            AbstractBackupPath path, Set<String> compressedFiles) {
+        if (!BackupFileType.isV2(path.getType())) {
+            return CompressionAlgorithm.SNAPPY;
+        }
+        String file = path.getFileName();
         BackupsToCompress which = config.getBackupsToCompress();
         switch (which) {
             case NONE:

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
@@ -88,19 +88,17 @@ public abstract class AbstractBackup extends Task {
 
                 if (async)
                     futures.add(
-                            fs.asyncUploadFile(
+                            fs.asyncUploadAndDelete(
                                     Paths.get(bp.getBackupFile().getAbsolutePath()),
                                     Paths.get(bp.getRemotePath()),
                                     bp,
-                                    10,
-                                    true));
+                                    10));
                 else
-                    fs.uploadFile(
+                    fs.uploadAndDelete(
                             Paths.get(bp.getBackupFile().getAbsolutePath()),
                             Paths.get(bp.getRemotePath()),
                             bp,
-                            10,
-                            true);
+                            10);
 
                 bps.add(bp);
             }

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
@@ -77,7 +77,7 @@ public abstract class AbstractBackup extends Task {
             final File parent, final BackupFileType type, boolean async, boolean waitForCompletion)
             throws Exception {
         final List<AbstractBackupPath> bps = Lists.newArrayList();
-        final List<Future<Path>> futures = Lists.newArrayList();
+        final List<Future<AbstractBackupPath>> futures = Lists.newArrayList();
 
         File[] files = parent.listFiles();
         if (files == null) return bps;
@@ -86,19 +86,8 @@ public abstract class AbstractBackup extends Task {
             if (file.isFile() && file.exists()) {
                 AbstractBackupPath bp = getAbstractBackupPath(file, type);
 
-                if (async)
-                    futures.add(
-                            fs.asyncUploadAndDelete(
-                                    Paths.get(bp.getBackupFile().getAbsolutePath()),
-                                    Paths.get(bp.getRemotePath()),
-                                    bp,
-                                    10));
-                else
-                    fs.uploadAndDelete(
-                            Paths.get(bp.getBackupFile().getAbsolutePath()),
-                            Paths.get(bp.getRemotePath()),
-                            bp,
-                            10);
+                if (async) futures.add(fs.asyncUploadAndDelete(bp, 10));
+                else fs.uploadAndDelete(bp, 10);
 
                 bps.add(bp);
             }
@@ -106,7 +95,7 @@ public abstract class AbstractBackup extends Task {
 
         // Wait for all files to be uploaded.
         if (async && waitForCompletion) {
-            for (Future future : futures)
+            for (Future<AbstractBackupPath> future : futures)
                 future.get(); // This might throw exception if there is any error
         }
 

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.ImplementedBy;
 import com.netflix.priam.aws.RemoteBackupPath;
-import com.netflix.priam.compress.CompressionAlgorithm;
+import com.netflix.priam.compress.CompressionType;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.cryptography.CryptographyAlgorithm;
 import com.netflix.priam.identity.InstanceIdentity;
@@ -95,7 +95,7 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
     private Instant lastModified;
     private Instant creationTime;
     private Date uploadedTs;
-    private CompressionAlgorithm compression = CompressionAlgorithm.SNAPPY;
+    private CompressionType compression = CompressionType.SNAPPY;
     private CryptographyAlgorithm encryption = CryptographyAlgorithm.PLAINTEXT;
 
     public AbstractBackupPath(IConfiguration config, InstanceIdentity instanceIdentity) {
@@ -307,12 +307,12 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
         this.creationTime = instant;
     }
 
-    public CompressionAlgorithm getCompression() {
+    public CompressionType getCompression() {
         return compression;
     }
 
-    public void setCompression(CompressionAlgorithm compressionAlgorithm) {
-        this.compression = compressionAlgorithm;
+    public void setCompression(CompressionType compressionType) {
+        this.compression = compressionType;
     }
 
     public CryptographyAlgorithm getEncryption() {

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
@@ -80,7 +80,7 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
     private long compressedFileSize = 0;
     protected final InstanceIdentity instanceIdentity;
     protected final IConfiguration config;
-    private File backupFile;
+    protected File backupFile;
     private Instant lastModified;
     private Date uploadedTs;
     private CompressionAlgorithm compression = CompressionAlgorithm.SNAPPY;

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
@@ -281,8 +281,8 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
         return compression;
     }
 
-    public void setCompression(String compression) {
-        this.compression = CompressionAlgorithm.valueOf(compression);
+    public void setCompression(CompressionAlgorithm compressionAlgorithm) {
+        this.compression = compressionAlgorithm;
     }
 
     public CryptographyAlgorithm getEncryption() {

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
@@ -53,8 +53,15 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
         private static ImmutableSet<BackupFileType> DATA_FILE_TYPES =
                 ImmutableSet.of(SECONDARY_INDEX_V2, SNAP, SST, SST_V2);
 
+        private static ImmutableSet<BackupFileType> V2_FILE_TYPES =
+                ImmutableSet.of(SECONDARY_INDEX_V2, SST_V2, META_V2);
+
         public static boolean isDataFile(BackupFileType type) {
             return DATA_FILE_TYPES.contains(type);
+        }
+
+        public static boolean isV2(BackupFileType type) {
+            return V2_FILE_TYPES.contains(type);
         }
 
         public static BackupFileType fromString(String s) throws BackupRestoreException {

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractFileSystem.java
@@ -113,7 +113,7 @@ public abstract class AbstractFileSystem implements IBackupFileSystem, EventGene
     @Override
     public Future<Path> asyncDownloadFile(
             final Path remotePath, final Path localPath, final int retry)
-            throws BackupRestoreException, RejectedExecutionException {
+            throws RejectedExecutionException {
         return fileDownloadExecutor.submit(
                 () -> {
                     downloadFile(remotePath, localPath, retry);
@@ -159,7 +159,7 @@ public abstract class AbstractFileSystem implements IBackupFileSystem, EventGene
             final AbstractBackupPath path,
             final int retry,
             final boolean deleteAfterSuccessfulUpload)
-            throws FileNotFoundException, RejectedExecutionException, BackupRestoreException {
+            throws RejectedExecutionException {
         return fileUploadExecutor.submit(
                 () -> {
                     uploadFile(localPath, remotePath, path, retry, deleteAfterSuccessfulUpload);

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractFileSystem.java
@@ -152,27 +152,25 @@ public abstract class AbstractFileSystem implements IBackupFileSystem, EventGene
             throws BackupRestoreException;
 
     @Override
-    public Future<Path> asyncUploadFile(
+    public Future<Path> asyncUploadAndDelete(
             final Path localPath,
             final Path remotePath,
             final AbstractBackupPath path,
-            final int retry,
-            final boolean deleteAfterSuccessfulUpload)
+            final int retry)
             throws RejectedExecutionException {
         return fileUploadExecutor.submit(
                 () -> {
-                    uploadFile(localPath, remotePath, path, retry, deleteAfterSuccessfulUpload);
+                    uploadAndDelete(localPath, remotePath, path, retry);
                     return localPath;
                 });
     }
 
     @Override
-    public void uploadFile(
+    public void uploadAndDelete(
             final Path localPath,
             final Path remotePath,
             final AbstractBackupPath path,
-            final int retry,
-            final boolean deleteAfterSuccessfulUpload)
+            final int retry)
             throws FileNotFoundException, BackupRestoreException {
         if (localPath == null
                 || remotePath == null
@@ -217,7 +215,7 @@ public abstract class AbstractFileSystem implements IBackupFileSystem, EventGene
                 logger.info(
                         "Successfully uploaded file: {} to location: {}", localPath, remotePath);
 
-                if (deleteAfterSuccessfulUpload && !FileUtils.deleteQuietly(localPath.toFile()))
+                if (!FileUtils.deleteQuietly(localPath.toFile()))
                     logger.warn(
                             String.format(
                                     "Failed to delete local file %s.",

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractFileSystem.java
@@ -17,6 +17,7 @@
 
 package com.netflix.priam.backup;
 
+import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.inject.Inject;
@@ -32,7 +33,6 @@ import com.netflix.priam.scheduler.BlockingSubmitThreadPoolExecutor;
 import com.netflix.priam.utils.BoundedExponentialRetryCallable;
 import com.netflix.spectator.api.patterns.PolledMeter;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Date;
@@ -152,35 +152,24 @@ public abstract class AbstractFileSystem implements IBackupFileSystem, EventGene
             throws BackupRestoreException;
 
     @Override
-    public Future<Path> asyncUploadAndDelete(
-            final Path localPath,
-            final Path remotePath,
-            final AbstractBackupPath path,
-            final int retry)
-            throws RejectedExecutionException {
+    public Future<AbstractBackupPath> asyncUploadAndDelete(
+            final AbstractBackupPath path, final int retry) throws RejectedExecutionException {
         return fileUploadExecutor.submit(
                 () -> {
-                    uploadAndDelete(localPath, remotePath, path, retry);
-                    return localPath;
+                    uploadAndDelete(path, retry);
+                    return path;
                 });
     }
 
     @Override
-    public void uploadAndDelete(
-            final Path localPath,
-            final Path remotePath,
-            final AbstractBackupPath path,
-            final int retry)
-            throws FileNotFoundException, BackupRestoreException {
-        if (localPath == null
-                || remotePath == null
-                || !localPath.toFile().exists()
-                || localPath.toFile().isDirectory())
-            throw new FileNotFoundException(
-                    "File do not exist or is a directory. localPath: "
-                            + localPath
-                            + ", remotePath: "
-                            + remotePath);
+    public void uploadAndDelete(final AbstractBackupPath path, final int retry)
+            throws BackupRestoreException {
+        Path localPath = Paths.get(path.getBackupFile().getAbsolutePath());
+        File localFile = localPath.toFile();
+        Preconditions.checkArgument(localFile.exists(), "Can't upload nonexistent {}", localPath);
+        Preconditions.checkArgument(
+                !localFile.isDirectory(), "Can only upload files {} is a directory", localPath);
+        Path remotePath = Paths.get(path.getRemotePath());
 
         if (tasksQueued.add(localPath)) {
             logger.info("Uploading file: {} to location: {}", localPath, remotePath);
@@ -215,11 +204,11 @@ public abstract class AbstractFileSystem implements IBackupFileSystem, EventGene
                 logger.info(
                         "Successfully uploaded file: {} to location: {}", localPath, remotePath);
 
-                if (!FileUtils.deleteQuietly(localPath.toFile()))
+                if (!FileUtils.deleteQuietly(localFile))
                     logger.warn(
                             String.format(
                                     "Failed to delete local file %s.",
-                                    localPath.toFile().getAbsolutePath()));
+                                    localFile.getAbsolutePath()));
 
             } catch (Exception e) {
                 backupMetrics.incrementInvalidUploads();

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractFileSystem.java
@@ -124,14 +124,14 @@ public abstract class AbstractFileSystem implements IBackupFileSystem, EventGene
     public void downloadFile(final AbstractBackupPath path, String suffix, final int retry)
             throws BackupRestoreException {
         // TODO: Should we download the file if localPath already exists?
-        Path remotePath = Paths.get(path.getRemotePath());
-        Path localPath = Paths.get(path.newRestoreFile().getAbsolutePath() + suffix);
-        logger.info("Downloading file: {} to location: {}", remotePath, localPath);
+        String remotePath = path.getRemotePath();
+        String localPath = path.newRestoreFile().getAbsolutePath() + suffix;
+        logger.info("Downloading file: {} to location: {}", path.getRemotePath(), localPath);
         try {
             new BoundedExponentialRetryCallable<Void>(500, 10000, retry) {
                 @Override
                 public Void retriableCall() throws Exception {
-                    downloadFileImpl(remotePath, localPath);
+                    downloadFileImpl(path, suffix);
                     return null;
                 }
             }.call();
@@ -148,7 +148,7 @@ public abstract class AbstractFileSystem implements IBackupFileSystem, EventGene
         }
     }
 
-    protected abstract void downloadFileImpl(final Path remotePath, final Path localPath)
+    protected abstract void downloadFileImpl(final AbstractBackupPath path, String suffix)
             throws BackupRestoreException;
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractFileSystem.java
@@ -183,7 +183,7 @@ public abstract class AbstractFileSystem implements IBackupFileSystem, EventGene
                             new BoundedExponentialRetryCallable<Long>(500, 10000, retry) {
                                 @Override
                                 public Long retriableCall() throws Exception {
-                                    return uploadFileImpl(localPath, remotePath);
+                                    return uploadFileImpl(path);
                                 }
                             }.call();
 
@@ -264,7 +264,7 @@ public abstract class AbstractFileSystem implements IBackupFileSystem, EventGene
 
     protected abstract boolean doesRemoteFileExist(Path remotePath);
 
-    protected abstract long uploadFileImpl(final Path localPath, final Path remotePath)
+    protected abstract long uploadFileImpl(final AbstractBackupPath path)
             throws BackupRestoreException;
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/backup/CommitLogBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/CommitLogBackup.java
@@ -20,7 +20,6 @@ import com.google.inject.name.Named;
 import com.netflix.priam.backup.AbstractBackupPath.BackupFileType;
 import com.netflix.priam.utils.DateUtil;
 import java.io.File;
-import java.nio.file.Paths;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -66,11 +65,7 @@ public class CommitLogBackup {
 
                 if (snapshotName != null) bp.time = DateUtil.getDate(snapshotName);
 
-                fs.uploadAndDelete(
-                        Paths.get(bp.getBackupFile().getAbsolutePath()),
-                        Paths.get(bp.getRemotePath()),
-                        bp,
-                        10);
+                fs.uploadAndDelete(bp, 10);
                 bps.add(bp);
                 addToRemotePath(bp.getRemotePath());
             } catch (Exception e) {

--- a/priam/src/main/java/com/netflix/priam/backup/CommitLogBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/CommitLogBackup.java
@@ -66,12 +66,11 @@ public class CommitLogBackup {
 
                 if (snapshotName != null) bp.time = DateUtil.getDate(snapshotName);
 
-                fs.uploadFile(
+                fs.uploadAndDelete(
                         Paths.get(bp.getBackupFile().getAbsolutePath()),
                         Paths.get(bp.getRemotePath()),
                         bp,
-                        10,
-                        true);
+                        10);
                 bps.add(bp);
                 addToRemotePath(bp.getRemotePath());
             } catch (Exception e) {

--- a/priam/src/main/java/com/netflix/priam/backup/IBackupFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/backup/IBackupFileSystem.java
@@ -42,7 +42,7 @@ public interface IBackupFileSystem {
      * Download the file denoted by remotePath in an async fashion to the local file system denoted
      * by local path.
      *
-     * @param path Backuop path representing a local and remote file pair
+     * @param path Backup path representing a local and remote file pair
      * @param retry No. of times to retry to download a file from remote file system. If &lt;1, it
      *     will try to download file exactly once.
      * @return The future of the async job to monitor the progress of the job.
@@ -55,17 +55,14 @@ public interface IBackupFileSystem {
             throws BackupRestoreException, RejectedExecutionException;
 
     /**
-     * Upload the local file denoted by localPath to the remote file system at location denoted by
-     * remotePath. De-duping of the file to upload will always be done by comparing the
+     * Upload the local file to its remote counterpart. Both locations are embedded within the path
+     * parameter. De-duping of the file to upload will always be done by comparing the
      * files-in-progress to be uploaded. This may result in this particular request to not to be
      * executed e.g. if any other thread has given the same file to upload and that file is in
      * internal queue. Note that de-duping is best effort and is not always guaranteed as we try to
      * avoid lock on read/write of the files-in-progress. Once uploaded, files are deleted.
      *
-     * @param localPath Path of the local file that needs to be uploaded.
-     * @param remotePath Fully qualified path on the remote file system where file should be
-     *     uploaded.
-     * @param path AbstractBackupPath to be used to send backup notifications only.
+     * @param path Backup path representing a local and remote file pair
      * @param retry No of times to retry to upload a file. If &lt;1, it will try to upload file
      *     exactly once.
      * @throws BackupRestoreException in case of failure to upload for any reason including file not
@@ -73,16 +70,13 @@ public interface IBackupFileSystem {
      * @throws FileNotFoundException If a file as denoted by localPath is not available or is a
      *     directory.
      */
-    void uploadAndDelete(Path localPath, Path remotePath, AbstractBackupPath path, int retry)
+    void uploadAndDelete(AbstractBackupPath path, int retry)
             throws FileNotFoundException, BackupRestoreException;
 
     /**
      * Upload the local file denoted by localPath in async fashion to the remote file system at
      * location denoted by remotePath.
      *
-     * @param localPath Path of the local file that needs to be uploaded.
-     * @param remotePath Fully qualified path on the remote file system where file should be
-     *     uploaded.
      * @param path AbstractBackupPath to be used to send backup notifications only.
      * @param retry No of times to retry to upload a file. If &lt;1, it will try to upload file
      *     exactly once.
@@ -95,11 +89,7 @@ public interface IBackupFileSystem {
      * @throws RejectedExecutionException if the queue is full and TIMEOUT is reached while trying
      *     to add the work to the queue.
      */
-    Future<Path> asyncUploadAndDelete(
-            final Path localPath,
-            final Path remotePath,
-            final AbstractBackupPath path,
-            final int retry)
+    Future<AbstractBackupPath> asyncUploadAndDelete(final AbstractBackupPath path, final int retry)
             throws FileNotFoundException, RejectedExecutionException, BackupRestoreException;
 
     /**

--- a/priam/src/main/java/com/netflix/priam/backup/IBackupFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/backup/IBackupFileSystem.java
@@ -171,7 +171,7 @@ public interface IBackupFileSystem {
      * @throws BackupRestoreException in case of failure to read object denoted by remotePath or any
      *     other error.
      */
-    long getFileSize(Path remotePath) throws BackupRestoreException;
+    long getFileSize(String remotePath) throws BackupRestoreException;
 
     /**
      * Checks if the file denoted by remotePath exists on the remote file system. It does not need

--- a/priam/src/main/java/com/netflix/priam/backup/IBackupFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/backup/IBackupFileSystem.java
@@ -29,21 +29,20 @@ public interface IBackupFileSystem {
     /**
      * Download the file denoted by remotePath to the local file system denoted by local path.
      *
-     * @param remotePath fully qualified location of the file on remote file system.
-     * @param localPath location on the local file sytem where remote file should be downloaded.
+     * @param path Backup path representing a local and remote file pair
      * @param retry No. of times to retry to download a file from remote file system. If &lt;1, it
      *     will try to download file exactly once.
      * @throws BackupRestoreException if file is not available, downloadable or any other error from
      *     remote file system.
      */
-    void downloadFile(Path remotePath, Path localPath, int retry) throws BackupRestoreException;
+    void downloadFile(AbstractBackupPath path, String suffix, int retry)
+            throws BackupRestoreException;
 
     /**
      * Download the file denoted by remotePath in an async fashion to the local file system denoted
      * by local path.
      *
-     * @param remotePath fully qualified location of the file on remote file system.
-     * @param localPath location on the local file sytem where remote file should be downloaded.
+     * @param path Backuop path representing a local and remote file pair
      * @param retry No. of times to retry to download a file from remote file system. If &lt;1, it
      *     will try to download file exactly once.
      * @return The future of the async job to monitor the progress of the job.
@@ -52,7 +51,7 @@ public interface IBackupFileSystem {
      * @throws RejectedExecutionException if the queue is full and TIMEOUT is reached while trying
      *     to add the work to the queue.
      */
-    Future<Path> asyncDownloadFile(final Path remotePath, final Path localPath, final int retry)
+    Future<Path> asyncDownloadFile(final AbstractBackupPath path, final int retry)
             throws BackupRestoreException, RejectedExecutionException;
 
     /**

--- a/priam/src/main/java/com/netflix/priam/backup/IBackupFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/backup/IBackupFileSystem.java
@@ -60,7 +60,7 @@ public interface IBackupFileSystem {
      * files-in-progress to be uploaded. This may result in this particular request to not to be
      * executed e.g. if any other thread has given the same file to upload and that file is in
      * internal queue. Note that de-duping is best effort and is not always guaranteed as we try to
-     * avoid lock on read/write of the files-in-progress.
+     * avoid lock on read/write of the files-in-progress. Once uploaded, files are deleted.
      *
      * @param localPath Path of the local file that needs to be uploaded.
      * @param remotePath Fully qualified path on the remote file system where file should be
@@ -68,20 +68,12 @@ public interface IBackupFileSystem {
      * @param path AbstractBackupPath to be used to send backup notifications only.
      * @param retry No of times to retry to upload a file. If &lt;1, it will try to upload file
      *     exactly once.
-     * @param deleteAfterSuccessfulUpload If true, delete the file denoted by localPath after it is
-     *     successfully uploaded to the filesystem. If there is any failure, file will not be
-     *     deleted.
      * @throws BackupRestoreException in case of failure to upload for any reason including file not
      *     readable or remote file system errors.
      * @throws FileNotFoundException If a file as denoted by localPath is not available or is a
      *     directory.
      */
-    void uploadFile(
-            Path localPath,
-            Path remotePath,
-            AbstractBackupPath path,
-            int retry,
-            boolean deleteAfterSuccessfulUpload)
+    void uploadAndDelete(Path localPath, Path remotePath, AbstractBackupPath path, int retry)
             throws FileNotFoundException, BackupRestoreException;
 
     /**
@@ -94,9 +86,6 @@ public interface IBackupFileSystem {
      * @param path AbstractBackupPath to be used to send backup notifications only.
      * @param retry No of times to retry to upload a file. If &lt;1, it will try to upload file
      *     exactly once.
-     * @param deleteAfterSuccessfulUpload If true, delete the file denoted by localPath after it is
-     *     successfully uploaded to the filesystem. If there is any failure, file will not be
-     *     deleted.
      * @return The future of the async job to monitor the progress of the job. This will be null if
      *     file was de-duped for upload.
      * @throws BackupRestoreException in case of failure to upload for any reason including file not
@@ -106,12 +95,11 @@ public interface IBackupFileSystem {
      * @throws RejectedExecutionException if the queue is full and TIMEOUT is reached while trying
      *     to add the work to the queue.
      */
-    Future<Path> asyncUploadFile(
+    Future<Path> asyncUploadAndDelete(
             final Path localPath,
             final Path remotePath,
             final AbstractBackupPath path,
-            final int retry,
-            final boolean deleteAfterSuccessfulUpload)
+            final int retry)
             throws FileNotFoundException, RejectedExecutionException, BackupRestoreException;
 
     /**

--- a/priam/src/main/java/com/netflix/priam/backup/MetaData.java
+++ b/priam/src/main/java/com/netflix/priam/backup/MetaData.java
@@ -62,12 +62,11 @@ public class MetaData {
             fr.write(jsonObj.toJSONString());
         }
         AbstractBackupPath backupfile = decorateMetaJson(metafile, snapshotName);
-        fs.uploadFile(
+        fs.uploadAndDelete(
                 Paths.get(backupfile.getBackupFile().getAbsolutePath()),
                 Paths.get(backupfile.getRemotePath()),
                 backupfile,
-                10,
-                true);
+                10);
         addToRemotePath(backupfile.getRemotePath());
         return backupfile;
     }

--- a/priam/src/main/java/com/netflix/priam/backup/MetaData.java
+++ b/priam/src/main/java/com/netflix/priam/backup/MetaData.java
@@ -24,7 +24,6 @@ import com.netflix.priam.utils.DateUtil;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,11 +61,7 @@ public class MetaData {
             fr.write(jsonObj.toJSONString());
         }
         AbstractBackupPath backupfile = decorateMetaJson(metafile, snapshotName);
-        fs.uploadAndDelete(
-                Paths.get(backupfile.getBackupFile().getAbsolutePath()),
-                Paths.get(backupfile.getRemotePath()),
-                backupfile,
-                10);
+        fs.uploadAndDelete(backupfile, 10);
         addToRemotePath(backupfile.getRemotePath());
         return backupfile;
     }

--- a/priam/src/main/java/com/netflix/priam/backup/MetaData.java
+++ b/priam/src/main/java/com/netflix/priam/backup/MetaData.java
@@ -92,10 +92,7 @@ public class MetaData {
      */
     public Boolean doesExist(final AbstractBackupPath meta) {
         try {
-            fs.downloadFile(
-                    Paths.get(meta.getRemotePath()),
-                    Paths.get(meta.newRestoreFile().getAbsolutePath()),
-                    5); // download actual file to disk
+            fs.downloadFile(meta, "" /* suffix */, 5 /* retries */);
         } catch (Exception e) {
             logger.error("Error downloading the Meta data try with a different date...", e);
         }

--- a/priam/src/main/java/com/netflix/priam/backupv2/FileUploadResult.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/FileUploadResult.java
@@ -17,6 +17,7 @@
 package com.netflix.priam.backupv2;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.netflix.priam.backup.AbstractBackupPath;
 import com.netflix.priam.compress.CompressionAlgorithm;
 import com.netflix.priam.cryptography.CryptographyAlgorithm;
@@ -56,12 +57,13 @@ public class FileUploadResult {
     }
 
     public FileUploadResult(AbstractBackupPath path) {
+        Preconditions.checkArgument(path.getLastModified().toEpochMilli() > 0);
+        Preconditions.checkArgument(path.getCreationTime().toEpochMilli() > 0);
         File file = path.getBackupFile();
         this.fileName = file.toPath();
         this.backupPath = path.getRemotePath();
-        // TODO Remove this. It is redundant with fileCreationTime as the files are immutable.
         this.lastModifiedTime = path.getLastModified();
-        this.fileCreationTime = path.getLastModified();
+        this.fileCreationTime = path.getCreationTime();
         this.fileSizeOnDisk = path.getSize();
         this.compression = path.getCompression();
         this.encryption = path.getEncryption();

--- a/priam/src/main/java/com/netflix/priam/backupv2/FileUploadResult.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/FileUploadResult.java
@@ -19,7 +19,7 @@ package com.netflix.priam.backupv2;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.netflix.priam.backup.AbstractBackupPath;
-import com.netflix.priam.compress.CompressionAlgorithm;
+import com.netflix.priam.compress.CompressionType;
 import com.netflix.priam.cryptography.CryptographyAlgorithm;
 import com.netflix.priam.utils.GsonJsonSerializer;
 import java.io.File;
@@ -35,7 +35,7 @@ public class FileUploadResult {
     private final Instant fileCreationTime;
     private final long fileSizeOnDisk; // Size on disk in bytes
     // Valid compression technique for now is SNAPPY only. Future we need to support LZ4 and NONE
-    private final CompressionAlgorithm compression;
+    private final CompressionType compression;
     // Valid encryption technique for now is PLAINTEXT only. In future we will support pgp and more.
     private final CryptographyAlgorithm encryption;
 
@@ -52,7 +52,7 @@ public class FileUploadResult {
         this.lastModifiedTime = lastModifiedTime;
         this.fileCreationTime = fileCreationTime;
         this.fileSizeOnDisk = fileSizeOnDisk;
-        this.compression = CompressionAlgorithm.SNAPPY;
+        this.compression = CompressionType.SNAPPY;
         this.encryption = CryptographyAlgorithm.PLAINTEXT;
     }
 

--- a/priam/src/main/java/com/netflix/priam/backupv2/FileUploadResult.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/FileUploadResult.java
@@ -59,8 +59,9 @@ public class FileUploadResult {
         File file = path.getBackupFile();
         this.fileName = file.toPath();
         this.backupPath = path.getRemotePath();
+        // TODO Remove this. It is redundant with fileCreationTime as the files are immutable.
         this.lastModifiedTime = path.getLastModified();
-        this.fileCreationTime = path.getLastModified(); // Remove. Always immutable in practice.
+        this.fileCreationTime = path.getLastModified();
         this.fileSizeOnDisk = path.getSize();
         this.compression = path.getCompression();
         this.encryption = path.getEncryption();

--- a/priam/src/main/java/com/netflix/priam/backupv2/FileUploadResult.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/FileUploadResult.java
@@ -16,9 +16,12 @@
  */
 package com.netflix.priam.backupv2;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.priam.backup.AbstractBackupPath;
 import com.netflix.priam.compress.CompressionAlgorithm;
 import com.netflix.priam.cryptography.CryptographyAlgorithm;
 import com.netflix.priam.utils.GsonJsonSerializer;
+import java.io.File;
 import java.nio.file.Path;
 import java.time.Instant;
 
@@ -31,13 +34,14 @@ public class FileUploadResult {
     private final Instant fileCreationTime;
     private final long fileSizeOnDisk; // Size on disk in bytes
     // Valid compression technique for now is SNAPPY only. Future we need to support LZ4 and NONE
-    private final CompressionAlgorithm compression = CompressionAlgorithm.SNAPPY;
+    private final CompressionAlgorithm compression;
     // Valid encryption technique for now is PLAINTEXT only. In future we will support pgp and more.
-    private final CryptographyAlgorithm encryption = CryptographyAlgorithm.PLAINTEXT;
+    private final CryptographyAlgorithm encryption;
 
     private Boolean isUploaded;
     private String backupPath;
 
+    @VisibleForTesting
     public FileUploadResult(
             Path fileName,
             Instant lastModifiedTime,
@@ -47,6 +51,19 @@ public class FileUploadResult {
         this.lastModifiedTime = lastModifiedTime;
         this.fileCreationTime = fileCreationTime;
         this.fileSizeOnDisk = fileSizeOnDisk;
+        this.compression = CompressionAlgorithm.SNAPPY;
+        this.encryption = CryptographyAlgorithm.PLAINTEXT;
+    }
+
+    public FileUploadResult(AbstractBackupPath path) {
+        File file = path.getBackupFile();
+        this.fileName = file.toPath();
+        this.backupPath = path.getRemotePath();
+        this.lastModifiedTime = path.getLastModified();
+        this.fileCreationTime = path.getLastModified(); // Remove. Always immutable in practice.
+        this.fileSizeOnDisk = path.getSize();
+        this.compression = path.getCompression();
+        this.encryption = path.getEncryption();
     }
 
     public void setUploaded(Boolean uploaded) {

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaFileWriterBuilder.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaFileWriterBuilder.java
@@ -188,8 +188,7 @@ public class MetaFileWriterBuilder {
             AbstractBackupPath abstractBackupPath = pathFactory.get();
             abstractBackupPath.parseLocal(
                     metaFilePath.toFile(), AbstractBackupPath.BackupFileType.META_V2);
-            backupFileSystem.uploadAndDelete(
-                    metaFilePath, Paths.get(getRemoteMetaFilePath()), abstractBackupPath, 10);
+            backupFileSystem.uploadAndDelete(abstractBackupPath, 10);
         }
 
         public Path getMetaFilePath() {

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaFileWriterBuilder.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaFileWriterBuilder.java
@@ -67,7 +67,7 @@ public class MetaFileWriterBuilder {
     }
 
     public interface UploadStep {
-        void uploadMetaFile(boolean deleteOnSuccess) throws Exception;
+        void uploadMetaFile() throws Exception;
 
         Path getMetaFilePath();
 
@@ -182,20 +182,14 @@ public class MetaFileWriterBuilder {
         /**
          * Upload the meta file generated to backup file system.
          *
-         * @param deleteOnSuccess delete the meta file from local file system if backup is
-         *     successful. Useful for testing purposes
          * @throws Exception when unable to upload the meta file.
          */
-        public void uploadMetaFile(boolean deleteOnSuccess) throws Exception {
+        public void uploadMetaFile() throws Exception {
             AbstractBackupPath abstractBackupPath = pathFactory.get();
             abstractBackupPath.parseLocal(
                     metaFilePath.toFile(), AbstractBackupPath.BackupFileType.META_V2);
-            backupFileSystem.uploadFile(
-                    metaFilePath,
-                    Paths.get(getRemoteMetaFilePath()),
-                    abstractBackupPath,
-                    10,
-                    deleteOnSuccess);
+            backupFileSystem.uploadAndDelete(
+                    metaFilePath, Paths.get(getRemoteMetaFilePath()), abstractBackupPath, 10);
         }
 
         public Path getMetaFilePath() {

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaFileWriterBuilder.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaFileWriterBuilder.java
@@ -16,6 +16,9 @@
  */
 package com.netflix.priam.backupv2;
 
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.gson.stream.JsonWriter;
 import com.google.inject.Provider;
 import com.netflix.priam.backup.AbstractBackupPath;
@@ -30,6 +33,7 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.slf4j.Logger;
@@ -61,7 +65,11 @@ public class MetaFileWriterBuilder {
     }
 
     public interface DataStep {
-        DataStep addColumnfamilyResult(ColumnfamilyResult columnfamilyResult) throws IOException;
+        DataStep addColumnfamilyResult(
+                String keyspace,
+                String columnFamily,
+                ImmutableMultimap<String, AbstractBackupPath> sstables)
+                throws IOException;
 
         UploadStep endMetaFileGeneration() throws IOException;
     }
@@ -132,18 +140,18 @@ public class MetaFileWriterBuilder {
          * Add {@link ColumnfamilyResult} after it has been processed so it can be streamed to
          * meta.json. Streaming write to meta.json is required so we don't get Priam OOM.
          *
-         * @param columnfamilyResult a POJO encapsulating the column family result
          * @throws IOException if unable to write to the file or if JSON is not valid
          */
-        public MetaFileWriterBuilder.DataStep addColumnfamilyResult(
-                ColumnfamilyResult columnfamilyResult) throws IOException {
+        public DataStep addColumnfamilyResult(
+                String keyspace,
+                String columnFamily,
+                ImmutableMultimap<String, AbstractBackupPath> sstables)
+                throws IOException {
+
             if (jsonWriter == null)
                 throw new NullPointerException(
                         "addColumnfamilyResult: Json Writer in MetaFileWriter is null. This should not happen!");
-            if (columnfamilyResult == null)
-                throw new NullPointerException(
-                        "Column family result is null in MetaFileWriter. This should not happen!");
-            jsonWriter.jsonValue(columnfamilyResult.toString());
+            jsonWriter.jsonValue(toColumnFamilyResult(keyspace, columnFamily, sstables).toString());
             return this;
         }
 
@@ -200,6 +208,41 @@ public class MetaFileWriterBuilder {
             abstractBackupPath.parseLocal(
                     metaFilePath.toFile(), AbstractBackupPath.BackupFileType.META_V2);
             return abstractBackupPath.getRemotePath();
+        }
+
+        private ColumnfamilyResult toColumnFamilyResult(
+                String keyspace,
+                String columnFamily,
+                ImmutableMultimap<String, AbstractBackupPath> sstables) {
+            ColumnfamilyResult columnfamilyResult = new ColumnfamilyResult(keyspace, columnFamily);
+            sstables.keySet()
+                    .stream()
+                    .map(k -> toSSTableResult(k, sstables.get(k)))
+                    .forEach(columnfamilyResult::addSstable);
+            return columnfamilyResult;
+        }
+
+        private ColumnfamilyResult.SSTableResult toSSTableResult(
+                String prefix, ImmutableCollection<AbstractBackupPath> sstable) {
+            ColumnfamilyResult.SSTableResult ssTableResult = new ColumnfamilyResult.SSTableResult();
+            ssTableResult.setPrefix(prefix);
+            ssTableResult.setSstableComponents(
+                    ImmutableSet.copyOf(
+                            sstable.stream()
+                                    .map(this::toFileUploadResult)
+                                    .collect(Collectors.toSet())));
+            return ssTableResult;
+        }
+
+        private FileUploadResult toFileUploadResult(AbstractBackupPath path) {
+            FileUploadResult fileUploadResult = new FileUploadResult(path);
+            try {
+                Path backupPath = Paths.get(fileUploadResult.getBackupPath());
+                fileUploadResult.setUploaded(backupFileSystem.checkObjectExists(backupPath));
+            } catch (Exception e) {
+                logger.error("Error checking if file exists. Ignoring as it is not fatal.", e);
+            }
+            return fileUploadResult;
         }
     }
 }

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaV1Proxy.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaV1Proxy.java
@@ -149,9 +149,8 @@ public class MetaV1Proxy implements IMetaProxy {
 
     @Override
     public Path downloadMetaFile(AbstractBackupPath meta) throws BackupRestoreException {
-        Path localFile = Paths.get(meta.newRestoreFile().getAbsolutePath() + ".download");
-        fs.downloadFile(Paths.get(meta.getRemotePath()), localFile, 10);
-        return localFile;
+        fs.downloadFile(meta, ".download" /* suffix */, 10 /* retries */);
+        return Paths.get(meta.newRestoreFile().getAbsolutePath() + ".download");
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaV2Proxy.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaV2Proxy.java
@@ -152,9 +152,8 @@ public class MetaV2Proxy implements IMetaProxy {
 
     @Override
     public Path downloadMetaFile(AbstractBackupPath meta) throws BackupRestoreException {
-        Path localFile = Paths.get(meta.newRestoreFile().getAbsolutePath());
-        fs.downloadFile(Paths.get(meta.getRemotePath()), localFile, 10);
-        return localFile;
+        fs.downloadFile(meta, "" /* suffix */, 10 /* retries */);
+        return Paths.get(meta.newRestoreFile().getAbsolutePath());
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/backupv2/SnapshotMetaTask.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/SnapshotMetaTask.java
@@ -219,7 +219,7 @@ public class SnapshotMetaTask extends AbstractBackup {
             MetaFileWriterBuilder.UploadStep uploadStep = processSnapshot(snapshotInstant);
             backupMetadata.setSnapshotLocation(
                     config.getBackupPrefix() + File.separator + uploadStep.getRemoteMetaFilePath());
-            uploadStep.uploadMetaFile(true);
+            uploadStep.uploadMetaFile();
 
             logger.info("Finished processing snapshot meta service");
 

--- a/priam/src/main/java/com/netflix/priam/compress/ChunkedStream.java
+++ b/priam/src/main/java/com/netflix/priam/compress/ChunkedStream.java
@@ -32,13 +32,13 @@ public class ChunkedStream implements Iterator<byte[]> {
     private final SnappyOutputStream snappy;
     private final InputStream origin;
     private final long chunkSize;
-    private final CompressionAlgorithm compression;
+    private final CompressionType compression;
 
     public ChunkedStream(InputStream is, long chunkSize) {
-        this(is, chunkSize, CompressionAlgorithm.NONE);
+        this(is, chunkSize, CompressionType.NONE);
     }
 
-    public ChunkedStream(InputStream is, long chunkSize, CompressionAlgorithm compression) {
+    public ChunkedStream(InputStream is, long chunkSize, CompressionType compression) {
         this.origin = is;
         this.bos = new ByteArrayOutputStream();
         this.snappy = new SnappyOutputStream(bos);
@@ -77,7 +77,7 @@ public class ChunkedStream implements Iterator<byte[]> {
     }
 
     private byte[] done() throws IOException {
-        if (compression == CompressionAlgorithm.SNAPPY) snappy.flush();
+        if (compression == CompressionType.SNAPPY) snappy.flush();
         byte[] return_ = bos.toByteArray();
         hasnext = false;
         IOUtils.closeQuietly(snappy);

--- a/priam/src/main/java/com/netflix/priam/compress/ChunkedStream.java
+++ b/priam/src/main/java/com/netflix/priam/compress/ChunkedStream.java
@@ -25,18 +25,25 @@ import org.xerial.snappy.SnappyOutputStream;
 
 /** Byte iterator representing compressed data. Uses snappy compression */
 public class ChunkedStream implements Iterator<byte[]> {
-    private boolean hasnext = true;
-    private final ByteArrayOutputStream bos;
-    private final SnappyOutputStream compress;
-    private final InputStream origin;
-    private final long chunkSize;
     private static final int BYTES_TO_READ = 2048;
 
-    public ChunkedStream(InputStream is, long chunkSize) throws IOException {
+    private boolean hasnext = true;
+    private final ByteArrayOutputStream bos;
+    private final SnappyOutputStream snappy;
+    private final InputStream origin;
+    private final long chunkSize;
+    private final CompressionAlgorithm compression;
+
+    public ChunkedStream(InputStream is, long chunkSize) {
+        this(is, chunkSize, CompressionAlgorithm.NONE);
+    }
+
+    public ChunkedStream(InputStream is, long chunkSize, CompressionAlgorithm compression) {
         this.origin = is;
         this.bos = new ByteArrayOutputStream();
-        this.compress = new SnappyOutputStream(bos);
+        this.snappy = new SnappyOutputStream(bos);
         this.chunkSize = chunkSize;
+        this.compression = compression;
     }
 
     @Override
@@ -50,7 +57,16 @@ public class ChunkedStream implements Iterator<byte[]> {
             byte data[] = new byte[BYTES_TO_READ];
             int count;
             while ((count = origin.read(data, 0, data.length)) != -1) {
-                compress.write(data, 0, count);
+                switch (compression) {
+                    case NONE:
+                        bos.write(data, 0, count);
+                        break;
+                    case SNAPPY:
+                        snappy.write(data, 0, count);
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Snappy compression only.");
+                }
                 if (bos.size() >= chunkSize) return returnSafe();
             }
             // We don't have anything else to read hence set to false.
@@ -61,10 +77,10 @@ public class ChunkedStream implements Iterator<byte[]> {
     }
 
     private byte[] done() throws IOException {
-        compress.flush();
+        if (compression == CompressionAlgorithm.SNAPPY) snappy.flush();
         byte[] return_ = bos.toByteArray();
         hasnext = false;
-        IOUtils.closeQuietly(compress);
+        IOUtils.closeQuietly(snappy);
         IOUtils.closeQuietly(bos);
         IOUtils.closeQuietly(origin);
         return return_;

--- a/priam/src/main/java/com/netflix/priam/compress/CompressionType.java
+++ b/priam/src/main/java/com/netflix/priam/compress/CompressionType.java
@@ -1,6 +1,6 @@
 package com.netflix.priam.compress;
 
-public enum CompressionAlgorithm {
+public enum CompressionType {
     SNAPPY,
     LZ4,
     NONE

--- a/priam/src/main/java/com/netflix/priam/compress/ICompression.java
+++ b/priam/src/main/java/com/netflix/priam/compress/ICompression.java
@@ -20,7 +20,6 @@ import com.google.inject.ImplementedBy;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Iterator;
 
 @ImplementedBy(SnappyCompression.class)
 public interface ICompression {
@@ -30,7 +29,4 @@ public interface ICompression {
      * streams
      */
     void decompressAndClose(InputStream input, OutputStream output) throws IOException;
-
-    /** Produces chunks of compressed data. */
-    Iterator<byte[]> compress(InputStream is, long chunkSize) throws IOException;
 }

--- a/priam/src/main/java/com/netflix/priam/compress/SnappyCompression.java
+++ b/priam/src/main/java/com/netflix/priam/compress/SnappyCompression.java
@@ -17,18 +17,12 @@
 package com.netflix.priam.compress;
 
 import java.io.*;
-import java.util.Iterator;
 import org.apache.commons.io.IOUtils;
 import org.xerial.snappy.SnappyInputStream;
 
 /** Class to generate compressed chunks of data from an input stream using SnappyCompression */
 public class SnappyCompression implements ICompression {
     private static final int BUFFER = 2 * 1024;
-
-    @Override
-    public Iterator<byte[]> compress(InputStream is, long chunkSize) throws IOException {
-        return new ChunkedStream(is, chunkSize);
-    }
 
     @Override
     public void decompressAndClose(InputStream input, OutputStream output) throws IOException {

--- a/priam/src/main/java/com/netflix/priam/config/BackupsToCompress.java
+++ b/priam/src/main/java/com/netflix/priam/config/BackupsToCompress.java
@@ -1,0 +1,7 @@
+package com.netflix.priam.config;
+
+public enum BackupsToCompress {
+    ALL,
+    UNCOMPRESSED,
+    NONE
+}

--- a/priam/src/main/java/com/netflix/priam/config/BackupsToCompress.java
+++ b/priam/src/main/java/com/netflix/priam/config/BackupsToCompress.java
@@ -2,6 +2,6 @@ package com.netflix.priam.config;
 
 public enum BackupsToCompress {
     ALL,
-    UNCOMPRESSED,
+    IF_REQUIRED,
     NONE
 }

--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -1104,6 +1104,14 @@ public interface IConfiguration {
     }
 
     /**
+     * @return BackupsToCompress UNCOMPRESSED means compress backups only when the files are not
+     *     already compressed by Cassandra
+     */
+    default BackupsToCompress getBackupsToCompress() {
+        return BackupsToCompress.ALL;
+    }
+
+    /**
      * Escape hatch for getting any arbitrary property by key This is useful so we don't have to
      * keep adding methods to this interface for every single configuration option ever. Also
      * exposed via HTTP at v1/config/unstructured/X

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -768,4 +768,10 @@ public class PriamConfiguration implements IConfiguration {
     public boolean isForgottenFileMoveEnabled() {
         return config.get(PRIAM_PRE + ".forgottenFileMoveEnabled", false);
     }
+
+    @Override
+    public BackupsToCompress getBackupsToCompress() {
+        return BackupsToCompress.valueOf(
+                config.get("priam.backupsToCompress", BackupsToCompress.ALL.name()));
+    }
 }

--- a/priam/src/main/java/com/netflix/priam/google/GoogleEncryptedFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/google/GoogleEncryptedFileSystem.java
@@ -236,7 +236,7 @@ public class GoogleEncryptedFileSystem extends AbstractFileSystem {
     }
 
     @Override
-    protected long uploadFileImpl(Path localPath, Path remotePath) throws BackupRestoreException {
+    protected long uploadFileImpl(AbstractBackupPath path) throws BackupRestoreException {
         throw new UnsupportedOperationException();
     }
 

--- a/priam/src/main/java/com/netflix/priam/google/GoogleEncryptedFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/google/GoogleEncryptedFileSystem.java
@@ -175,12 +175,15 @@ public class GoogleEncryptedFileSystem extends AbstractFileSystem {
     }
 
     @Override
-    protected void downloadFileImpl(Path remotePath, Path localPath) throws BackupRestoreException {
+    protected void downloadFileImpl(AbstractBackupPath path, String suffix)
+            throws BackupRestoreException {
+        String remotePath = path.getRemotePath();
+        File localFile = new File(path.newRestoreFile().getAbsolutePath() + suffix);
         String objectName = parseObjectname(getPrefix().toString());
         com.google.api.services.storage.Storage.Objects.Get get;
 
         try {
-            get = constructObjectResourceHandle().get(this.srcBucketName, remotePath.toString());
+            get = constructObjectResourceHandle().get(this.srcBucketName, remotePath);
         } catch (IOException e) {
             throw new BackupRestoreException(
                     "IO error retrieving metadata for: "
@@ -193,7 +196,7 @@ public class GoogleEncryptedFileSystem extends AbstractFileSystem {
         // If you're not using GCS' AppEngine, download the whole thing (instead of chunks) in one
         // request, if possible.
         get.getMediaHttpDownloader().setDirectDownloadEnabled(true);
-        try (OutputStream os = new FileOutputStream(localPath.toFile());
+        try (OutputStream os = new FileOutputStream(localFile);
                 InputStream is = get.executeMediaAsInputStream()) {
             IOUtils.copyLarge(is, os);
         } catch (IOException e) {
@@ -238,7 +241,7 @@ public class GoogleEncryptedFileSystem extends AbstractFileSystem {
     }
 
     @Override
-    public long getFileSize(Path remotePath) throws BackupRestoreException {
+    public long getFileSize(String remotePath) throws BackupRestoreException {
         return 0;
     }
 

--- a/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
@@ -137,7 +137,7 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
                                 + localFileHandler.getAbsolutePath()
                                 + File.pathSeparator
                                 + localFileHandler.getName());
-            futureList.add(downloadFile(temp, localFileHandler));
+            futureList.add(downloadFile(temp));
         }
 
         // Wait for all download to finish that were started from this method.
@@ -301,13 +301,10 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
      * decrypted(optionally) and decompressed before saving to final location.
      *
      * @param path - path of object to download from source S3/GCS.
-     * @param restoreLocation - path to the final location of the decompressed and/or decrypted
-     *     file.
      * @return Future of the job to track the progress of the job.
      * @throws Exception If there is any error in downloading file from the remote file system.
      */
-    protected abstract Future<Path> downloadFile(
-            final AbstractBackupPath path, final File restoreLocation) throws Exception;
+    protected abstract Future<Path> downloadFile(final AbstractBackupPath path) throws Exception;
 
     final class BoundedList<E> extends LinkedList<E> {
 

--- a/priam/src/main/java/com/netflix/priam/restore/EncryptedRestoreBase.java
+++ b/priam/src/main/java/com/netflix/priam/restore/EncryptedRestoreBase.java
@@ -17,7 +17,7 @@ import com.google.inject.Provider;
 import com.netflix.priam.backup.AbstractBackupPath;
 import com.netflix.priam.backup.IBackupFileSystem;
 import com.netflix.priam.backup.MetaData;
-import com.netflix.priam.compress.CompressionAlgorithm;
+import com.netflix.priam.compress.CompressionType;
 import com.netflix.priam.compress.ICompression;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.cred.ICredentialGeneric;
@@ -160,7 +160,7 @@ public abstract class EncryptedRestoreBase extends AbstractRestore {
                         }
 
                         // == object is downloaded and decrypted, now uncompress it if necessary
-                        if (path.getCompression() == CompressionAlgorithm.NONE) {
+                        if (path.getCompression() == CompressionType.NONE) {
                             Files.move(decryptedFile.toPath(), restoreLocation.toPath());
                         } else {
                             logger.info(

--- a/priam/src/main/java/com/netflix/priam/restore/Restore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/Restore.java
@@ -30,9 +30,7 @@ import com.netflix.priam.identity.InstanceIdentity;
 import com.netflix.priam.scheduler.SimpleTimer;
 import com.netflix.priam.scheduler.TaskTimer;
 import com.netflix.priam.utils.Sleeper;
-import java.io.File;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.concurrent.Future;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,10 +68,8 @@ public class Restore extends AbstractRestore {
     }
 
     @Override
-    protected final Future<Path> downloadFile(
-            final AbstractBackupPath path, final File restoreLocation) throws Exception {
-        return fs.asyncDownloadFile(
-                Paths.get(path.getRemotePath()), Paths.get(restoreLocation.getAbsolutePath()), 5);
+    protected final Future<Path> downloadFile(final AbstractBackupPath path) throws Exception {
+        return fs.asyncDownloadFile(path, 5 /* retries */);
     }
 
     public static TaskTimer getTimer() {

--- a/priam/src/test/java/com/netflix/priam/backup/FakeBackupFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/FakeBackupFileSystem.java
@@ -166,9 +166,9 @@ public class FakeBackupFileSystem extends AbstractFileSystem {
     }
 
     @Override
-    protected long uploadFileImpl(Path localPath, Path remotePath) throws BackupRestoreException {
-        uploadedFiles.add(localPath.toFile().getAbsolutePath());
-        addFile(remotePath.toString());
-        return localPath.toFile().length();
+    protected long uploadFileImpl(AbstractBackupPath path) throws BackupRestoreException {
+        uploadedFiles.add(path.getBackupFile().getAbsolutePath());
+        addFile(path.getRemotePath());
+        return path.getBackupFile().length();
     }
 }

--- a/priam/src/test/java/com/netflix/priam/backup/FakeBackupFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/FakeBackupFileSystem.java
@@ -24,6 +24,7 @@ import com.netflix.priam.aws.RemoteBackupPath;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.merics.BackupMetrics;
 import com.netflix.priam.notification.BackupNotificationMgr;
+import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -111,7 +112,7 @@ public class FakeBackupFileSystem extends AbstractFileSystem {
     }
 
     @Override
-    public long getFileSize(Path remotePath) throws BackupRestoreException {
+    public long getFileSize(String remotePath) throws BackupRestoreException {
         return 0;
     }
 
@@ -142,13 +143,12 @@ public class FakeBackupFileSystem extends AbstractFileSystem {
     }
 
     @Override
-    protected void downloadFileImpl(Path remotePath, Path localPath) throws BackupRestoreException {
-        AbstractBackupPath path = pathProvider.get();
-        path.parseRemote(remotePath.toString());
-
+    protected void downloadFileImpl(AbstractBackupPath path, String suffix)
+            throws BackupRestoreException {
+        File localFile = new File(path.newRestoreFile().getAbsolutePath() + suffix);
         if (path.getType() == AbstractBackupPath.BackupFileType.META) {
             // List all files and generate the file
-            try (FileWriter fr = new FileWriter(localPath.toFile())) {
+            try (FileWriter fr = new FileWriter(localFile)) {
                 JSONArray jsonObj = new JSONArray();
                 for (AbstractBackupPath filePath : flist) {
                     if (filePath.type == AbstractBackupPath.BackupFileType.SNAP
@@ -162,7 +162,7 @@ public class FakeBackupFileSystem extends AbstractFileSystem {
                 throw new BackupRestoreException(io.getMessage(), io);
             }
         }
-        downloadedFiles.add(remotePath.toString());
+        downloadedFiles.add(path.getRemotePath());
     }
 
     @Override

--- a/priam/src/test/java/com/netflix/priam/backup/NullBackupFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/NullBackupFileSystem.java
@@ -72,7 +72,7 @@ public class NullBackupFileSystem extends AbstractFileSystem {
     }
 
     @Override
-    protected long uploadFileImpl(Path localPath, Path remotePath) throws BackupRestoreException {
+    protected long uploadFileImpl(AbstractBackupPath path) throws BackupRestoreException {
         return 0;
     }
 }

--- a/priam/src/test/java/com/netflix/priam/backup/NullBackupFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/NullBackupFileSystem.java
@@ -43,7 +43,7 @@ public class NullBackupFileSystem extends AbstractFileSystem {
     }
 
     @Override
-    public long getFileSize(Path remotePath) throws BackupRestoreException {
+    public long getFileSize(String remotePath) throws BackupRestoreException {
         return 0;
     }
 
@@ -63,7 +63,7 @@ public class NullBackupFileSystem extends AbstractFileSystem {
     }
 
     @Override
-    protected void downloadFileImpl(Path remotePath, Path localPath)
+    protected void downloadFileImpl(AbstractBackupPath path, String suffix)
             throws BackupRestoreException {}
 
     @Override

--- a/priam/src/test/java/com/netflix/priam/backup/TestAbstractBackup.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestAbstractBackup.java
@@ -1,0 +1,131 @@
+package com.netflix.priam.backup;
+
+import com.google.appengine.repackaged.com.google.common.collect.ImmutableList;
+import com.google.common.truth.Truth;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import com.netflix.priam.compress.CompressionAlgorithm;
+import com.netflix.priam.config.BackupsToCompress;
+import com.netflix.priam.config.FakeConfiguration;
+import com.netflix.priam.config.IConfiguration;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestAbstractBackup {
+    private static final String COMPRESSED_DATA = "compressed-1234-Data.db";
+    private static final String COMPRESSION_INFO = "compressed-1234-CompressionInfo.db";
+    private static final String UNCOMPRESSED_DATA = "uncompressed-1234-Data.db";
+    private static final String RANDOM_DATA = "random-1234-Data.db";
+    private static final String RANDOM_COMPONENT = "random-1234-compressioninfo.db";
+    private static final ImmutableList<String> TABLE_PARTS =
+            ImmutableList.of(
+                    COMPRESSED_DATA,
+                    COMPRESSION_INFO,
+                    UNCOMPRESSED_DATA,
+                    RANDOM_DATA,
+                    RANDOM_COMPONENT);
+
+    private static final String DIRECTORY = "target/data/ks/cf/backup/";
+    private final AbstractBackup abstractBackup;
+    private final FakeConfiguration fakeConfiguration;
+    private final String tablePart;
+    private final CompressionAlgorithm compressionAlgorithm;
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+        FileUtils.forceMkdir(new File(DIRECTORY));
+    }
+
+    @Before
+    public void createFiles() throws IOException {
+        for (String tablePart : TABLE_PARTS) {
+            File file = Paths.get(DIRECTORY, tablePart).toFile();
+            if (file.createNewFile()) {
+                FileUtils.forceDeleteOnExit(file);
+            } else {
+                throw new IllegalStateException("failed to create " + tablePart);
+            }
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws IOException {
+        FileUtils.deleteDirectory(new File(DIRECTORY));
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(
+                new Object[][] {
+                    {BackupsToCompress.NONE, COMPRESSED_DATA, CompressionAlgorithm.NONE},
+                    {BackupsToCompress.NONE, COMPRESSION_INFO, CompressionAlgorithm.NONE},
+                    {BackupsToCompress.NONE, UNCOMPRESSED_DATA, CompressionAlgorithm.NONE},
+                    {BackupsToCompress.NONE, RANDOM_DATA, CompressionAlgorithm.NONE},
+                    {BackupsToCompress.NONE, RANDOM_COMPONENT, CompressionAlgorithm.NONE},
+                    {BackupsToCompress.ALL, COMPRESSED_DATA, CompressionAlgorithm.SNAPPY},
+                    {BackupsToCompress.ALL, COMPRESSION_INFO, CompressionAlgorithm.SNAPPY},
+                    {BackupsToCompress.ALL, UNCOMPRESSED_DATA, CompressionAlgorithm.SNAPPY},
+                    {BackupsToCompress.ALL, RANDOM_DATA, CompressionAlgorithm.SNAPPY},
+                    {BackupsToCompress.ALL, RANDOM_COMPONENT, CompressionAlgorithm.SNAPPY},
+                    {BackupsToCompress.UNCOMPRESSED, COMPRESSED_DATA, CompressionAlgorithm.NONE},
+                    {BackupsToCompress.UNCOMPRESSED, COMPRESSION_INFO, CompressionAlgorithm.NONE},
+                    {
+                        BackupsToCompress.UNCOMPRESSED,
+                        UNCOMPRESSED_DATA,
+                        CompressionAlgorithm.SNAPPY
+                    },
+                    {BackupsToCompress.UNCOMPRESSED, RANDOM_DATA, CompressionAlgorithm.SNAPPY},
+                    {BackupsToCompress.UNCOMPRESSED, RANDOM_COMPONENT, CompressionAlgorithm.SNAPPY},
+                });
+    }
+
+    public TestAbstractBackup(
+            BackupsToCompress which, String tablePart, CompressionAlgorithm algo) {
+        this.tablePart = tablePart;
+        this.compressionAlgorithm = algo;
+        Injector injector = Guice.createInjector(new BRTestModule());
+        fakeConfiguration = (FakeConfiguration) injector.getInstance(IConfiguration.class);
+        fakeConfiguration.setFakeConfig("Priam.backupsToCompress", which);
+        IFileSystemContext context = injector.getInstance(IFileSystemContext.class);
+        Provider<AbstractBackupPath> pathFactory = injector.getProvider(AbstractBackupPath.class);
+        abstractBackup =
+                new AbstractBackup(fakeConfiguration, context, pathFactory) {
+                    @Override
+                    protected void processColumnFamily(String ks, String cf, File dir) {}
+
+                    @Override
+                    public void execute() {}
+
+                    @Override
+                    public String getName() {
+                        return null;
+                    }
+                };
+    }
+
+    @Test
+    public void testCorrectCompressionAlgorithm() throws Exception {
+        File parent = new File(DIRECTORY);
+        AbstractBackupPath.BackupFileType backupFileType = AbstractBackupPath.BackupFileType.SST_V2;
+        List<AbstractBackupPath> abps = abstractBackup.upload(parent, backupFileType, false, false);
+        AbstractBackupPath abstractBackupPath =
+                abps.stream()
+                        .filter(abp -> abp.getFileName().equals(tablePart))
+                        .findAny()
+                        .orElseThrow(IllegalStateException::new);
+        Truth.assertThat(abstractBackupPath.getCompression()).isEqualTo(compressionAlgorithm);
+    }
+}

--- a/priam/src/test/java/com/netflix/priam/backup/TestAbstractBackup.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestAbstractBackup.java
@@ -120,11 +120,11 @@ public class TestAbstractBackup {
     public void testCorrectCompressionAlgorithm() throws Exception {
         File parent = new File(DIRECTORY);
         AbstractBackupPath.BackupFileType backupFileType = AbstractBackupPath.BackupFileType.SST_V2;
-        ImmutableSet<AbstractBackupPath> abps =
+        ImmutableSet<AbstractBackupPath> paths =
                 abstractBackup.upload(parent, backupFileType, false, false);
         AbstractBackupPath abstractBackupPath =
-                abps.stream()
-                        .filter(abp -> abp.getFileName().equals(tablePart))
+                paths.stream()
+                        .filter(path -> path.getFileName().equals(tablePart))
                         .findAny()
                         .orElseThrow(IllegalStateException::new);
         Truth.assertThat(abstractBackupPath.getCompression()).isEqualTo(compressionAlgorithm);

--- a/priam/src/test/java/com/netflix/priam/backup/TestAbstractBackup.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestAbstractBackup.java
@@ -6,7 +6,7 @@ import com.google.common.truth.Truth;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Provider;
-import com.netflix.priam.compress.CompressionAlgorithm;
+import com.netflix.priam.compress.CompressionType;
 import com.netflix.priam.config.BackupsToCompress;
 import com.netflix.priam.config.FakeConfiguration;
 import com.netflix.priam.config.IConfiguration;
@@ -42,7 +42,7 @@ public class TestAbstractBackup {
     private final AbstractBackup abstractBackup;
     private final FakeConfiguration fakeConfiguration;
     private final String tablePart;
-    private final CompressionAlgorithm compressionAlgorithm;
+    private final CompressionType compressionAlgorithm;
 
     @BeforeClass
     public static void setUp() throws IOException {
@@ -70,26 +70,25 @@ public class TestAbstractBackup {
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
-                    {BackupsToCompress.NONE, COMPRESSED_DATA, CompressionAlgorithm.NONE},
-                    {BackupsToCompress.NONE, COMPRESSION_INFO, CompressionAlgorithm.NONE},
-                    {BackupsToCompress.NONE, UNCOMPRESSED_DATA, CompressionAlgorithm.NONE},
-                    {BackupsToCompress.NONE, RANDOM_DATA, CompressionAlgorithm.NONE},
-                    {BackupsToCompress.NONE, RANDOM_COMPONENT, CompressionAlgorithm.NONE},
-                    {BackupsToCompress.ALL, COMPRESSED_DATA, CompressionAlgorithm.SNAPPY},
-                    {BackupsToCompress.ALL, COMPRESSION_INFO, CompressionAlgorithm.SNAPPY},
-                    {BackupsToCompress.ALL, UNCOMPRESSED_DATA, CompressionAlgorithm.SNAPPY},
-                    {BackupsToCompress.ALL, RANDOM_DATA, CompressionAlgorithm.SNAPPY},
-                    {BackupsToCompress.ALL, RANDOM_COMPONENT, CompressionAlgorithm.SNAPPY},
-                    {BackupsToCompress.IF_REQUIRED, COMPRESSED_DATA, CompressionAlgorithm.NONE},
-                    {BackupsToCompress.IF_REQUIRED, COMPRESSION_INFO, CompressionAlgorithm.NONE},
-                    {BackupsToCompress.IF_REQUIRED, UNCOMPRESSED_DATA, CompressionAlgorithm.SNAPPY},
-                    {BackupsToCompress.IF_REQUIRED, RANDOM_DATA, CompressionAlgorithm.SNAPPY},
-                    {BackupsToCompress.IF_REQUIRED, RANDOM_COMPONENT, CompressionAlgorithm.SNAPPY},
+                    {BackupsToCompress.NONE, COMPRESSED_DATA, CompressionType.NONE},
+                    {BackupsToCompress.NONE, COMPRESSION_INFO, CompressionType.NONE},
+                    {BackupsToCompress.NONE, UNCOMPRESSED_DATA, CompressionType.NONE},
+                    {BackupsToCompress.NONE, RANDOM_DATA, CompressionType.NONE},
+                    {BackupsToCompress.NONE, RANDOM_COMPONENT, CompressionType.NONE},
+                    {BackupsToCompress.ALL, COMPRESSED_DATA, CompressionType.SNAPPY},
+                    {BackupsToCompress.ALL, COMPRESSION_INFO, CompressionType.SNAPPY},
+                    {BackupsToCompress.ALL, UNCOMPRESSED_DATA, CompressionType.SNAPPY},
+                    {BackupsToCompress.ALL, RANDOM_DATA, CompressionType.SNAPPY},
+                    {BackupsToCompress.ALL, RANDOM_COMPONENT, CompressionType.SNAPPY},
+                    {BackupsToCompress.IF_REQUIRED, COMPRESSED_DATA, CompressionType.NONE},
+                    {BackupsToCompress.IF_REQUIRED, COMPRESSION_INFO, CompressionType.NONE},
+                    {BackupsToCompress.IF_REQUIRED, UNCOMPRESSED_DATA, CompressionType.SNAPPY},
+                    {BackupsToCompress.IF_REQUIRED, RANDOM_DATA, CompressionType.SNAPPY},
+                    {BackupsToCompress.IF_REQUIRED, RANDOM_COMPONENT, CompressionType.SNAPPY},
                 });
     }
 
-    public TestAbstractBackup(
-            BackupsToCompress which, String tablePart, CompressionAlgorithm algo) {
+    public TestAbstractBackup(BackupsToCompress which, String tablePart, CompressionType algo) {
         this.tablePart = tablePart;
         this.compressionAlgorithm = algo;
         Injector injector = Guice.createInjector(new BRTestModule());
@@ -113,7 +112,7 @@ public class TestAbstractBackup {
     }
 
     @Test
-    public void testCorrectCompressionAlgorithm() throws Exception {
+    public void testCorrectCompressionType() throws Exception {
         File parent = new File(DIRECTORY);
         AbstractBackupPath.BackupFileType backupFileType = AbstractBackupPath.BackupFileType.SST_V2;
         ImmutableSet<AbstractBackupPath> paths =

--- a/priam/src/test/java/com/netflix/priam/backup/TestAbstractBackup.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestAbstractBackup.java
@@ -80,15 +80,11 @@ public class TestAbstractBackup {
                     {BackupsToCompress.ALL, UNCOMPRESSED_DATA, CompressionAlgorithm.SNAPPY},
                     {BackupsToCompress.ALL, RANDOM_DATA, CompressionAlgorithm.SNAPPY},
                     {BackupsToCompress.ALL, RANDOM_COMPONENT, CompressionAlgorithm.SNAPPY},
-                    {BackupsToCompress.UNCOMPRESSED, COMPRESSED_DATA, CompressionAlgorithm.NONE},
-                    {BackupsToCompress.UNCOMPRESSED, COMPRESSION_INFO, CompressionAlgorithm.NONE},
-                    {
-                        BackupsToCompress.UNCOMPRESSED,
-                        UNCOMPRESSED_DATA,
-                        CompressionAlgorithm.SNAPPY
-                    },
-                    {BackupsToCompress.UNCOMPRESSED, RANDOM_DATA, CompressionAlgorithm.SNAPPY},
-                    {BackupsToCompress.UNCOMPRESSED, RANDOM_COMPONENT, CompressionAlgorithm.SNAPPY},
+                    {BackupsToCompress.IF_REQUIRED, COMPRESSED_DATA, CompressionAlgorithm.NONE},
+                    {BackupsToCompress.IF_REQUIRED, COMPRESSION_INFO, CompressionAlgorithm.NONE},
+                    {BackupsToCompress.IF_REQUIRED, UNCOMPRESSED_DATA, CompressionAlgorithm.SNAPPY},
+                    {BackupsToCompress.IF_REQUIRED, RANDOM_DATA, CompressionAlgorithm.SNAPPY},
+                    {BackupsToCompress.IF_REQUIRED, RANDOM_COMPONENT, CompressionAlgorithm.SNAPPY},
                 });
     }
 

--- a/priam/src/test/java/com/netflix/priam/backup/TestAbstractBackup.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestAbstractBackup.java
@@ -1,6 +1,7 @@
 package com.netflix.priam.backup;
 
 import com.google.appengine.repackaged.com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.truth.Truth;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -14,7 +15,6 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -120,7 +120,8 @@ public class TestAbstractBackup {
     public void testCorrectCompressionAlgorithm() throws Exception {
         File parent = new File(DIRECTORY);
         AbstractBackupPath.BackupFileType backupFileType = AbstractBackupPath.BackupFileType.SST_V2;
-        List<AbstractBackupPath> abps = abstractBackup.upload(parent, backupFileType, false, false);
+        ImmutableSet<AbstractBackupPath> abps =
+                abstractBackup.upload(parent, backupFileType, false, false);
         AbstractBackupPath abstractBackupPath =
                 abps.stream()
                         .filter(abp -> abp.getFileName().equals(tablePart))

--- a/priam/src/test/java/com/netflix/priam/backup/TestAbstractFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestAbstractFileSystem.java
@@ -310,11 +310,11 @@ public class TestAbstractFileSystem {
         }
 
         @Override
-        protected void downloadFileImpl(Path remotePath, Path localPath)
+        protected void downloadFileImpl(AbstractBackupPath path, String suffix)
                 throws BackupRestoreException {
             throw new BackupRestoreException(
                     "User injected failure file system error for testing download. Remote path: "
-                            + remotePath);
+                            + path.getRemotePath());
         }
 
         @Override
@@ -340,7 +340,7 @@ public class TestAbstractFileSystem {
         }
 
         @Override
-        protected void downloadFileImpl(Path remotePath, Path localPath)
+        protected void downloadFileImpl(AbstractBackupPath path, String suffix)
                 throws BackupRestoreException {
             try {
                 Thread.sleep(random.nextInt(20));

--- a/priam/src/test/java/com/netflix/priam/backup/TestAbstractFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestAbstractFileSystem.java
@@ -82,8 +82,8 @@ public class TestAbstractFileSystem {
         try {
             Collection<File> files = generateFiles(1, 1, 1);
             for (File file : files) {
-                failureFileSystem.uploadFile(
-                        file.toPath(), file.toPath(), getDummyPath(file.toPath()), 2, true);
+                failureFileSystem.uploadAndDelete(
+                        file.toPath(), file.toPath(), getDummyPath(file.toPath()), 2);
             }
         } catch (BackupRestoreException e) {
             // Verify the failure metric for upload is incremented.
@@ -125,12 +125,11 @@ public class TestAbstractFileSystem {
         Collection<File> files = generateFiles(1, 1, 1);
         // Dummy upload with compressed size.
         for (File file : files) {
-            myFileSystem.uploadFile(
+            myFileSystem.uploadAndDelete(
                     file.toPath(),
                     Paths.get(file.toString() + ".tmp"),
                     getDummyPath(file.toPath()),
-                    2,
-                    true);
+                    2);
             // Verify the success metric for upload is incremented.
             Assert.assertEquals(1, (int) backupMetrics.getValidUploads().actualCount());
 
@@ -154,12 +153,11 @@ public class TestAbstractFileSystem {
         Collection<File> files = generateFiles(1, 1, 1);
         for (File file : files) {
             myFileSystem
-                    .asyncUploadFile(
+                    .asyncUploadAndDelete(
                             file.toPath(),
                             Paths.get(file.toString() + ".tmp"),
                             getDummyPath(file.toPath()),
-                            2,
-                            true)
+                            2)
                     .get();
             // 1. Verify the success metric for upload is incremented.
             Assert.assertEquals(1, (int) backupMetrics.getValidUploads().actualCount());
@@ -177,12 +175,11 @@ public class TestAbstractFileSystem {
         List<Future<Path>> futures = new ArrayList<>();
         for (File file : files) {
             futures.add(
-                    myFileSystem.asyncUploadFile(
+                    myFileSystem.asyncUploadAndDelete(
                             file.toPath(),
                             Paths.get(file.toString() + ".tmp"),
                             getDummyPath(file.toPath()),
-                            2,
-                            true));
+                            2));
         }
 
         // Verify all the work is finished.
@@ -209,8 +206,8 @@ public class TestAbstractFileSystem {
         for (int i = 0; i < size; i++) {
             torun.add(
                     () -> {
-                        myFileSystem.uploadFile(
-                                file.toPath(), file.toPath(), abstractBackupPath, 2, true);
+                        myFileSystem.uploadAndDelete(
+                                file.toPath(), file.toPath(), abstractBackupPath, 2);
                         return Boolean.TRUE;
                     });
         }
@@ -238,8 +235,8 @@ public class TestAbstractFileSystem {
         Collection<File> files = generateFiles(1, 1, 1);
         for (File file : files) {
             Future<Path> future =
-                    failureFileSystem.asyncUploadFile(
-                            file.toPath(), file.toPath(), getDummyPath(file.toPath()), 2, true);
+                    failureFileSystem.asyncUploadAndDelete(
+                            file.toPath(), file.toPath(), getDummyPath(file.toPath()), 2);
             try {
                 future.get();
             } catch (Exception e) {

--- a/priam/src/test/java/com/netflix/priam/backup/TestAbstractFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestAbstractFileSystem.java
@@ -284,11 +284,10 @@ public class TestAbstractFileSystem {
         }
 
         @Override
-        protected long uploadFileImpl(Path localPath, Path remotePath)
-                throws BackupRestoreException {
+        protected long uploadFileImpl(AbstractBackupPath path) throws BackupRestoreException {
             throw new BackupRestoreException(
                     "User injected failure file system error for testing upload. Local path: "
-                            + localPath);
+                            + path.getBackupFile().getAbsolutePath());
         }
     }
 
@@ -316,8 +315,7 @@ public class TestAbstractFileSystem {
         }
 
         @Override
-        protected long uploadFileImpl(Path localPath, Path remotePath)
-                throws BackupRestoreException {
+        protected long uploadFileImpl(AbstractBackupPath path) throws BackupRestoreException {
             try {
                 Thread.sleep(random.nextInt(20));
             } catch (InterruptedException e) {

--- a/priam/src/test/java/com/netflix/priam/backup/TestCompression.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestCompression.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.netflix.priam.compress.ChunkedStream;
-import com.netflix.priam.compress.CompressionAlgorithm;
+import com.netflix.priam.compress.CompressionType;
 import com.netflix.priam.compress.ICompression;
 import com.netflix.priam.compress.SnappyCompression;
 import com.netflix.priam.utils.SystemUtils;
@@ -123,7 +123,7 @@ public class TestCompression {
                     new ChunkedStream(
                             new FileInputStream(randomContentFile),
                             chunkSize,
-                            CompressionAlgorithm.SNAPPY);
+                            CompressionType.SNAPPY);
             try (FileOutputStream ostream = new FileOutputStream(compressedOutputFile)) {
                 while (it.hasNext()) {
                     byte[] chunk = it.next();

--- a/priam/src/test/java/com/netflix/priam/backup/TestCompression.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestCompression.java
@@ -20,6 +20,8 @@ package com.netflix.priam.backup;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.netflix.priam.compress.ChunkedStream;
+import com.netflix.priam.compress.CompressionAlgorithm;
 import com.netflix.priam.compress.ICompression;
 import com.netflix.priam.compress.SnappyCompression;
 import com.netflix.priam.utils.SystemUtils;
@@ -118,7 +120,10 @@ public class TestCompression {
         try {
 
             Iterator<byte[]> it =
-                    compress.compress(new FileInputStream(randomContentFile), chunkSize);
+                    new ChunkedStream(
+                            new FileInputStream(randomContentFile),
+                            chunkSize,
+                            CompressionAlgorithm.SNAPPY);
             try (FileOutputStream ostream = new FileOutputStream(compressedOutputFile)) {
                 while (it.hasNext()) {
                     byte[] chunk = it.next();

--- a/priam/src/test/java/com/netflix/priam/backup/TestS3FileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestS3FileSystem.java
@@ -37,16 +37,6 @@ import com.netflix.priam.backup.AbstractBackupPath.BackupFileType;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.identity.config.InstanceInfo;
 import com.netflix.priam.merics.BackupMetrics;
-import mockit.Mock;
-import mockit.MockUp;
-import org.apache.commons.io.FileUtils;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -58,6 +48,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestS3FileSystem {
     private static Injector injector;
@@ -97,11 +96,7 @@ public class TestS3FileSystem {
         RemoteBackupPath backupfile = injector.getInstance(RemoteBackupPath.class);
         backupfile.parseLocal(localFile(), BackupFileType.SNAP);
         long noOfFilesUploaded = backupMetrics.getUploadRate().count();
-        fs.uploadAndDelete(
-                Paths.get(backupfile.getBackupFile().getAbsolutePath()),
-                Paths.get(backupfile.getRemotePath()),
-                backupfile,
-                0);
+        fs.uploadAndDelete(backupfile, 0);
         Assert.assertEquals(1, backupMetrics.getUploadRate().count() - noOfFilesUploaded);
     }
 
@@ -111,11 +106,7 @@ public class TestS3FileSystem {
         IBackupFileSystem fs = injector.getInstance(NullBackupFileSystem.class);
         RemoteBackupPath backupfile = injector.getInstance(RemoteBackupPath.class);
         backupfile.parseLocal(localFile(), BackupFileType.SST_V2);
-        fs.uploadAndDelete(
-                Paths.get(backupfile.getBackupFile().getAbsolutePath()),
-                Paths.get(backupfile.getRemotePath()),
-                backupfile,
-                0);
+        fs.uploadAndDelete(backupfile, 0);
         Assert.assertTrue(fs.checkObjectExists(Paths.get(backupfile.getRemotePath())));
         // Lets delete the file now.
         List<Path> deleteFiles = Lists.newArrayList();
@@ -133,11 +124,7 @@ public class TestS3FileSystem {
         RemoteBackupPath backupfile = injector.getInstance(RemoteBackupPath.class);
         backupfile.parseLocal(localFile(), BackupFileType.SNAP);
         try {
-            fs.uploadAndDelete(
-                    Paths.get(backupfile.getBackupFile().getAbsolutePath()),
-                    Paths.get(backupfile.getRemotePath()),
-                    backupfile,
-                    0);
+            fs.uploadAndDelete(backupfile, 0);
         } catch (BackupRestoreException e) {
             // ignore
         }
@@ -154,11 +141,7 @@ public class TestS3FileSystem {
         RemoteBackupPath backupfile = injector.getInstance(RemoteBackupPath.class);
         backupfile.parseLocal(localFile(), BackupFileType.SNAP);
         try {
-            fs.uploadAndDelete(
-                    Paths.get(backupfile.getBackupFile().getAbsolutePath()),
-                    Paths.get(backupfile.getRemotePath()),
-                    backupfile,
-                    0);
+            fs.uploadAndDelete(backupfile, 0);
         } catch (BackupRestoreException e) {
             // ignore
         }

--- a/priam/src/test/java/com/netflix/priam/backup/TestS3FileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestS3FileSystem.java
@@ -25,6 +25,7 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.*;
 import com.amazonaws.services.s3.model.lifecycle.LifecycleFilter;
 import com.amazonaws.services.s3.model.lifecycle.LifecyclePrefixPredicate;
+import com.google.api.client.util.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -36,18 +37,9 @@ import com.netflix.priam.backup.AbstractBackupPath.BackupFileType;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.identity.config.InstanceInfo;
 import com.netflix.priam.merics.BackupMetrics;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -55,11 +47,22 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 public class TestS3FileSystem {
     private static Injector injector;
     private static final Logger logger = LoggerFactory.getLogger(TestS3FileSystem.class);
-    private static final String FILE_PATH =
-            "target/data/Keyspace1/Standard1/backups/201108082320/Keyspace1-Standard1-ia-1-Data.db";
+    private static final File DIR = new File("target/data/KS1/CF1/backups/201108082320/");
     private static BackupMetrics backupMetrics;
     private static String region;
     private static IConfiguration configuration;
@@ -76,26 +79,15 @@ public class TestS3FileSystem {
     }
 
     @BeforeClass
-    public static void setup() throws InterruptedException, IOException {
+    public static void setUp() {
         new MockS3PartUploader();
         new MockAmazonS3Client();
-
-        File dir1 = new File("target/data/Keyspace1/Standard1/backups/201108082320");
-        if (!dir1.exists()) dir1.mkdirs();
-        File file = new File(FILE_PATH);
-        long fiveKB = (5L * 1024);
-        byte b = 8;
-        BufferedOutputStream bos1 = new BufferedOutputStream(new FileOutputStream(file));
-        for (long i = 0; i < fiveKB; i++) {
-            bos1.write(b);
-        }
-        bos1.close();
+        if (!DIR.exists()) DIR.mkdirs();
     }
 
     @AfterClass
-    public static void cleanup() {
-        File file = new File(FILE_PATH);
-        file.delete();
+    public static void cleanup() throws IOException {
+        FileUtils.cleanDirectory(DIR);
     }
 
     @Test
@@ -103,14 +95,13 @@ public class TestS3FileSystem {
         MockS3PartUploader.setup();
         IBackupFileSystem fs = injector.getInstance(NullBackupFileSystem.class);
         RemoteBackupPath backupfile = injector.getInstance(RemoteBackupPath.class);
-        backupfile.parseLocal(new File(FILE_PATH), BackupFileType.SNAP);
+        backupfile.parseLocal(localFile(), BackupFileType.SNAP);
         long noOfFilesUploaded = backupMetrics.getUploadRate().count();
-        fs.uploadFile(
+        fs.uploadAndDelete(
                 Paths.get(backupfile.getBackupFile().getAbsolutePath()),
                 Paths.get(backupfile.getRemotePath()),
                 backupfile,
-                0,
-                false);
+                0);
         Assert.assertEquals(1, backupMetrics.getUploadRate().count() - noOfFilesUploaded);
     }
 
@@ -119,13 +110,12 @@ public class TestS3FileSystem {
         MockS3PartUploader.setup();
         IBackupFileSystem fs = injector.getInstance(NullBackupFileSystem.class);
         RemoteBackupPath backupfile = injector.getInstance(RemoteBackupPath.class);
-        backupfile.parseLocal(new File(FILE_PATH), BackupFileType.SST_V2);
-        fs.uploadFile(
+        backupfile.parseLocal(localFile(), BackupFileType.SST_V2);
+        fs.uploadAndDelete(
                 Paths.get(backupfile.getBackupFile().getAbsolutePath()),
                 Paths.get(backupfile.getRemotePath()),
                 backupfile,
-                0,
-                false);
+                0);
         Assert.assertTrue(fs.checkObjectExists(Paths.get(backupfile.getRemotePath())));
         // Lets delete the file now.
         List<Path> deleteFiles = Lists.newArrayList();
@@ -140,17 +130,14 @@ public class TestS3FileSystem {
         MockS3PartUploader.partFailure = true;
         long noOfFailures = backupMetrics.getInvalidUploads().count();
         S3FileSystem fs = injector.getInstance(S3FileSystem.class);
-        String snapshotfile =
-                "target/data/Keyspace1/Standard1/backups/201108082320/Keyspace1-Standard1-ia-1-Data.db";
         RemoteBackupPath backupfile = injector.getInstance(RemoteBackupPath.class);
-        backupfile.parseLocal(new File(snapshotfile), BackupFileType.SNAP);
+        backupfile.parseLocal(localFile(), BackupFileType.SNAP);
         try {
-            fs.uploadFile(
+            fs.uploadAndDelete(
                     Paths.get(backupfile.getBackupFile().getAbsolutePath()),
                     Paths.get(backupfile.getRemotePath()),
                     backupfile,
-                    0,
-                    false);
+                    0);
         } catch (BackupRestoreException e) {
             // ignore
         }
@@ -164,17 +151,14 @@ public class TestS3FileSystem {
         MockS3PartUploader.completionFailure = true;
         S3FileSystem fs = injector.getInstance(S3FileSystem.class);
         fs.setS3Client(new MockAmazonS3Client().getMockInstance());
-        String snapshotfile =
-                "target/data/Keyspace1/Standard1/backups/201108082320/Keyspace1-Standard1-ia-1-Data.db";
         RemoteBackupPath backupfile = injector.getInstance(RemoteBackupPath.class);
-        backupfile.parseLocal(new File(snapshotfile), BackupFileType.SNAP);
+        backupfile.parseLocal(localFile(), BackupFileType.SNAP);
         try {
-            fs.uploadFile(
+            fs.uploadAndDelete(
                     Paths.get(backupfile.getBackupFile().getAbsolutePath()),
                     Paths.get(backupfile.getRemotePath()),
                     backupfile,
-                    0,
-                    false);
+                    0);
         } catch (BackupRestoreException e) {
             // ignore
         }
@@ -235,6 +219,20 @@ public class TestS3FileSystem {
         } catch (BackupRestoreException e) {
             Assert.assertTrue(true);
         }
+    }
+
+    private File localFile() throws IOException {
+        String caller = Thread.currentThread().getStackTrace()[1].getMethodName();
+        File file = new File(DIR + caller + "KS1-CF1-ia-1-Data.db");
+        if (file.createNewFile()) {
+            byte[] data = new byte[5 << 10];
+            Arrays.fill(data, (byte) 8);
+            try (BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(file))) {
+                os.write(data);
+            }
+        }
+        Preconditions.checkState(file.exists());
+        return file;
     }
 
     // Mock Nodeprobe class

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestBackupUtils.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestBackupUtils.java
@@ -61,6 +61,7 @@ public class TestBackupUtils {
             String prefix = basename.substring(0, lastIndex);
             AbstractBackupPath path = pathProvider.get();
             path.parseRemote(file);
+            path.setCreationTime(path.getLastModified());
             builder.put(prefix, path);
         }
         dataStep.addColumnfamilyResult(keyspace, columnfamily, builder.build());

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestMetaV2Proxy.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestMetaV2Proxy.java
@@ -171,7 +171,7 @@ public class TestMetaV2Proxy {
                         "columnfamily1",
                         "SNAPPY",
                         "PLAINTEXT",
-                        "file1.Data.db"));
+                        "file1-Data.db"));
         files.add(
                 Paths.get(
                         getPrefix(),
@@ -181,7 +181,7 @@ public class TestMetaV2Proxy {
                         "columnfamily1",
                         "SNAPPY",
                         "PLAINTEXT",
-                        "file2.Data.db"));
+                        "file2-Data.db"));
 
         files.add(
                 Paths.get(
@@ -210,7 +210,7 @@ public class TestMetaV2Proxy {
                         "columnfamily1",
                         "SNAPPY",
                         "PLAINTEXT",
-                        "file3.Data.db"));
+                        "file3-Data.db"));
         files.add(
                 Paths.get(
                         getPrefix(),
@@ -220,7 +220,7 @@ public class TestMetaV2Proxy {
                         "columnfamily1",
                         "SNAPPY",
                         "PLAINTEXT",
-                        "file4.Data.db"));
+                        "file4-Data.db"));
         files.add(
                 Paths.get(
                         getPrefix(),

--- a/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
@@ -229,4 +229,9 @@ public class FakeConfiguration implements IConfiguration {
     public void usePrivateIP(boolean usePrivateIp) {
         this.usePrivateIp = usePrivateIp;
     }
+
+    public BackupsToCompress getBackupsToCompress() {
+        return (BackupsToCompress)
+                fakeConfig.getOrDefault("Priam.backupsToCompress", BackupsToCompress.ALL);
+    }
 }


### PR DESCRIPTION
Introduced new BackupsToCompress enum. ALL = compress all backups, NONE = compress no backups, UNCOMPRESSED = compress only those sstables lacking a CompressionInfo.db component.

In the process made AbstractBackupPath more of a first-class citizen and changed the IBackupFileSystem API's downloadFile method take one directly rather than Java Paths.