### PR TITLE
Revert "Adding support for custom override for role_manager (#917)"

### DIFF
--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -561,11 +561,6 @@ public interface IConfiguration {
         return "org.apache.cassandra.auth.AllowAllAuthorizer";
     }
 
-    /** Defaults to 'CassandraRoleManager'. */
-    default String getRoleManager() {
-        return "org.apache.cassandra.auth.CassandraRoleManager";
-    }
-
     /** @return true/false, if Cassandra needs to be started manually */
     default boolean doesCassandraStartManually() {
         return false;

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -427,11 +427,6 @@ public class PriamConfiguration implements IConfiguration {
                 PRIAM_PRE + ".authorizer", "org.apache.cassandra.auth.AllowAllAuthorizer");
     }
 
-    public String getRoleManager() {
-        return config.get(
-                PRIAM_PRE + ".roleManager", "org.apache.cassandra.auth.CassandraRoleManager");
-    }
-
     @Override
     public boolean doesCassandraStartManually() {
         return config.get(PRIAM_PRE + ".cass.manual.start.enable", false);

--- a/priam/src/main/java/com/netflix/priam/tuner/StandardTuner.java
+++ b/priam/src/main/java/com/netflix/priam/tuner/StandardTuner.java
@@ -104,7 +104,6 @@ public class StandardTuner implements ICassandraTuner {
         map.put("hinted_handoff_throttle_in_kb", config.getHintedHandoffThrottleKb());
         map.put("authenticator", config.getAuthenticator());
         map.put("authorizer", config.getAuthorizer());
-        map.put("role_manager", config.getRoleManager());
         map.put("internode_compression", config.getInternodeCompression());
         map.put("dynamic_snitch", config.isDynamicSnitchEnabled());
 

--- a/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
@@ -31,7 +31,6 @@ public class FakeConfiguration implements IConfiguration {
 
     private final String appName;
     private String restorePrefix = "";
-    private String roleManager = "";
     private boolean mayCreateNewToken;
     private ImmutableList<String> racs;
     private boolean usePrivateIp;
@@ -201,16 +200,6 @@ public class FakeConfiguration implements IConfiguration {
     public ImmutableSet<String> getTunablePropertyFiles() {
         String path = new File(getYamlLocation()).getParentFile().getPath();
         return ImmutableSet.of(path + "/cassandra-rackdc.properties");
-    }
-
-    @Override
-    public String getRoleManager() {
-        return this.roleManager;
-    }
-
-    public FakeConfiguration setRoleManager(String roleManager) {
-        this.roleManager = roleManager;
-        return this;
     }
 
     public String getRAC() {

--- a/priam/src/test/java/com/netflix/priam/tuner/StandardTunerTest.java
+++ b/priam/src/test/java/com/netflix/priam/tuner/StandardTunerTest.java
@@ -142,28 +142,11 @@ public class StandardTunerTest {
         extraParamValues.put(priamKeyName2, "test");
         extraParamValues.put(priamKeyName3, "randomKeyValue");
         extraParamValues.put(priamKeyName4, "randomGroupValue");
-
-        Map map =
-                applyFakeConfiguration(new TunerConfiguration(extraConfigParam, extraParamValues));
-        Assert.assertEquals("your_host", map.get("listen_address"));
-        Assert.assertEquals("true", ((Map) map.get("client_encryption_options")).get("optional"));
-        Assert.assertEquals(
-                "test", ((Map) map.get("client_encryption_options")).get("keystore_password"));
-        Assert.assertEquals("randomKeyValue", map.get("randomKey"));
-        Assert.assertEquals("randomGroupValue", ((Map) map.get("randomGroup")).get("randomKey"));
-    }
-
-    @Test
-    public void testRoleManagerOverride() throws Exception {
-        String roleManagerOverride = "org.apache.cassandra.auth.CustomRoleManager";
-        Map map =
-                applyFakeConfiguration(new FakeConfiguration().setRoleManager(roleManagerOverride));
-        Assert.assertEquals(roleManagerOverride, map.get("role_manager"));
-    }
-
-    private Map applyFakeConfiguration(FakeConfiguration fakeConfiguration) throws Exception {
         StandardTuner tuner =
-                new StandardTuner(fakeConfiguration, backupRestoreConfig, instanceInfo);
+                new StandardTuner(
+                        new TunerConfiguration(extraConfigParam, extraParamValues),
+                        backupRestoreConfig,
+                        instanceInfo);
         Files.copy(new File("src/main/resources/incr-restore-cassandra.yaml"), target);
         tuner.writeAllProperties(target.getAbsolutePath(), "your_host", "YourSeedProvider");
 
@@ -171,7 +154,13 @@ public class StandardTunerTest {
         DumperOptions options = new DumperOptions();
         options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
         Yaml yaml = new Yaml(options);
-        return yaml.load(new FileInputStream(target));
+        Map map = yaml.load(new FileInputStream(target));
+        Assert.assertEquals("your_host", map.get("listen_address"));
+        Assert.assertEquals("true", ((Map) map.get("client_encryption_options")).get("optional"));
+        Assert.assertEquals(
+                "test", ((Map) map.get("client_encryption_options")).get("keystore_password"));
+        Assert.assertEquals("randomKeyValue", map.get("randomKey"));
+        Assert.assertEquals("randomGroupValue", ((Map) map.get("randomGroup")).get("randomKey"));
     }
 
     private class TunerConfiguration extends FakeConfiguration {


### PR DESCRIPTION
This reverts commit ae1fbff70fa75b4d61703035a91342a2263842f3. Reason being, Cassandra 2.1 does not have support for role_manager.