### PR TITLE
Improve the configurability of setting ingress rules

### DIFF
--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -1100,6 +1100,26 @@ public interface IConfiguration {
     }
 
     /**
+     * @return true if Priam should skip deleting ingress rules for IPs not found in the token
+     *     database.
+     */
+    default boolean skipDeletingOthersIngressRules() {
+        return false;
+    }
+
+    /**
+     * @return true if Priam should skip updating ingress rules for ips found in the token database.
+     */
+    default boolean skipUpdatingOthersIngressRules() {
+        return false;
+    }
+
+    /** @return get the threshold at which point we might risk not getting our ingress rule set. */
+    default int getACLSizeWarnThreshold() {
+        return 500;
+    }
+
+    /**
      * Escape hatch for getting any arbitrary property by key This is useful so we don't have to
      * keep adding methods to this interface for every single configuration option ever. Also
      * exposed via HTTP at v1/config/unstructured/X

--- a/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
@@ -34,6 +34,8 @@ public class FakeConfiguration implements IConfiguration {
     private boolean mayCreateNewToken;
     private ImmutableList<String> racs;
     private boolean usePrivateIp;
+    private boolean skipDeletingOthersIngressRules;
+    private boolean skipUpdatingOthersIngressRules;
 
     public final Map<String, String> fakeProperties = new HashMap<>();
 
@@ -226,5 +228,23 @@ public class FakeConfiguration implements IConfiguration {
 
     public void usePrivateIP(boolean usePrivateIp) {
         this.usePrivateIp = usePrivateIp;
+    }
+
+    @Override
+    public boolean skipDeletingOthersIngressRules() {
+        return this.skipDeletingOthersIngressRules;
+    }
+
+    public void setSkipDeletingOthersIngressRules(boolean skipDeletingOthersIngressRules) {
+        this.skipDeletingOthersIngressRules = skipDeletingOthersIngressRules;
+    }
+
+    @Override
+    public boolean skipUpdatingOthersIngressRules() {
+        return this.skipUpdatingOthersIngressRules;
+    }
+
+    public void setSkipUpdatingOthersIngressRules(boolean skipUpdatingOthersIngressRules) {
+        this.skipUpdatingOthersIngressRules = skipUpdatingOthersIngressRules;
     }
 }


### PR DESCRIPTION
This gives us very fine-grained control over the behavior of every part of UpdateSecuritySettings. Fret not the verbosity. It will be gone soon.