### PR TITLE
Replace JCenter with Maven Central (3.x branch)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 googleJavaFormat {
@@ -33,7 +33,7 @@ subprojects {
     group = 'com.netflix.priam'
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     configurations {


### PR DESCRIPTION
Hi folks,

As you might be aware, JFrog is sunsetting Bintray and JCenter: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

This is to use maven central instead of jcenter