### PR TITLE
Remove codecov integration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,0 @@
-codecov:
-  branch: 3.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: java
 jdk:
 - openjdk8
-after_success:
-- bash <(curl -s https://codecov.io/bash)
 sudo: false
 install: "./installViaTravis.sh"
 script:


### PR DESCRIPTION
While we were not affected by the https://about.codecov.io/security-update/

We suggest to move away from this pattern of curling codecov.io to get the bash script

This is to prevent potential problems in the future