### PR TITLE
Verify thrift listening on port before returning its status

### DIFF
--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -1103,6 +1103,11 @@ public interface IConfiguration {
         return getSnitch().equals("org.apache.cassandra.locator.GossipingPropertyFileSnitch");
     }
 
+    /** @return true to check is thrift listening on the rpc_port. */
+    default boolean checkThriftServerIsListening() {
+        return false;
+    }
+
     /**
      * @return BackupsToCompress UNCOMPRESSED means compress backups only when the files are not
      *     already compressed by Cassandra

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -774,4 +774,9 @@ public class PriamConfiguration implements IConfiguration {
         return BackupsToCompress.valueOf(
                 config.get("priam.backupsToCompress", BackupsToCompress.ALL.name()));
     }
+
+    @Override
+    public boolean checkThriftServerIsListening() {
+        return config.get(PRIAM_PRE + ".checkThriftServerIsListening", false);
+    }
 }

--- a/priam/src/main/java/com/netflix/priam/health/CassandraMonitor.java
+++ b/priam/src/main/java/com/netflix/priam/health/CassandraMonitor.java
@@ -47,17 +47,20 @@ public class CassandraMonitor extends Task {
     private final InstanceState instanceState;
     private final ICassandraProcess cassProcess;
     private final CassMonitorMetrics cassMonitorMetrics;
+    private final IThriftChecker thriftChecker;
 
     @Inject
     protected CassandraMonitor(
             IConfiguration config,
             InstanceState instanceState,
             ICassandraProcess cassProcess,
-            CassMonitorMetrics cassMonitorMetrics) {
+            CassMonitorMetrics cassMonitorMetrics,
+            IThriftChecker thriftChecker) {
         super(config);
         this.instanceState = instanceState;
         this.cassProcess = cassProcess;
         this.cassMonitorMetrics = cassMonitorMetrics;
+        this.thriftChecker = thriftChecker;
     }
 
     @Override
@@ -92,7 +95,9 @@ public class CassandraMonitor extends Task {
                 NodeProbe bean = JMXNodeTool.instance(this.config);
                 instanceState.setIsGossipActive(bean.isGossipRunning());
                 instanceState.setIsNativeTransportActive(bean.isNativeTransportRunning());
-                instanceState.setIsThriftActive(bean.isThriftServerRunning());
+                instanceState.setIsThriftActive(
+                        bean.isThriftServerRunning() && thriftChecker.isThriftServerListening());
+
             } else {
                 // Setting cassandra flag to false
                 instanceState.setCassandraProcessAlive(false);

--- a/priam/src/main/java/com/netflix/priam/health/IThriftChecker.java
+++ b/priam/src/main/java/com/netflix/priam/health/IThriftChecker.java
@@ -1,0 +1,8 @@
+package com.netflix.priam.health;
+
+import com.google.inject.ImplementedBy;
+
+@ImplementedBy(ThriftChecker.class)
+public interface IThriftChecker {
+    boolean isThriftServerListening();
+}

--- a/priam/src/main/java/com/netflix/priam/health/ThriftChecker.java
+++ b/priam/src/main/java/com/netflix/priam/health/ThriftChecker.java
@@ -1,0 +1,52 @@
+package com.netflix.priam.health;
+
+import com.google.inject.Inject;
+import com.netflix.priam.config.IConfiguration;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ThriftChecker implements IThriftChecker {
+    private static final Logger logger = LoggerFactory.getLogger(ThriftChecker.class);
+    protected final IConfiguration config;
+
+    @Inject
+    public ThriftChecker(IConfiguration config) {
+        this.config = config;
+    }
+
+    public boolean isThriftServerListening() {
+        if (!config.checkThriftServerIsListening()) {
+            return true;
+        }
+        String[] cmd =
+                new String[] {
+                    "/bin/sh", "-c", "ss -tuln | grep -c " + config.getThriftPort(), " 2>/dev/null"
+                };
+        Process process = null;
+        try {
+            process = Runtime.getRuntime().exec(cmd);
+            process.waitFor(1, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            logger.warn("Exception while executing the process: ", e);
+        }
+        if (process != null) {
+            try (BufferedReader reader =
+                    new BufferedReader(new InputStreamReader(process.getInputStream())); ) {
+                if (Integer.parseInt(reader.readLine()) == 0) {
+                    logger.info(
+                            "Could not find anything listening on the rpc port {}!",
+                            config.getThriftPort());
+                    return false;
+                }
+            } catch (Exception e) {
+                logger.warn("Exception while reading the input stream: ", e);
+            }
+        }
+        // A quiet on-call is our top priority, err on the side of avoiding false positives by
+        // default.
+        return true;
+    }
+}

--- a/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
@@ -35,6 +35,7 @@ public class FakeConfiguration implements IConfiguration {
     private boolean mayCreateNewToken;
     private ImmutableList<String> racs;
     private boolean usePrivateIp;
+    private boolean checkThriftIsListening;
 
     public Map<String, String> fakeProperties = new HashMap<>();
 
@@ -233,5 +234,14 @@ public class FakeConfiguration implements IConfiguration {
     public BackupsToCompress getBackupsToCompress() {
         return (BackupsToCompress)
                 fakeConfig.getOrDefault("Priam.backupsToCompress", BackupsToCompress.ALL);
+    }
+
+    @Override
+    public boolean checkThriftServerIsListening() {
+        return checkThriftIsListening;
+    }
+
+    public void setCheckThriftServerIsListening(boolean checkThriftServerIsListening) {
+        this.checkThriftIsListening = checkThriftServerIsListening;
     }
 }

--- a/priam/src/test/java/com/netflix/priam/health/TestCassandraMonitor.java
+++ b/priam/src/test/java/com/netflix/priam/health/TestCassandraMonitor.java
@@ -37,6 +37,8 @@ public class TestCassandraMonitor {
     private static CassandraMonitor monitor;
     private static InstanceState instanceState;
     private static CassMonitorMetrics cassMonitorMetrics;
+    private static IThriftChecker thriftChecker;
+
     private IConfiguration config;
 
     @Mocked private Process mockProcess;
@@ -47,13 +49,16 @@ public class TestCassandraMonitor {
     public void setUp() {
         Injector injector = Guice.createInjector(new BRTestModule());
         config = injector.getInstance(IConfiguration.class);
+        thriftChecker = injector.getInstance(ThriftChecker.class);
         if (instanceState == null) instanceState = injector.getInstance(InstanceState.class);
 
         if (cassMonitorMetrics == null)
             cassMonitorMetrics = injector.getInstance(CassMonitorMetrics.class);
 
         if (monitor == null)
-            monitor = new CassandraMonitor(config, instanceState, cassProcess, cassMonitorMetrics);
+            monitor =
+                    new CassandraMonitor(
+                            config, instanceState, cassProcess, cassMonitorMetrics, thriftChecker);
     }
 
     @Test

--- a/priam/src/test/java/com/netflix/priam/health/TestThriftChecker.java
+++ b/priam/src/test/java/com/netflix/priam/health/TestThriftChecker.java
@@ -1,0 +1,86 @@
+package com.netflix.priam.health;
+
+import com.netflix.priam.config.FakeConfiguration;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestThriftChecker {
+    private FakeConfiguration config;
+    private ThriftChecker thriftChecker;
+
+    @Mocked private Process mockProcess;
+
+    @Before
+    public void TestThriftChecker() {
+        config = new FakeConfiguration();
+        thriftChecker = new ThriftChecker(config);
+    }
+
+    @Test
+    public void testThriftServerIsListeningDisabled() {
+        config.setCheckThriftServerIsListening(false);
+        Assert.assertTrue(thriftChecker.isThriftServerListening());
+    }
+
+    @Test
+    public void testThriftServerIsNotListening() {
+        config.setCheckThriftServerIsListening(true);
+        Assert.assertFalse(thriftChecker.isThriftServerListening());
+    }
+
+    @Test
+    public void testThriftServerIsListening() throws IOException {
+        config.setCheckThriftServerIsListening(true);
+        final InputStream mockOutput = new ByteArrayInputStream("1".getBytes());
+        new Expectations() {
+            {
+                mockProcess.getInputStream();
+                result = mockOutput;
+            }
+        };
+        // Mock out the ps call
+        final Runtime r = Runtime.getRuntime();
+        String[] cmd = {
+            "/bin/sh", "-c", "ss -tuln | grep -c " + config.getThriftPort(), " 2>/dev/null"
+        };
+        new Expectations(r) {
+            {
+                r.exec(cmd);
+                result = mockProcess;
+            }
+        };
+
+        Assert.assertTrue(thriftChecker.isThriftServerListening());
+    }
+
+    @Test
+    public void testThriftServerIsListeningException() throws IOException {
+        config.setCheckThriftServerIsListening(true);
+        final IOException mockOutput = new IOException("Command exited with code 0");
+        new Expectations() {
+            {
+                mockProcess.getInputStream();
+                result = mockOutput;
+            }
+        };
+        // Mock out the ps call
+        final Runtime r = Runtime.getRuntime();
+        String[] cmd = {
+            "/bin/sh", "-c", "ss -tuln | grep -c " + config.getThriftPort(), " 2>/dev/null"
+        };
+        new Expectations(r) {
+            {
+                r.exec(cmd);
+                result = mockProcess;
+            }
+        };
+
+        Assert.assertTrue(thriftChecker.isThriftServerListening());
+    }
+}


### PR DESCRIPTION
Priam marks isThriftActive = true if nodestool statusthrift is true. It does not check whether a process is listening on the rpc port. As a result Priam reports healthy even when nothing is actually listening on the rpc_port.

With the changes added to this PR, Priam will only report isthriftActive = true if nodestool statusthrift is true and if something is listening on the rpc_port. This is added as a fast property and can be turned off by setting ".checkThriftOnPort" as false.