### PR TITLE
Verify thrift listening on port before returning its status

### DIFF
--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -1100,8 +1100,8 @@ public interface IConfiguration {
     }
 
     /** @return true to check is thrift listening on the rpc_port. */
-    default boolean isCheckThriftOnPortEnabled() {
-        return true;
+    default boolean checkThriftServerIsListening() {
+        return false;
     }
 
     /**

--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -1099,6 +1099,11 @@ public interface IConfiguration {
         return getSnitch().equals("org.apache.cassandra.locator.GossipingPropertyFileSnitch");
     }
 
+    /** @return true to check is thrift listening on the rpc_port. */
+    default boolean isCheckThriftOnPortEnabled() {
+        return true;
+    }
+
     /**
      * Escape hatch for getting any arbitrary property by key This is useful so we don't have to
      * keep adding methods to this interface for every single configuration option ever. Also

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -765,7 +765,7 @@ public class PriamConfiguration implements IConfiguration {
     }
 
     @Override
-    public boolean isCheckThriftOnPortEnabled() {
-        return config.get(PRIAM_PRE + ".checkThriftOnPort", true);
+    public boolean checkThriftServerIsListening() {
+        return config.get(PRIAM_PRE + ".checkThriftServerIsListening", false);
     }
 }

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -763,4 +763,9 @@ public class PriamConfiguration implements IConfiguration {
     public boolean isForgottenFileMoveEnabled() {
         return config.get(PRIAM_PRE + ".forgottenFileMoveEnabled", false);
     }
+
+    @Override
+    public boolean isCheckThriftOnPortEnabled() {
+        return config.get(PRIAM_PRE + ".checkThriftOnPort", true);
+    }
 }

--- a/priam/src/main/java/com/netflix/priam/health/CassandraMonitor.java
+++ b/priam/src/main/java/com/netflix/priam/health/CassandraMonitor.java
@@ -25,7 +25,10 @@ import com.netflix.priam.merics.CassMonitorMetrics;
 import com.netflix.priam.scheduler.SimpleTimer;
 import com.netflix.priam.scheduler.Task;
 import com.netflix.priam.scheduler.TaskTimer;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.commons.io.IOUtils;
@@ -44,17 +47,20 @@ public class CassandraMonitor extends Task {
     private final InstanceState instanceState;
     private final ICassandraProcess cassProcess;
     private final CassMonitorMetrics cassMonitorMetrics;
+    private final IThriftChecker thriftChecker;
 
     @Inject
     protected CassandraMonitor(
             IConfiguration config,
             InstanceState instanceState,
             ICassandraProcess cassProcess,
-            CassMonitorMetrics cassMonitorMetrics) {
+            CassMonitorMetrics cassMonitorMetrics,
+            IThriftChecker thriftChecker) {
         super(config);
         this.instanceState = instanceState;
         this.cassProcess = cassProcess;
         this.cassMonitorMetrics = cassMonitorMetrics;
+        this.thriftChecker = thriftChecker;
     }
 
     @Override
@@ -89,7 +95,6 @@ public class CassandraMonitor extends Task {
                 NodeProbe bean = JMXNodeTool.instance(this.config);
                 instanceState.setIsGossipActive(bean.isGossipRunning());
                 instanceState.setIsNativeTransportActive(bean.isNativeTransportRunning());
-                ThriftChecker thriftChecker = new ThriftChecker(this.config);
                 instanceState.setIsThriftActive(
                         bean.isThriftServerRunning() && thriftChecker.isThriftServerListening());
 

--- a/priam/src/main/java/com/netflix/priam/health/IThriftChecker.java
+++ b/priam/src/main/java/com/netflix/priam/health/IThriftChecker.java
@@ -1,0 +1,8 @@
+package com.netflix.priam.health;
+
+import com.google.inject.ImplementedBy;
+
+@ImplementedBy(ThriftChecker.class)
+public interface IThriftChecker {
+    boolean isThriftServerListening();
+}

--- a/priam/src/main/java/com/netflix/priam/health/ThriftChecker.java
+++ b/priam/src/main/java/com/netflix/priam/health/ThriftChecker.java
@@ -1,0 +1,53 @@
+package com.netflix.priam.health;
+
+import com.google.inject.Inject;
+import com.netflix.priam.config.IConfiguration;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ThriftChecker implements IThriftChecker {
+    private static final Logger logger = LoggerFactory.getLogger(ThriftChecker.class);
+    protected final IConfiguration config;
+
+    @Inject
+    public ThriftChecker(IConfiguration config) {
+        this.config = config;
+    }
+
+    public boolean isThriftServerListening() {
+        if (!config.checkThriftServerIsListening()) {
+            return true;
+        }
+        try {
+            Process process =
+                    Runtime.getRuntime()
+                            .exec(
+                                    new String[] {
+                                        "/bin/sh",
+                                        "-c",
+                                        "ss -tuln | grep -c " + config.getThriftPort(),
+                                        " 2>/dev/null"
+                                    });
+            process.waitFor(1, TimeUnit.SECONDS);
+            BufferedReader reader =
+                    new BufferedReader(new InputStreamReader(process.getInputStream()));
+            String line = reader.readLine();
+            reader.close();
+            if (Integer.parseInt(line) == 0) {
+                logger.info(
+                        "Could not find anything listening on the rpc port {}!",
+                        config.getThriftPort());
+                return false;
+            }
+        } catch (Exception e) {
+            logger.warn("Exception thrown while checking if process is listening on a port ", e);
+        }
+        // Returning true for exceptions as well because we do not want to generate unnecessary
+        // noise that thrift is not listening on the port when actually we are unable to execute the
+        // query.
+        return true;
+    }
+}

--- a/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
@@ -34,6 +34,7 @@ public class FakeConfiguration implements IConfiguration {
     private boolean mayCreateNewToken;
     private ImmutableList<String> racs;
     private boolean usePrivateIp;
+    private boolean checkThriftIsListening;
 
     public final Map<String, String> fakeProperties = new HashMap<>();
 
@@ -226,5 +227,14 @@ public class FakeConfiguration implements IConfiguration {
 
     public void usePrivateIP(boolean usePrivateIp) {
         this.usePrivateIp = usePrivateIp;
+    }
+
+    @Override
+    public boolean checkThriftServerIsListening() {
+        return checkThriftIsListening;
+    }
+
+    public void setCheckThriftServerIsListening(boolean checkThriftServerIsListening) {
+        this.checkThriftIsListening = checkThriftServerIsListening;
     }
 }

--- a/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
@@ -238,7 +238,8 @@ public class FakeConfiguration implements IConfiguration {
 
     public void setCheckThriftServerIsListening(boolean checkThriftServerIsListening) {
         this.checkThriftIsListening = checkThriftServerIsListening;
-    
+    }
+
     @Override
     public boolean skipDeletingOthersIngressRules() {
         return this.skipDeletingOthersIngressRules;

--- a/priam/src/test/java/com/netflix/priam/health/TestCassandraMonitor.java
+++ b/priam/src/test/java/com/netflix/priam/health/TestCassandraMonitor.java
@@ -37,6 +37,7 @@ public class TestCassandraMonitor {
     private static CassandraMonitor monitor;
     private static InstanceState instanceState;
     private static CassMonitorMetrics cassMonitorMetrics;
+    private static IThriftChecker thriftChecker;
 
     private IConfiguration config;
 
@@ -48,11 +49,14 @@ public class TestCassandraMonitor {
     public void setUp() {
         Injector injector = Guice.createInjector(new BRTestModule());
         config = injector.getInstance(IConfiguration.class);
+        thriftChecker = injector.getInstance(ThriftChecker.class);
         if (instanceState == null) instanceState = injector.getInstance(InstanceState.class);
         if (cassMonitorMetrics == null)
             cassMonitorMetrics = injector.getInstance(CassMonitorMetrics.class);
         if (monitor == null)
-            monitor = new CassandraMonitor(config, instanceState, cassProcess, cassMonitorMetrics);
+            monitor =
+                    new CassandraMonitor(
+                            config, instanceState, cassProcess, cassMonitorMetrics, thriftChecker);
     }
 
     @Test

--- a/priam/src/test/java/com/netflix/priam/health/TestThriftChecker.java
+++ b/priam/src/test/java/com/netflix/priam/health/TestThriftChecker.java
@@ -1,10 +1,6 @@
 package com.netflix.priam.health;
 
-import com.google.inject.Guice;
-import com.google.inject.Injector;
-import com.netflix.priam.backup.BRTestModule;
 import com.netflix.priam.config.FakeConfiguration;
-import com.netflix.priam.config.IConfiguration;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -15,34 +11,32 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TestThriftChecker {
-    private IConfiguration config;
+    private FakeConfiguration config;
+    private ThriftChecker thriftChecker;
 
     @Mocked private Process mockProcess;
 
     @Before
     public void TestThriftChecker() {
-        Injector injector = Guice.createInjector(new BRTestModule());
-        config = injector.getInstance(IConfiguration.class);
+        config = new FakeConfiguration();
+        thriftChecker = new ThriftChecker(config);
     }
 
     @Test
     public void testThriftServerIsListeningDisabled() {
-        ((FakeConfiguration) config).setCheckThriftServerIsListening(false);
-        ThriftChecker checker = new ThriftChecker(config);
-        Assert.assertTrue(checker.isThriftServerListening());
+        config.setCheckThriftServerIsListening(false);
+        Assert.assertTrue(thriftChecker.isThriftServerListening());
     }
 
     @Test
     public void testThriftServerIsNotListening() {
-        ((FakeConfiguration) config).setCheckThriftServerIsListening(true);
-        ThriftChecker checker = new ThriftChecker(config);
-        Assert.assertFalse(checker.isThriftServerListening());
+        config.setCheckThriftServerIsListening(true);
+        Assert.assertFalse(thriftChecker.isThriftServerListening());
     }
 
     @Test
     public void testThriftServerIsListening() throws IOException {
-        ((FakeConfiguration) config).setCheckThriftServerIsListening(true);
-        ThriftChecker checker = new ThriftChecker(config);
+        config.setCheckThriftServerIsListening(true);
         final InputStream mockOutput = new ByteArrayInputStream("1".getBytes());
         new Expectations() {
             {
@@ -62,13 +56,12 @@ public class TestThriftChecker {
             }
         };
 
-        Assert.assertTrue(checker.isThriftServerListening());
+        Assert.assertTrue(thriftChecker.isThriftServerListening());
     }
 
     @Test
     public void testThriftServerIsListeningException() throws IOException {
-        ((FakeConfiguration) config).setCheckThriftServerIsListening(true);
-        ThriftChecker checker = new ThriftChecker(config);
+        config.setCheckThriftServerIsListening(true);
         final IOException mockOutput = new IOException("Command exited with code 0");
         new Expectations() {
             {
@@ -88,6 +81,6 @@ public class TestThriftChecker {
             }
         };
 
-        Assert.assertTrue(checker.isThriftServerListening());
+        Assert.assertTrue(thriftChecker.isThriftServerListening());
     }
 }

--- a/priam/src/test/java/com/netflix/priam/health/TestThriftChecker.java
+++ b/priam/src/test/java/com/netflix/priam/health/TestThriftChecker.java
@@ -1,0 +1,93 @@
+package com.netflix.priam.health;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.netflix.priam.backup.BRTestModule;
+import com.netflix.priam.config.FakeConfiguration;
+import com.netflix.priam.config.IConfiguration;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestThriftChecker {
+    private IConfiguration config;
+
+    @Mocked private Process mockProcess;
+
+    @Before
+    public void TestThriftChecker() {
+        Injector injector = Guice.createInjector(new BRTestModule());
+        config = injector.getInstance(IConfiguration.class);
+    }
+
+    @Test
+    public void testThriftServerIsListeningDisabled() {
+        ((FakeConfiguration) config).setCheckThriftServerIsListening(false);
+        ThriftChecker checker = new ThriftChecker(config);
+        Assert.assertTrue(checker.isThriftServerListening());
+    }
+
+    @Test
+    public void testThriftServerIsNotListening() {
+        ((FakeConfiguration) config).setCheckThriftServerIsListening(true);
+        ThriftChecker checker = new ThriftChecker(config);
+        Assert.assertFalse(checker.isThriftServerListening());
+    }
+
+    @Test
+    public void testThriftServerIsListening() throws IOException {
+        ((FakeConfiguration) config).setCheckThriftServerIsListening(true);
+        ThriftChecker checker = new ThriftChecker(config);
+        final InputStream mockOutput = new ByteArrayInputStream("1".getBytes());
+        new Expectations() {
+            {
+                mockProcess.getInputStream();
+                result = mockOutput;
+            }
+        };
+        // Mock out the ps call
+        final Runtime r = Runtime.getRuntime();
+        String[] cmd = {
+            "/bin/sh", "-c", "ss -tuln | grep -c " + config.getThriftPort(), " 2>/dev/null"
+        };
+        new Expectations(r) {
+            {
+                r.exec(cmd);
+                result = mockProcess;
+            }
+        };
+
+        Assert.assertTrue(checker.isThriftServerListening());
+    }
+
+    @Test
+    public void testThriftServerIsListeningException() throws IOException {
+        ((FakeConfiguration) config).setCheckThriftServerIsListening(true);
+        ThriftChecker checker = new ThriftChecker(config);
+        final IOException mockOutput = new IOException("Command exited with code 0");
+        new Expectations() {
+            {
+                mockProcess.getInputStream();
+                result = mockOutput;
+            }
+        };
+        // Mock out the ps call
+        final Runtime r = Runtime.getRuntime();
+        String[] cmd = {
+            "/bin/sh", "-c", "ss -tuln | grep -c " + config.getThriftPort(), " 2>/dev/null"
+        };
+        new Expectations(r) {
+            {
+                r.exec(cmd);
+                result = mockProcess;
+            }
+        };
+
+        Assert.assertTrue(checker.isThriftServerListening());
+    }
+}


### PR DESCRIPTION
Priam marks isThriftActive = true if nodestool statusthrift is true. It does not check whether a process is listening on the rpc port. As a result Priam reports healthy even when nothing is actually listening on the rpc_port. 

With the changes added to this PR, Priam will only report isthriftActive = true if nodestool statusthrift is true and if something is listening on the rpc_port. This is added as a fast property and can be turned off by setting ".checkThriftOnPort" as false.