### PR TITLE
refactor: JUnit Jupiter migration from JUnit 4.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,8 +94,9 @@ subprojects {
         testCompile 'org.jmockit:jmockit:1.38'
         testCompile "org.spockframework:spock-core:1.1-groovy-2.4"
         testCompile "com.google.truth:truth:1.0.1"
-        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
+        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
+        testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
+        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
 
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8

--- a/priam/src/test/java/com/netflix/priam/TestModule.java
+++ b/priam/src/test/java/com/netflix/priam/TestModule.java
@@ -40,11 +40,11 @@ import com.netflix.priam.utils.FakeSleeper;
 import com.netflix.priam.utils.Sleeper;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.quartz.SchedulerFactory;
 import org.quartz.impl.StdSchedulerFactory;
 
-@Ignore
+@Disabled
 public class TestModule extends AbstractModule {
 
     @Override

--- a/priam/src/test/java/com/netflix/priam/aws/TestRemoteBackupPath.java
+++ b/priam/src/test/java/com/netflix/priam/aws/TestRemoteBackupPath.java
@@ -30,8 +30,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.ParseException;
 import java.time.Instant;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,13 +60,13 @@ public class TestRemoteBackupPath {
         abstractBackupPath.parseLocal(path.toFile(), BackupFileType.SST);
 
         // Verify parse local
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 0, abstractBackupPath.getLastModified().toEpochMilli()); // File do not exist.
-        Assert.assertEquals("keyspace1", abstractBackupPath.getKeyspace());
-        Assert.assertEquals("columnfamily1", abstractBackupPath.getColumnFamily());
-        Assert.assertEquals(BackupFileType.SST, abstractBackupPath.getType());
-        Assert.assertEquals(path.toFile(), abstractBackupPath.getBackupFile());
-        Assert.assertEquals(
+        Assertions.assertEquals("keyspace1", abstractBackupPath.getKeyspace());
+        Assertions.assertEquals("columnfamily1", abstractBackupPath.getColumnFamily());
+        Assertions.assertEquals(BackupFileType.SST, abstractBackupPath.getType());
+        Assertions.assertEquals(path.toFile(), abstractBackupPath.getBackupFile());
+        Assertions.assertEquals(
                 0,
                 abstractBackupPath
                         .getTime()
@@ -79,16 +79,16 @@ public class TestRemoteBackupPath {
         AbstractBackupPath abstractBackupPath2 = pathFactory.get();
         abstractBackupPath2.parseRemote(remotePath);
         validateAbstractBackupPath(abstractBackupPath, abstractBackupPath2);
-        Assert.assertEquals(abstractBackupPath.getTime(), abstractBackupPath2.getTime());
+        Assertions.assertEquals(abstractBackupPath.getTime(), abstractBackupPath2.getTime());
     }
 
     private void validateAbstractBackupPath(AbstractBackupPath abp1, AbstractBackupPath abp2) {
-        Assert.assertEquals(abp1.getKeyspace(), abp2.getKeyspace());
-        Assert.assertEquals(abp1.getColumnFamily(), abp2.getColumnFamily());
-        Assert.assertEquals(abp1.getFileName(), abp2.getFileName());
-        Assert.assertEquals(abp1.getType(), abp2.getType());
-        Assert.assertEquals(abp1.getCompression(), abp2.getCompression());
-        Assert.assertEquals(abp1.getEncryption(), abp2.getEncryption());
+        Assertions.assertEquals(abp1.getKeyspace(), abp2.getKeyspace());
+        Assertions.assertEquals(abp1.getColumnFamily(), abp2.getColumnFamily());
+        Assertions.assertEquals(abp1.getFileName(), abp2.getFileName());
+        Assertions.assertEquals(abp1.getType(), abp2.getType());
+        Assertions.assertEquals(abp1.getCompression(), abp2.getCompression());
+        Assertions.assertEquals(abp1.getEncryption(), abp2.getEncryption());
     }
 
     @Test
@@ -105,13 +105,13 @@ public class TestRemoteBackupPath {
         abstractBackupPath.parseLocal(path.toFile(), BackupFileType.SNAP);
 
         // Verify parse local
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 0, abstractBackupPath.getLastModified().toEpochMilli()); // File do not exist.
-        Assert.assertEquals("keyspace1", abstractBackupPath.getKeyspace());
-        Assert.assertEquals("columnfamily1", abstractBackupPath.getColumnFamily());
-        Assert.assertEquals(BackupFileType.SNAP, abstractBackupPath.getType());
-        Assert.assertEquals(path.toFile(), abstractBackupPath.getBackupFile());
-        Assert.assertEquals(
+        Assertions.assertEquals("keyspace1", abstractBackupPath.getKeyspace());
+        Assertions.assertEquals("columnfamily1", abstractBackupPath.getColumnFamily());
+        Assertions.assertEquals(BackupFileType.SNAP, abstractBackupPath.getType());
+        Assertions.assertEquals(path.toFile(), abstractBackupPath.getBackupFile());
+        Assertions.assertEquals(
                 "201801011201", DateUtil.formatyyyyMMddHHmm(abstractBackupPath.getTime()));
 
         // Verify toRemote and parseRemote.
@@ -121,7 +121,7 @@ public class TestRemoteBackupPath {
         AbstractBackupPath abstractBackupPath2 = pathFactory.get();
         abstractBackupPath2.parseRemote(remotePath);
         validateAbstractBackupPath(abstractBackupPath, abstractBackupPath2);
-        Assert.assertEquals(abstractBackupPath.getTime(), abstractBackupPath2.getTime());
+        Assertions.assertEquals(abstractBackupPath.getTime(), abstractBackupPath2.getTime());
     }
 
     @Test
@@ -131,12 +131,12 @@ public class TestRemoteBackupPath {
         abstractBackupPath.parseLocal(path.toFile(), BackupFileType.META);
 
         // Verify parse local
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 0, abstractBackupPath.getLastModified().toEpochMilli()); // File do not exist.
-        Assert.assertEquals(null, abstractBackupPath.getKeyspace());
-        Assert.assertEquals(null, abstractBackupPath.getColumnFamily());
-        Assert.assertEquals(BackupFileType.META, abstractBackupPath.getType());
-        Assert.assertEquals(path.toFile(), abstractBackupPath.getBackupFile());
+        Assertions.assertEquals(null, abstractBackupPath.getKeyspace());
+        Assertions.assertEquals(null, abstractBackupPath.getColumnFamily());
+        Assertions.assertEquals(BackupFileType.META, abstractBackupPath.getType());
+        Assertions.assertEquals(path.toFile(), abstractBackupPath.getBackupFile());
 
         // Verify toRemote and parseRemote.
         String remotePath = abstractBackupPath.getRemotePath();
@@ -145,7 +145,7 @@ public class TestRemoteBackupPath {
         AbstractBackupPath abstractBackupPath2 = pathFactory.get();
         abstractBackupPath2.parseRemote(remotePath);
         validateAbstractBackupPath(abstractBackupPath, abstractBackupPath2);
-        Assert.assertEquals(abstractBackupPath.getTime(), abstractBackupPath2.getTime());
+        Assertions.assertEquals(abstractBackupPath.getTime(), abstractBackupPath2.getTime());
     }
 
     @Test
@@ -161,13 +161,13 @@ public class TestRemoteBackupPath {
         abstractBackupPath.parseLocal(path.toFile(), BackupFileType.SST_V2);
 
         // Verify parse local
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 0, abstractBackupPath.getLastModified().toEpochMilli()); // File do not exist.
-        Assert.assertEquals("keyspace1", abstractBackupPath.getKeyspace());
-        Assert.assertEquals("columnfamily1", abstractBackupPath.getColumnFamily());
-        Assert.assertEquals("SNAPPY", abstractBackupPath.getCompression().name());
-        Assert.assertEquals(BackupFileType.SST_V2, abstractBackupPath.getType());
-        Assert.assertEquals(path.toFile(), abstractBackupPath.getBackupFile());
+        Assertions.assertEquals("keyspace1", abstractBackupPath.getKeyspace());
+        Assertions.assertEquals("columnfamily1", abstractBackupPath.getColumnFamily());
+        Assertions.assertEquals("SNAPPY", abstractBackupPath.getCompression().name());
+        Assertions.assertEquals(BackupFileType.SST_V2, abstractBackupPath.getType());
+        Assertions.assertEquals(path.toFile(), abstractBackupPath.getBackupFile());
 
         // Verify toRemote and parseRemote.
         Instant now = DateUtil.getInstant();
@@ -177,7 +177,7 @@ public class TestRemoteBackupPath {
 
         AbstractBackupPath abstractBackupPath2 = pathFactory.get();
         abstractBackupPath2.parseRemote(remotePath);
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 now.toEpochMilli() / 1_000L * 1_000L,
                 abstractBackupPath2.getLastModified().toEpochMilli());
         validateAbstractBackupPath(abstractBackupPath, abstractBackupPath2);
@@ -190,13 +190,14 @@ public class TestRemoteBackupPath {
         abstractBackupPath.parseLocal(path.toFile(), BackupFileType.META_V2);
 
         // Verify parse local
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 0, abstractBackupPath.getLastModified().toEpochMilli()); // File do not exist.
-        Assert.assertEquals(null, abstractBackupPath.getKeyspace());
-        Assert.assertEquals(null, abstractBackupPath.getColumnFamily());
-        Assert.assertEquals(BackupFileType.META_V2, abstractBackupPath.getType());
-        Assert.assertEquals(path.toFile(), abstractBackupPath.getBackupFile());
-        Assert.assertEquals(CryptographyAlgorithm.PLAINTEXT, abstractBackupPath.getEncryption());
+        Assertions.assertEquals(null, abstractBackupPath.getKeyspace());
+        Assertions.assertEquals(null, abstractBackupPath.getColumnFamily());
+        Assertions.assertEquals(BackupFileType.META_V2, abstractBackupPath.getType());
+        Assertions.assertEquals(path.toFile(), abstractBackupPath.getBackupFile());
+        Assertions.assertEquals(
+                CryptographyAlgorithm.PLAINTEXT, abstractBackupPath.getEncryption());
 
         // Verify toRemote and parseRemote.
         Instant now = DateUtil.getInstant();
@@ -204,11 +205,11 @@ public class TestRemoteBackupPath {
         String remotePath = abstractBackupPath.getRemotePath();
         logger.info(remotePath);
 
-        Assert.assertEquals("SNAPPY", abstractBackupPath.getCompression().name());
+        Assertions.assertEquals("SNAPPY", abstractBackupPath.getCompression().name());
 
         AbstractBackupPath abstractBackupPath2 = pathFactory.get();
         abstractBackupPath2.parseRemote(remotePath);
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 now.toEpochMilli() / 1_000L * 1_000L,
                 abstractBackupPath2.getLastModified().toEpochMilli());
         validateAbstractBackupPath(abstractBackupPath, abstractBackupPath2);
@@ -218,12 +219,12 @@ public class TestRemoteBackupPath {
     public void testRemoteV2Prefix() throws ParseException {
         Path path = Paths.get("test_backup");
         AbstractBackupPath abstractBackupPath = pathFactory.get();
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 "casstestbackup/1049_fake-app/1808575600/META_V2",
                 abstractBackupPath.remoteV2Prefix(path, BackupFileType.META_V2).toString());
 
         path = Paths.get("s3-bucket-name", "fake_base_dir", "-6717_random_fake_app");
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 "fake_base_dir/-6717_random_fake_app/1808575600/META_V2",
                 abstractBackupPath.remoteV2Prefix(path, BackupFileType.META_V2).toString());
     }

--- a/priam/src/test/java/com/netflix/priam/aws/TestUpdateSecuritySettings.java
+++ b/priam/src/test/java/com/netflix/priam/aws/TestUpdateSecuritySettings.java
@@ -9,8 +9,8 @@ import com.netflix.priam.config.FakeConfiguration;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.identity.IMembership;
 import com.netflix.priam.identity.IPriamInstanceFactory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /* Tests of {@link UpdateSecuritySettings.java} */
 public class TestUpdateSecuritySettings {
@@ -22,7 +22,7 @@ public class TestUpdateSecuritySettings {
     private FakeConfiguration config;
     private FakeIPConverter ipConverter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         Injector injector = Guice.createInjector(new TestModule());
         factory = injector.getInstance(IPriamInstanceFactory.class);

--- a/priam/src/test/java/com/netflix/priam/backup/BRTestModule.java
+++ b/priam/src/test/java/com/netflix/priam/backup/BRTestModule.java
@@ -43,11 +43,11 @@ import com.netflix.priam.utils.Sleeper;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
 import java.util.Collections;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.quartz.SchedulerFactory;
 import org.quartz.impl.StdSchedulerFactory;
 
-@Ignore
+@Disabled
 public class BRTestModule extends AbstractModule {
 
     @Override

--- a/priam/src/test/java/com/netflix/priam/backup/TestAbstractFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestAbstractFileSystem.java
@@ -35,9 +35,9 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.*;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * The goal of this class is to test common functionality which are encapsulated in
@@ -52,7 +52,7 @@ public class TestAbstractFileSystem {
     private FailureFileSystem failureFileSystem;
     private MyFileSystem myFileSystem;
 
-    @Before
+    @BeforeEach
     public void setBackupMetrics() {
         if (injector == null) injector = Guice.createInjector(new BRTestModule());
 
@@ -86,7 +86,7 @@ public class TestAbstractFileSystem {
             }
         } catch (BackupRestoreException e) {
             // Verify the failure metric for upload is incremented.
-            Assert.assertEquals(1, (int) backupMetrics.getInvalidUploads().count());
+            Assertions.assertEquals(1, (int) backupMetrics.getInvalidUploads().count());
         }
     }
 
@@ -115,7 +115,7 @@ public class TestAbstractFileSystem {
             failureFileSystem.downloadFile(getDummyPath(), "", 2);
         } catch (BackupRestoreException e) {
             // Verify the failure metric for download is incremented.
-            Assert.assertEquals(1, (int) backupMetrics.getInvalidDownloads().count());
+            Assertions.assertEquals(1, (int) backupMetrics.getInvalidDownloads().count());
         }
     }
 
@@ -123,8 +123,8 @@ public class TestAbstractFileSystem {
     public void testUpload() throws Exception {
         File file = generateFiles(1, 1, 1).iterator().next();
         myFileSystem.uploadAndDelete(getDummyPath(file.toPath()), 2);
-        Assert.assertEquals(1, (int) backupMetrics.getValidUploads().actualCount());
-        Assert.assertFalse(file.exists());
+        Assertions.assertEquals(1, (int) backupMetrics.getValidUploads().actualCount());
+        Assertions.assertFalse(file.exists());
     }
 
     @Test
@@ -132,15 +132,15 @@ public class TestAbstractFileSystem {
         // Dummy download
         myFileSystem.downloadFile(getDummyPath(), "", 2);
         // Verify the success metric for download is incremented.
-        Assert.assertEquals(1, (int) backupMetrics.getValidDownloads().actualCount());
+        Assertions.assertEquals(1, (int) backupMetrics.getValidDownloads().actualCount());
     }
 
     @Test
     public void testAsyncUpload() throws Exception {
         File file = generateFiles(1, 1, 1).iterator().next();
         myFileSystem.asyncUploadAndDelete(getDummyPath(file.toPath()), 2).get();
-        Assert.assertEquals(1, (int) backupMetrics.getValidUploads().actualCount());
-        Assert.assertEquals(0, myFileSystem.getUploadTasksQueued());
+        Assertions.assertEquals(1, (int) backupMetrics.getValidUploads().actualCount());
+        Assertions.assertEquals(0, myFileSystem.getUploadTasksQueued());
     }
 
     @Test
@@ -158,10 +158,10 @@ public class TestAbstractFileSystem {
             future.get();
         }
         // 2. Success metric is incremented correctly
-        Assert.assertEquals(files.size(), (int) backupMetrics.getValidUploads().actualCount());
+        Assertions.assertEquals(files.size(), (int) backupMetrics.getValidUploads().actualCount());
 
         // 3. The task queue is empty after upload is finished.
-        Assert.assertEquals(0, myFileSystem.getUploadTasksQueued());
+        Assertions.assertEquals(0, myFileSystem.getUploadTasksQueued());
     }
 
     @Test
@@ -196,7 +196,7 @@ public class TestAbstractFileSystem {
         }
         // 2. Verify the success metric for upload is not same as size, i.e. some amount of
         // de-duping happened.
-        Assert.assertNotEquals(size, (int) backupMetrics.getValidUploads().actualCount());
+        Assertions.assertNotEquals(size, (int) backupMetrics.getValidUploads().actualCount());
     }
 
     @Test
@@ -212,10 +212,10 @@ public class TestAbstractFileSystem {
                 // 1. Future get returns error message.
 
                 // 2. Verify the failure metric for upload is incremented.
-                Assert.assertEquals(1, (int) backupMetrics.getInvalidUploads().count());
+                Assertions.assertEquals(1, (int) backupMetrics.getInvalidUploads().count());
 
                 // 3. The task queue is empty after upload is finished.
-                Assert.assertEquals(0, failureFileSystem.getUploadTasksQueued());
+                Assertions.assertEquals(0, failureFileSystem.getUploadTasksQueued());
                 break;
             }
         }
@@ -227,9 +227,9 @@ public class TestAbstractFileSystem {
         Future<Path> future = myFileSystem.asyncDownloadFile(getDummyPath(), 2);
         future.get();
         // 1. Verify the success metric for download is incremented.
-        Assert.assertEquals(1, (int) backupMetrics.getValidDownloads().actualCount());
+        Assertions.assertEquals(1, (int) backupMetrics.getValidDownloads().actualCount());
         // 2. Verify the queue size is '0' after success.
-        Assert.assertEquals(0, myFileSystem.getDownloadTasksQueued());
+        Assertions.assertEquals(0, myFileSystem.getDownloadTasksQueued());
     }
 
     @Test
@@ -247,10 +247,10 @@ public class TestAbstractFileSystem {
         }
 
         // 2. Success metric is incremented correctly -> exactly 1000 times.
-        Assert.assertEquals(totalFiles, (int) backupMetrics.getValidDownloads().actualCount());
+        Assertions.assertEquals(totalFiles, (int) backupMetrics.getValidDownloads().actualCount());
 
         // 3. The task queue is empty after download is finished.
-        Assert.assertEquals(0, myFileSystem.getDownloadTasksQueued());
+        Assertions.assertEquals(0, myFileSystem.getDownloadTasksQueued());
     }
 
     @Test
@@ -260,7 +260,7 @@ public class TestAbstractFileSystem {
             future.get();
         } catch (Exception e) {
             // Verify the failure metric for upload is incremented.
-            Assert.assertEquals(1, (int) backupMetrics.getInvalidDownloads().count());
+            Assertions.assertEquals(1, (int) backupMetrics.getInvalidDownloads().count());
         }
     }
 

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackup.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackup.java
@@ -31,7 +31,7 @@ import mockit.Mock;
 import mockit.MockUp;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.commons.io.FileUtils;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +46,7 @@ public class TestBackup {
     private static final Logger logger = LoggerFactory.getLogger(TestBackup.class);
     private static final Set<String> expectedFiles = new HashSet<>();
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws InterruptedException, IOException {
         new MockNodeProbe();
         injector = Guice.createInjector(new BRTestModule());
@@ -56,7 +56,7 @@ public class TestBackup {
                                 Key.get(IBackupFileSystem.class, Names.named("backup")));
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() throws IOException {
         File file = new File("target/data");
         FileUtils.deleteQuietly(file);
@@ -91,9 +91,9 @@ public class TestBackup {
         generateIncrementalFiles();
         IncrementalBackup backup = injector.getInstance(IncrementalBackup.class);
         backup.execute();
-        Assert.assertEquals(4, filesystem.uploadedFiles.size());
+        Assertions.assertEquals(4, filesystem.uploadedFiles.size());
         for (String filePath : expectedFiles)
-            Assert.assertTrue(filesystem.uploadedFiles.contains(filePath));
+            Assertions.assertTrue(filesystem.uploadedFiles.contains(filePath));
     }
 
     @Test
@@ -142,9 +142,9 @@ public class TestBackup {
         }
         IncrementalBackup backup = injector.getInstance(IncrementalBackup.class);
         backup.execute();
-        Assert.assertEquals(6, filesystem.uploadedFiles.size());
+        Assertions.assertEquals(6, filesystem.uploadedFiles.size());
         for (String filePath : expectedFiles)
-            Assert.assertTrue(filesystem.uploadedFiles.contains(filePath));
+            Assertions.assertTrue(filesystem.uploadedFiles.contains(filePath));
     }
 
     private static void generateIncrementalFiles() {
@@ -183,7 +183,7 @@ public class TestBackup {
     }
 
     // Mock Nodeprobe class
-    @Ignore
+    @Disabled
     static class MockNodeProbe extends MockUp<NodeProbe> {
 
         @Mock

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackupFile.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackupFile.java
@@ -30,16 +30,16 @@ import java.io.IOException;
 import java.sql.Date;
 import java.text.ParseException;
 import org.apache.commons.io.FileUtils;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestBackupFile {
     private static Injector injector;
     private static String region;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws IOException {
         injector = Guice.createInjector(new BRTestModule());
         File file =
@@ -62,7 +62,7 @@ public class TestBackupFile {
         region = factory.getInstanceInfo().getRegion();
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() throws IOException {
         File file = new File("Keyspace1-Standard1-ia-5-Data.db");
         FileUtils.deleteQuietly(file);
@@ -75,14 +75,14 @@ public class TestBackupFile {
                 "target/data/Keyspace1/Standard1/snapshots/201108082320/Keyspace1-Standard1-ia-5-Data.db";
         RemoteBackupPath backupfile = injector.getInstance(RemoteBackupPath.class);
         backupfile.parseLocal(new File(snapshotfile), BackupFileType.SNAP);
-        Assert.assertEquals(BackupFileType.SNAP, backupfile.type);
-        Assert.assertEquals("Keyspace1", backupfile.keyspace);
-        Assert.assertEquals("Standard1", backupfile.columnFamily);
-        Assert.assertEquals("1234567", backupfile.token);
-        Assert.assertEquals("fake-app", backupfile.clusterName);
-        Assert.assertEquals(region, backupfile.region);
-        Assert.assertEquals("casstestbackup", backupfile.baseDir);
-        Assert.assertEquals(
+        Assertions.assertEquals(BackupFileType.SNAP, backupfile.type);
+        Assertions.assertEquals("Keyspace1", backupfile.keyspace);
+        Assertions.assertEquals("Standard1", backupfile.columnFamily);
+        Assertions.assertEquals("1234567", backupfile.token);
+        Assertions.assertEquals("fake-app", backupfile.clusterName);
+        Assertions.assertEquals(region, backupfile.region);
+        Assertions.assertEquals("casstestbackup", backupfile.baseDir);
+        Assertions.assertEquals(
                 "casstestbackup/"
                         + region
                         + "/fake-app/1234567/201108082320/SNAP/Keyspace1/Standard1/Keyspace1-Standard1-ia-5-Data.db",
@@ -95,15 +95,15 @@ public class TestBackupFile {
         File bfile = new File("target/data/Keyspace1/Standard1/Keyspace1-Standard1-ia-5-Data.db");
         RemoteBackupPath backupfile = injector.getInstance(RemoteBackupPath.class);
         backupfile.parseLocal(bfile, BackupFileType.SST);
-        Assert.assertEquals(BackupFileType.SST, backupfile.type);
-        Assert.assertEquals("Keyspace1", backupfile.keyspace);
-        Assert.assertEquals("Standard1", backupfile.columnFamily);
-        Assert.assertEquals("1234567", backupfile.token);
-        Assert.assertEquals("fake-app", backupfile.clusterName);
-        Assert.assertEquals(region, backupfile.region);
-        Assert.assertEquals("casstestbackup", backupfile.baseDir);
+        Assertions.assertEquals(BackupFileType.SST, backupfile.type);
+        Assertions.assertEquals("Keyspace1", backupfile.keyspace);
+        Assertions.assertEquals("Standard1", backupfile.columnFamily);
+        Assertions.assertEquals("1234567", backupfile.token);
+        Assertions.assertEquals("fake-app", backupfile.clusterName);
+        Assertions.assertEquals(region, backupfile.region);
+        Assertions.assertEquals("casstestbackup", backupfile.baseDir);
         String datestr = DateUtil.formatyyyyMMddHHmm(new Date(bfile.lastModified()));
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 "casstestbackup/"
                         + region
                         + "/fake-app/1234567/"
@@ -120,12 +120,12 @@ public class TestBackupFile {
         RemoteBackupPath backupfile = injector.getInstance(RemoteBackupPath.class);
         backupfile.parseLocal(bfile, BackupFileType.META);
         backupfile.setTime(DateUtil.getDate("201108082320"));
-        Assert.assertEquals(BackupFileType.META, backupfile.type);
-        Assert.assertEquals("1234567", backupfile.token);
-        Assert.assertEquals("fake-app", backupfile.clusterName);
-        Assert.assertEquals(region, backupfile.region);
-        Assert.assertEquals("casstestbackup", backupfile.baseDir);
-        Assert.assertEquals(
+        Assertions.assertEquals(BackupFileType.META, backupfile.type);
+        Assertions.assertEquals("1234567", backupfile.token);
+        Assertions.assertEquals("fake-app", backupfile.clusterName);
+        Assertions.assertEquals(region, backupfile.region);
+        Assertions.assertEquals("casstestbackup", backupfile.baseDir);
+        Assertions.assertEquals(
                 "casstestbackup/" + region + "/fake-app/1234567/201108082320/META/1234567.meta",
                 backupfile.getRemotePath());
     }

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackupService.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackupService.java
@@ -35,9 +35,9 @@ import java.time.Instant;
 import java.util.Set;
 import mockit.Expectations;
 import mockit.Mocked;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.quartz.SchedulerException;
 
 /** Created by aagrawal on 3/10/19. */
@@ -51,7 +51,7 @@ public class TestBackupService {
         this.cassandraTunerService = injector.getInstance(CassandraTunerService.class);
     }
 
-    @Before
+    @BeforeEach
     public void cleanup() throws SchedulerException {
         scheduler.getScheduler().clear();
     }
@@ -98,14 +98,14 @@ public class TestBackupService {
                 new BackupService(
                         configuration, backupRestoreConfig, scheduler, cassandraTunerService);
         backupService.scheduleService();
-        Assert.assertEquals(0, scheduler.getScheduler().getJobKeys(null).size());
+        Assertions.assertEquals(0, scheduler.getScheduler().getJobKeys(null).size());
 
         // snapshot V1 name should not be there.
         Set<Path> backupPaths =
                 AbstractBackup.getBackupDirectories(configuration, AbstractBackup.SNAPSHOT_FOLDER);
         for (Path backupPath : backupPaths) {
-            Assert.assertTrue(Files.exists(Paths.get(backupPath.toString(), snapshotName)));
-            Assert.assertFalse(Files.exists(Paths.get(backupPath.toString(), snapshotV1Name)));
+            Assertions.assertTrue(Files.exists(Paths.get(backupPath.toString(), snapshotName)));
+            Assertions.assertFalse(Files.exists(Paths.get(backupPath.toString(), snapshotV1Name)));
         }
     }
 
@@ -125,7 +125,7 @@ public class TestBackupService {
                 new BackupService(
                         configuration, backupRestoreConfig, scheduler, cassandraTunerService);
         backupService.scheduleService();
-        Assert.assertEquals(2, scheduler.getScheduler().getJobKeys(null).size());
+        Assertions.assertEquals(2, scheduler.getScheduler().getJobKeys(null).size());
     }
 
     @Test
@@ -144,7 +144,7 @@ public class TestBackupService {
                 new BackupService(
                         configuration, backupRestoreConfig, scheduler, cassandraTunerService);
         backupService.scheduleService();
-        Assert.assertEquals(3, scheduler.getScheduler().getJobKeys(null).size());
+        Assertions.assertEquals(3, scheduler.getScheduler().getJobKeys(null).size());
     }
 
     @Test
@@ -173,11 +173,11 @@ public class TestBackupService {
                 new BackupService(
                         configuration, backupRestoreConfig, scheduler, cassandraTunerService);
         backupService.scheduleService();
-        Assert.assertEquals(3, scheduler.getScheduler().getJobKeys(null).size());
+        Assertions.assertEquals(3, scheduler.getScheduler().getJobKeys(null).size());
 
         System.out.println("After updated");
         backupService.onChangeUpdateService();
         System.out.println(scheduler.getScheduler().getJobKeys(null));
-        Assert.assertEquals(2, scheduler.getScheduler().getJobKeys(null).size());
+        Assertions.assertEquals(2, scheduler.getScheduler().getJobKeys(null).size());
     }
 }

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackupStatusMgr.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackupStatusMgr.java
@@ -31,11 +31,7 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
 import org.joda.time.DateTime;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +42,7 @@ public class TestBackupStatusMgr {
     private static IBackupStatusMgr backupStatusMgr;
     private final String backupDate = "201812011000";
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         Injector injector = Guice.createInjector(new BRTestModule());
         // cleanup old saved file, if any
@@ -54,8 +50,8 @@ public class TestBackupStatusMgr {
         backupStatusMgr = injector.getInstance(IBackupStatusMgr.class);
     }
 
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void cleanup() {
         FileUtils.deleteQuietly(new File(configuration.getBackupStatusFileLoc()));
     }
@@ -91,15 +87,15 @@ public class TestBackupStatusMgr {
         backupStatusMgr.start(backupMetadata);
         Optional<BackupMetadata> backupMetadata1 =
                 backupStatusMgr.locate(startTime).stream().findFirst();
-        Assert.assertNull(backupMetadata1.get().getLastValidated());
+        Assertions.assertNull(backupMetadata1.get().getLastValidated());
         backupMetadata.setLastValidated(Calendar.getInstance().getTime());
         backupMetadata.setCassandraSnapshotSuccess(true);
         backupMetadata.setSnapshotLocation("random");
         backupStatusMgr.update(backupMetadata);
         backupMetadata1 = backupStatusMgr.locate(startTime).stream().findFirst();
-        Assert.assertNotNull(backupMetadata1.get().getLastValidated());
-        Assert.assertTrue(backupMetadata1.get().isCassandraSnapshotSuccess());
-        Assert.assertEquals("random", backupMetadata1.get().getSnapshotLocation());
+        Assertions.assertNotNull(backupMetadata1.get().getLastValidated());
+        Assertions.assertTrue(backupMetadata1.get().isCassandraSnapshotSuccess());
+        Assertions.assertEquals("random", backupMetadata1.get().getSnapshotLocation());
     }
 
     @Test
@@ -110,19 +106,19 @@ public class TestBackupStatusMgr {
                 new BackupMetadata(BackupVersion.SNAPSHOT_BACKUP, "123", startTime);
         backupStatusMgr.start(backupMetadata);
         List<BackupMetadata> metadataList = backupStatusMgr.locate(startTime);
-        Assert.assertNotNull(metadataList);
-        Assert.assertTrue(!metadataList.isEmpty());
-        Assert.assertEquals(1, metadataList.size());
-        Assert.assertEquals(startTime, metadataList.get(0).getStart());
+        Assertions.assertNotNull(metadataList);
+        Assertions.assertTrue(!metadataList.isEmpty());
+        Assertions.assertEquals(1, metadataList.size());
+        Assertions.assertEquals(startTime, metadataList.get(0).getStart());
         logger.info("Snapshot start: {}", metadataList.get(0));
 
         backupStatusMgr.finish(backupMetadata);
         metadataList = backupStatusMgr.locate(startTime);
-        Assert.assertNotNull(metadataList);
-        Assert.assertTrue(!metadataList.isEmpty());
-        Assert.assertEquals(1, metadataList.size());
-        Assert.assertEquals(Status.FINISHED, metadataList.get(0).getStatus());
-        Assert.assertTrue(metadataList.get(0).getCompleted() != null);
+        Assertions.assertNotNull(metadataList);
+        Assertions.assertTrue(!metadataList.isEmpty());
+        Assertions.assertEquals(1, metadataList.size());
+        Assertions.assertEquals(Status.FINISHED, metadataList.get(0).getStatus());
+        Assertions.assertTrue(metadataList.get(0).getCompleted() != null);
         logger.info("Snapshot finished: {}", metadataList.get(0));
     }
 
@@ -134,19 +130,19 @@ public class TestBackupStatusMgr {
                 new BackupMetadata(BackupVersion.SNAPSHOT_BACKUP, "123", startTime);
         backupStatusMgr.start(backupMetadata);
         List<BackupMetadata> metadataList = backupStatusMgr.locate(startTime);
-        Assert.assertNotNull(metadataList);
-        Assert.assertTrue(!metadataList.isEmpty());
-        Assert.assertEquals(1, metadataList.size());
-        Assert.assertEquals(startTime, metadataList.get(0).getStart());
+        Assertions.assertNotNull(metadataList);
+        Assertions.assertTrue(!metadataList.isEmpty());
+        Assertions.assertEquals(1, metadataList.size());
+        Assertions.assertEquals(startTime, metadataList.get(0).getStart());
         logger.info("Snapshot start: {}", metadataList.get(0));
 
         backupStatusMgr.failed(backupMetadata);
         metadataList = backupStatusMgr.locate(startTime);
-        Assert.assertNotNull(metadataList);
-        Assert.assertTrue(!metadataList.isEmpty());
-        Assert.assertEquals(1, metadataList.size());
-        Assert.assertEquals(Status.FAILED, metadataList.get(0).getStatus());
-        Assert.assertTrue(metadataList.get(0).getCompleted() != null);
+        Assertions.assertNotNull(metadataList);
+        Assertions.assertTrue(!metadataList.isEmpty());
+        Assertions.assertEquals(1, metadataList.size());
+        Assertions.assertEquals(Status.FAILED, metadataList.get(0).getStatus());
+        Assertions.assertTrue(metadataList.get(0).getCompleted() != null);
         logger.info("Snapshot failed: {}", metadataList.get(0));
     }
 
@@ -165,7 +161,7 @@ public class TestBackupStatusMgr {
         }
 
         List<BackupMetadata> metadataList = backupStatusMgr.locate(startTime);
-        Assert.assertEquals(noOfEntries, metadataList.size());
+        Assertions.assertEquals(noOfEntries, metadataList.size());
         logger.info(metadataList.toString());
 
         // Ensure that list is always maintained from latest to eldest
@@ -173,7 +169,7 @@ public class TestBackupStatusMgr {
         for (BackupMetadata backupMetadata : metadataList) {
             if (latest == null) latest = backupMetadata.getStart();
             else {
-                Assert.assertTrue(backupMetadata.getStart().before(latest));
+                Assertions.assertTrue(backupMetadata.getStart().before(latest));
                 latest = backupMetadata.getStart();
             }
         }
@@ -194,7 +190,7 @@ public class TestBackupStatusMgr {
         }
 
         // Verify there is only capacity entries
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 backupStatusMgr.getCapacity(), backupStatusMgr.getAllSnapshotStatus().size());
     }
 
@@ -213,7 +209,7 @@ public class TestBackupStatusMgr {
                                                 start.plus(12, ChronoUnit.HOURS))));
 
         Optional<BackupMetadata> backupMetadata = list.stream().findFirst();
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 start.plus(4, ChronoUnit.HOURS), backupMetadata.get().getStart().toInstant());
     }
 
@@ -227,7 +223,7 @@ public class TestBackupStatusMgr {
                         .stream()
                         .findFirst();
 
-        Assert.assertFalse(backupMetadata.isPresent());
+        Assertions.assertFalse(backupMetadata.isPresent());
 
         backupStatusMgr.failed(getBackupMetaData(DateUtil.parseInstant(backupDate), Status.FAILED));
         backupMetadata =
@@ -237,7 +233,7 @@ public class TestBackupStatusMgr {
                                 new DateRange(backupDate + "," + backupDate))
                         .stream()
                         .findFirst();
-        Assert.assertFalse(backupMetadata.isPresent());
+        Assertions.assertFalse(backupMetadata.isPresent());
     }
 
     @Test

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackupVerification.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackupVerification.java
@@ -38,10 +38,10 @@ import java.util.Optional;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Created by aagrawal on 1/23/19. */
 public class TestBackupVerification {
@@ -83,8 +83,8 @@ public class TestBackupVerification {
         }
     }
 
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void cleanup() {
         new MockMetaV1Proxy();
         new MockMetaV2Proxy();
@@ -95,9 +95,9 @@ public class TestBackupVerification {
     public void illegalDateRange() throws UnsupportedTypeException {
         try {
             backupVerification.verifyBackup(BackupVersion.SNAPSHOT_BACKUP, false, null);
-            Assert.assertTrue(false);
+            Assertions.assertTrue(false);
         } catch (IllegalArgumentException e) {
-            Assert.assertTrue(true);
+            Assertions.assertTrue(true);
         }
     }
 
@@ -105,9 +105,9 @@ public class TestBackupVerification {
     public void illegalDateRangeBackupDateRange() throws UnsupportedTypeException {
         try {
             backupVerification.verifyAllBackups(BackupVersion.SNAPSHOT_BACKUP, null);
-            Assert.assertTrue(false);
+            Assertions.assertTrue(false);
         } catch (IllegalArgumentException e) {
-            Assert.assertTrue(true);
+            Assertions.assertTrue(true);
         }
     }
 
@@ -118,14 +118,14 @@ public class TestBackupVerification {
                         BackupVersion.SNAPSHOT_BACKUP,
                         false,
                         new DateRange(Instant.now(), Instant.now()));
-        Assert.assertFalse(backupVerificationResultOptinal.isPresent());
+        Assertions.assertFalse(backupVerificationResultOptinal.isPresent());
 
         backupVerificationResultOptinal =
                 backupVerification.verifyBackup(
                         BackupVersion.SNAPSHOT_META_SERVICE,
                         false,
                         new DateRange(Instant.now(), Instant.now()));
-        Assert.assertFalse(backupVerificationResultOptinal.isPresent());
+        Assertions.assertFalse(backupVerificationResultOptinal.isPresent());
     }
 
     @Test
@@ -133,13 +133,13 @@ public class TestBackupVerification {
         List<BackupVerificationResult> backupVerificationResults =
                 backupVerification.verifyAllBackups(
                         BackupVersion.SNAPSHOT_BACKUP, new DateRange(Instant.now(), Instant.now()));
-        Assert.assertFalse(backupVerificationResults.size() > 0);
+        Assertions.assertFalse(backupVerificationResults.size() > 0);
 
         backupVerificationResults =
                 backupVerification.verifyAllBackups(
                         BackupVersion.SNAPSHOT_META_SERVICE,
                         new DateRange(Instant.now(), Instant.now()));
-        Assert.assertFalse(backupVerificationResults.size() > 0);
+        Assertions.assertFalse(backupVerificationResults.size() > 0);
     }
 
     private void setUp() throws Exception {
@@ -178,8 +178,9 @@ public class TestBackupVerification {
                         BackupVersion.SNAPSHOT_BACKUP,
                         false,
                         new DateRange(backupDate + "," + backupDate));
-        Assert.assertTrue(backupVerificationResultOptinal.isPresent());
-        Assert.assertEquals(Instant.EPOCH, backupVerificationResultOptinal.get().snapshotInstant);
+        Assertions.assertTrue(backupVerificationResultOptinal.isPresent());
+        Assertions.assertEquals(
+                Instant.EPOCH, backupVerificationResultOptinal.get().snapshotInstant);
         Optional<BackupMetadata> backupMetadata =
                 backupStatusMgr
                         .getLatestBackupMetadata(
@@ -187,8 +188,8 @@ public class TestBackupVerification {
                                 new DateRange(backupDate + "," + backupDate))
                         .stream()
                         .findFirst();
-        Assert.assertTrue(backupMetadata.isPresent());
-        Assert.assertNotNull(backupMetadata.get().getLastValidated());
+        Assertions.assertTrue(backupMetadata.isPresent());
+        Assertions.assertNotNull(backupMetadata.get().getLastValidated());
 
         backupMetadata =
                 backupStatusMgr
@@ -197,8 +198,8 @@ public class TestBackupVerification {
                                 new DateRange(backupDate + "," + backupDate))
                         .stream()
                         .findFirst();
-        Assert.assertTrue(backupMetadata.isPresent());
-        Assert.assertNull(backupMetadata.get().getLastValidated());
+        Assertions.assertTrue(backupMetadata.isPresent());
+        Assertions.assertNull(backupMetadata.get().getLastValidated());
     }
 
     @Test
@@ -209,26 +210,26 @@ public class TestBackupVerification {
                 backupVerification.verifyAllBackups(
                         BackupVersion.SNAPSHOT_BACKUP,
                         new DateRange(backupDate + "," + backupDateEnd));
-        Assert.assertTrue(!backupVerificationResults.isEmpty());
-        Assert.assertTrue(backupVerificationResults.size() == numFakeBackups);
+        Assertions.assertTrue(!backupVerificationResults.isEmpty());
+        Assertions.assertTrue(backupVerificationResults.size() == numFakeBackups);
         backupVerificationResults
                 .stream()
-                .forEach(b -> Assert.assertEquals(Instant.EPOCH, b.snapshotInstant));
+                .forEach(b -> Assertions.assertEquals(Instant.EPOCH, b.snapshotInstant));
         List<BackupMetadata> backupMetadata =
                 backupStatusMgr.getLatestBackupMetadata(
                         BackupVersion.SNAPSHOT_BACKUP,
                         new DateRange(backupDate + "," + backupDateEnd));
-        Assert.assertTrue(!backupMetadata.isEmpty());
-        Assert.assertTrue(backupMetadata.size() == numFakeBackups);
-        backupMetadata.stream().forEach(b -> Assert.assertNotNull(b.getLastValidated()));
+        Assertions.assertTrue(!backupMetadata.isEmpty());
+        Assertions.assertTrue(backupMetadata.size() == numFakeBackups);
+        backupMetadata.stream().forEach(b -> Assertions.assertNotNull(b.getLastValidated()));
 
         backupMetadata =
                 backupStatusMgr.getLatestBackupMetadata(
                         BackupVersion.SNAPSHOT_META_SERVICE,
                         new DateRange(backupDate + "," + backupDateEnd));
-        Assert.assertTrue(!backupMetadata.isEmpty());
-        Assert.assertTrue(backupMetadata.size() == numFakeBackups);
-        backupMetadata.stream().forEach(b -> Assert.assertNull(b.getLastValidated()));
+        Assertions.assertTrue(!backupMetadata.isEmpty());
+        Assertions.assertTrue(backupMetadata.size() == numFakeBackups);
+        backupMetadata.stream().forEach(b -> Assertions.assertNull(b.getLastValidated()));
     }
 
     @Test
@@ -240,9 +241,10 @@ public class TestBackupVerification {
                         BackupVersion.SNAPSHOT_META_SERVICE,
                         false,
                         new DateRange(backupDate + "," + backupDate));
-        Assert.assertTrue(backupVerificationResultOptinal.isPresent());
-        Assert.assertEquals(Instant.EPOCH, backupVerificationResultOptinal.get().snapshotInstant);
-        Assert.assertEquals("some_random", backupVerificationResultOptinal.get().remotePath);
+        Assertions.assertTrue(backupVerificationResultOptinal.isPresent());
+        Assertions.assertEquals(
+                Instant.EPOCH, backupVerificationResultOptinal.get().snapshotInstant);
+        Assertions.assertEquals("some_random", backupVerificationResultOptinal.get().remotePath);
 
         Optional<BackupMetadata> backupMetadata =
                 backupStatusMgr
@@ -251,8 +253,8 @@ public class TestBackupVerification {
                                 new DateRange(backupDate + "," + backupDate))
                         .stream()
                         .findFirst();
-        Assert.assertTrue(backupMetadata.isPresent());
-        Assert.assertNotNull(backupMetadata.get().getLastValidated());
+        Assertions.assertTrue(backupMetadata.isPresent());
+        Assertions.assertNotNull(backupMetadata.get().getLastValidated());
 
         // Retry the verification, it should not try and re-verify
         backupVerificationResultOptinal =
@@ -260,12 +262,12 @@ public class TestBackupVerification {
                         BackupVersion.SNAPSHOT_META_SERVICE,
                         false,
                         new DateRange(backupDate + "," + backupDate));
-        Assert.assertTrue(backupVerificationResultOptinal.isPresent());
-        Assert.assertEquals(
+        Assertions.assertTrue(backupVerificationResultOptinal.isPresent());
+        Assertions.assertEquals(
                 DateUtil.parseInstant(backupDate),
                 backupVerificationResultOptinal.get().snapshotInstant);
-        Assert.assertNotEquals("some_random", backupVerificationResultOptinal.get().remotePath);
-        Assert.assertEquals(
+        Assertions.assertNotEquals("some_random", backupVerificationResultOptinal.get().remotePath);
+        Assertions.assertEquals(
                 location.subpath(1, location.getNameCount()).toString(),
                 backupVerificationResultOptinal.get().remotePath);
 
@@ -276,8 +278,8 @@ public class TestBackupVerification {
                                 new DateRange(backupDate + "," + backupDate))
                         .stream()
                         .findFirst();
-        Assert.assertTrue(backupMetadata.isPresent());
-        Assert.assertNull(backupMetadata.get().getLastValidated());
+        Assertions.assertTrue(backupMetadata.isPresent());
+        Assertions.assertNull(backupMetadata.get().getLastValidated());
     }
 
     @Test
@@ -288,26 +290,26 @@ public class TestBackupVerification {
                 backupVerification.verifyAllBackups(
                         BackupVersion.SNAPSHOT_META_SERVICE,
                         new DateRange(backupDate + "," + backupDateEnd));
-        Assert.assertTrue(!backupVerificationResults.isEmpty());
-        Assert.assertTrue(backupVerificationResults.size() == numFakeBackups);
+        Assertions.assertTrue(!backupVerificationResults.isEmpty());
+        Assertions.assertTrue(backupVerificationResults.size() == numFakeBackups);
         backupVerificationResults
                 .stream()
-                .forEach(b -> Assert.assertEquals(Instant.EPOCH, b.snapshotInstant));
+                .forEach(b -> Assertions.assertEquals(Instant.EPOCH, b.snapshotInstant));
         List<BackupMetadata> backupMetadata =
                 backupStatusMgr.getLatestBackupMetadata(
                         BackupVersion.SNAPSHOT_META_SERVICE,
                         new DateRange(backupDate + "," + backupDateEnd));
-        Assert.assertTrue(!backupMetadata.isEmpty());
-        Assert.assertTrue(backupMetadata.size() == numFakeBackups);
-        backupMetadata.stream().forEach(b -> Assert.assertNotNull(b.getLastValidated()));
+        Assertions.assertTrue(!backupMetadata.isEmpty());
+        Assertions.assertTrue(backupMetadata.size() == numFakeBackups);
+        backupMetadata.stream().forEach(b -> Assertions.assertNotNull(b.getLastValidated()));
 
         backupMetadata =
                 backupStatusMgr.getLatestBackupMetadata(
                         BackupVersion.SNAPSHOT_BACKUP,
                         new DateRange(backupDate + "," + backupDateEnd));
-        Assert.assertTrue(!backupMetadata.isEmpty());
-        Assert.assertTrue(backupMetadata.size() == numFakeBackups);
-        backupMetadata.stream().forEach(b -> Assert.assertNull(b.getLastValidated()));
+        Assertions.assertTrue(!backupMetadata.isEmpty());
+        Assertions.assertTrue(backupMetadata.size() == numFakeBackups);
+        backupMetadata.stream().forEach(b -> Assertions.assertNull(b.getLastValidated()));
     }
 
     private BackupMetadata getBackupMetaData(
@@ -334,6 +336,6 @@ public class TestBackupVerification {
     @Test
     public void testGetMetaProxy() {
         IMetaProxy metaProxy = backupVerification.getMetaProxy(BackupVersion.SNAPSHOT_META_SERVICE);
-        Assert.assertTrue(metaProxy != null);
+        Assertions.assertTrue(metaProxy != null);
     }
 }

--- a/priam/src/test/java/com/netflix/priam/backup/TestCompression.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestCompression.java
@@ -17,8 +17,8 @@
 
 package com.netflix.priam.backup;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.netflix.priam.compress.ChunkedStream;
 import com.netflix.priam.compress.CompressionType;
@@ -32,15 +32,15 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestCompression {
 
     private final File randomContentFile = new File("/tmp/content.txt");
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
         try (FileOutputStream stream = new FileOutputStream(randomContentFile)) {
             for (int i = 0; i < (5 * 5); i++) {
@@ -54,7 +54,7 @@ public class TestCompression {
         }
     }
 
-    @After
+    @AfterEach
     public void done() {
         FileUtils.deleteQuietly(randomContentFile);
     }

--- a/priam/src/test/java/com/netflix/priam/backup/TestCustomizedTPE.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestCustomizedTPE.java
@@ -21,8 +21,8 @@ import com.netflix.priam.scheduler.BlockingSubmitThreadPoolExecutor;
 import java.util.concurrent.Callable;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +48,7 @@ public class TestCustomizedTPE {
                             });
         }
         startTest.sleepTillEmpty();
-        Assert.assertEquals(100, count.get());
+        Assertions.assertEquals(100, count.get());
     }
 
     @Test
@@ -67,6 +67,6 @@ public class TestCustomizedTPE {
         } catch (RuntimeException ex) {
             success = true;
         }
-        Assert.assertTrue("Failure to timeout...", success);
+        Assertions.assertTrue(success, "Failure to timeout...");
     }
 }

--- a/priam/src/test/java/com/netflix/priam/backup/TestFileIterator.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestFileIterator.java
@@ -31,10 +31,10 @@ import java.io.IOException;
 import java.util.*;
 import mockit.Mock;
 import mockit.MockUp;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for backup file iterator
@@ -48,7 +48,7 @@ public class TestFileIterator {
     private static String region;
     private static String bucket = "TESTBUCKET";
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws InterruptedException, IOException {
         AmazonS3Client s3client = new MockAmazonS3Client().getMockInstance();
         new MockObjectListing();
@@ -85,7 +85,7 @@ public class TestFileIterator {
     }
 
     // MockObjectListing class
-    @Ignore
+    @Disabled
     static class MockObjectListing extends MockUp<ObjectListing> {
         static boolean truncated = true;
         static boolean firstcall = true;
@@ -121,7 +121,7 @@ public class TestFileIterator {
         Iterator<AbstractBackupPath> fileIterator = s3FileSystem.list(bucket, stime, etime);
         Set<String> files = new HashSet<>();
         while (fileIterator.hasNext()) files.add(fileIterator.next().getRemotePath());
-        Assert.assertEquals(0, files.size());
+        Assertions.assertEquals(0, files.size());
     }
 
     @Test
@@ -134,23 +134,23 @@ public class TestFileIterator {
 
         Set<String> files = new HashSet<>();
         while (fileIterator.hasNext()) files.add(fileIterator.next().getRemotePath());
-        Assert.assertEquals(3, files.size());
-        Assert.assertTrue(
+        Assertions.assertEquals(3, files.size());
+        Assertions.assertTrue(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110030/SNAP/ks1/cf1/f1.db"));
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110430/SST/ks1/cf1/f2.db"));
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110030/META/meta.json"));
-        Assert.assertFalse(
+        Assertions.assertFalse(
                 files.contains(
                         "test_backup/"
                                 + region
@@ -167,39 +167,39 @@ public class TestFileIterator {
 
         Set<String> files = new HashSet<>();
         while (fileIterator.hasNext()) files.add(fileIterator.next().getRemotePath());
-        Assert.assertEquals(5, files.size());
-        Assert.assertTrue(
+        Assertions.assertEquals(5, files.size());
+        Assertions.assertTrue(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110030/SNAP/ks1/cf1/f1.db"));
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110430/SST/ks1/cf1/f2.db"));
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110030/META/meta.json"));
-        Assert.assertFalse(
+        Assertions.assertFalse(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110600/SST/ks1/cf1/f3.db"));
 
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110030/SNAP/ks2/cf1/f1.db"));
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110430/SST/ks2/cf1/f2.db"));
-        Assert.assertFalse(
+        Assertions.assertFalse(
                 files.contains(
                         "test_backup/"
                                 + region
@@ -216,39 +216,39 @@ public class TestFileIterator {
 
         Set<String> files = new HashSet<>();
         while (fileIterator.hasNext()) files.add(fileIterator.next().getRemotePath());
-        Assert.assertEquals(2, files.size());
-        Assert.assertFalse(
+        Assertions.assertEquals(2, files.size());
+        Assertions.assertFalse(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201107110030/SNAP/ks1/cf1/f1.db"));
-        Assert.assertFalse(
+        Assertions.assertFalse(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201107110430/SST/ks1/cf1/f2.db"));
-        Assert.assertFalse(
+        Assertions.assertFalse(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201107110030/META/meta.json"));
-        Assert.assertFalse(
+        Assertions.assertFalse(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201107110600/SST/ks1/cf1/f3.db"));
 
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110030/SNAP/ks2/cf1/f1.db"));
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110430/SST/ks2/cf1/f2.db"));
-        Assert.assertFalse(
+        Assertions.assertFalse(
                 files.contains(
                         "test_backup/"
                                 + region
@@ -271,39 +271,39 @@ public class TestFileIterator {
         while (fileIterator.hasNext()) files.add(fileIterator.next().getRemotePath());
         while (fileIterator.hasNext()) files.add(fileIterator.next().getRemotePath());
 
-        Assert.assertEquals(5, files.size());
-        Assert.assertTrue(
+        Assertions.assertEquals(5, files.size());
+        Assertions.assertTrue(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110030/SNAP/ks1/cf1/f1.db"));
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110430/SST/ks1/cf1/f2.db"));
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110030/META/meta.json"));
-        Assert.assertFalse(
+        Assertions.assertFalse(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110600/SST/ks1/cf1/f3.db"));
 
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110030/SNAP/ks2/cf1/f1.db"));
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 files.contains(
                         "test_backup/"
                                 + region
                                 + "/fakecluster/123456/201108110430/SST/ks2/cf1/f2.db"));
-        Assert.assertFalse(
+        Assertions.assertFalse(
                 files.contains(
                         "test_backup/"
                                 + region

--- a/priam/src/test/java/com/netflix/priam/backup/TestS3FileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestS3FileSystem.java
@@ -51,10 +51,10 @@ import java.util.stream.Collectors;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.commons.io.FileUtils;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,14 +77,14 @@ public class TestS3FileSystem {
         region = instanceInfo.getRegion();
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         new MockS3PartUploader();
         new MockAmazonS3Client();
         if (!DIR.exists()) DIR.mkdirs();
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() throws IOException {
         FileUtils.cleanDirectory(DIR);
     }
@@ -97,7 +97,7 @@ public class TestS3FileSystem {
         backupfile.parseLocal(localFile(), BackupFileType.SNAP);
         long noOfFilesUploaded = backupMetrics.getUploadRate().count();
         fs.uploadAndDelete(backupfile, 0);
-        Assert.assertEquals(1, backupMetrics.getUploadRate().count() - noOfFilesUploaded);
+        Assertions.assertEquals(1, backupMetrics.getUploadRate().count() - noOfFilesUploaded);
     }
 
     @Test
@@ -107,12 +107,12 @@ public class TestS3FileSystem {
         RemoteBackupPath backupfile = injector.getInstance(RemoteBackupPath.class);
         backupfile.parseLocal(localFile(), BackupFileType.SST_V2);
         fs.uploadAndDelete(backupfile, 0);
-        Assert.assertTrue(fs.checkObjectExists(Paths.get(backupfile.getRemotePath())));
+        Assertions.assertTrue(fs.checkObjectExists(Paths.get(backupfile.getRemotePath())));
         // Lets delete the file now.
         List<Path> deleteFiles = Lists.newArrayList();
         deleteFiles.add(Paths.get(backupfile.getRemotePath()));
         fs.deleteRemoteFiles(deleteFiles);
-        Assert.assertFalse(fs.checkObjectExists(Paths.get(backupfile.getRemotePath())));
+        Assertions.assertFalse(fs.checkObjectExists(Paths.get(backupfile.getRemotePath())));
     }
 
     @Test
@@ -128,8 +128,8 @@ public class TestS3FileSystem {
         } catch (BackupRestoreException e) {
             // ignore
         }
-        Assert.assertEquals(0, MockS3PartUploader.compattempts);
-        Assert.assertEquals(1, backupMetrics.getInvalidUploads().count() - noOfFailures);
+        Assertions.assertEquals(0, MockS3PartUploader.compattempts);
+        Assertions.assertEquals(1, backupMetrics.getInvalidUploads().count() - noOfFailures);
     }
 
     @Test
@@ -152,10 +152,10 @@ public class TestS3FileSystem {
         MockAmazonS3Client.setRuleAvailable(false);
         S3FileSystem fs = injector.getInstance(S3FileSystem.class);
         fs.cleanup();
-        Assert.assertEquals(1, MockAmazonS3Client.bconf.getRules().size());
+        Assertions.assertEquals(1, MockAmazonS3Client.bconf.getRules().size());
         BucketLifecycleConfiguration.Rule rule = MockAmazonS3Client.bconf.getRules().get(0);
-        Assert.assertEquals("casstestbackup/" + region + "/fake-app/", rule.getId());
-        Assert.assertEquals(configuration.getBackupRetentionDays(), rule.getExpirationInDays());
+        Assertions.assertEquals("casstestbackup/" + region + "/fake-app/", rule.getId());
+        Assertions.assertEquals(configuration.getBackupRetentionDays(), rule.getExpirationInDays());
     }
 
     @Test
@@ -163,10 +163,10 @@ public class TestS3FileSystem {
         MockAmazonS3Client.setRuleAvailable(true);
         S3FileSystem fs = injector.getInstance(S3FileSystem.class);
         fs.cleanup();
-        Assert.assertEquals(1, MockAmazonS3Client.bconf.getRules().size());
+        Assertions.assertEquals(1, MockAmazonS3Client.bconf.getRules().size());
         BucketLifecycleConfiguration.Rule rule = MockAmazonS3Client.bconf.getRules().get(0);
-        Assert.assertEquals("casstestbackup/" + region + "/fake-app/", rule.getId());
-        Assert.assertEquals(configuration.getBackupRetentionDays(), rule.getExpirationInDays());
+        Assertions.assertEquals("casstestbackup/" + region + "/fake-app/", rule.getId());
+        Assertions.assertEquals(configuration.getBackupRetentionDays(), rule.getExpirationInDays());
     }
 
     @Test
@@ -177,10 +177,10 @@ public class TestS3FileSystem {
         MockAmazonS3Client.updateRule(
                 MockAmazonS3Client.getBucketLifecycleConfig(clusterPrefix, 2));
         fs.cleanup();
-        Assert.assertEquals(1, MockAmazonS3Client.bconf.getRules().size());
+        Assertions.assertEquals(1, MockAmazonS3Client.bconf.getRules().size());
         BucketLifecycleConfiguration.Rule rule = MockAmazonS3Client.bconf.getRules().get(0);
-        Assert.assertEquals("casstestbackup/" + region + "/fake-app/", rule.getId());
-        Assert.assertEquals(configuration.getBackupRetentionDays(), rule.getExpirationInDays());
+        Assertions.assertEquals("casstestbackup/" + region + "/fake-app/", rule.getId());
+        Assertions.assertEquals(configuration.getBackupRetentionDays(), rule.getExpirationInDays());
     }
 
     @Test
@@ -198,9 +198,9 @@ public class TestS3FileSystem {
         try {
             MockAmazonS3Client.emulateError = true;
             fs.deleteRemoteFiles(filesToDelete);
-            Assert.assertTrue(false);
+            Assertions.assertTrue(false);
         } catch (BackupRestoreException e) {
-            Assert.assertTrue(true);
+            Assertions.assertTrue(true);
         }
     }
 

--- a/priam/src/test/java/com/netflix/priam/backup/identity/DoubleRingTest.java
+++ b/priam/src/test/java/com/netflix/priam/backup/identity/DoubleRingTest.java
@@ -17,7 +17,7 @@
 
 package com.netflix.priam.backup.identity;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -25,7 +25,7 @@ import com.netflix.priam.identity.DoubleRing;
 import com.netflix.priam.identity.InstanceIdentity;
 import com.netflix.priam.identity.PriamInstance;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DoubleRingTest extends InstanceTestUtils {
 

--- a/priam/src/test/java/com/netflix/priam/backup/identity/InstanceIdentityTest.java
+++ b/priam/src/test/java/com/netflix/priam/backup/identity/InstanceIdentityTest.java
@@ -17,13 +17,13 @@
 
 package com.netflix.priam.backup.identity;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import com.netflix.priam.identity.DoubleRing;
 import com.netflix.priam.identity.InstanceIdentity;
 import com.netflix.priam.identity.PriamInstance;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class InstanceIdentityTest extends InstanceTestUtils {
 

--- a/priam/src/test/java/com/netflix/priam/backup/identity/InstanceTestUtils.java
+++ b/priam/src/test/java/com/netflix/priam/backup/identity/InstanceTestUtils.java
@@ -28,10 +28,10 @@ import com.netflix.priam.utils.Sleeper;
 import com.netflix.priam.utils.TokenManager;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 
-@Ignore
+@Disabled
 abstract class InstanceTestUtils {
 
     private final List<String> instances = new ArrayList<>();
@@ -44,7 +44,7 @@ abstract class InstanceTestUtils {
     InstanceInfo instanceInfo;
     private final String region = "us-east-1";
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         instances.add("fakeinstance1");
         instances.add("fakeinstance2");

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestBackupTTLTask.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestBackupTTLTask.java
@@ -40,9 +40,9 @@ import java.util.List;
 import java.util.Map;
 import mockit.Expectations;
 import mockit.Mocked;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /** Created by aagrawal on 12/17/18. */
 public class TestBackupTTLTask {
@@ -135,7 +135,7 @@ public class TestBackupTTLTask {
         return path.getRemotePath();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         BackupFileUtils.cleanupDir(Paths.get(configuration.getDataFileLocation()));
         backupFileSystem.cleanup();
@@ -157,19 +157,19 @@ public class TestBackupTTLTask {
         List<String> remoteFiles = getAllFiles();
 
         // Confirm the files.
-        Assert.assertEquals(8, remoteFiles.size());
-        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-4-Data.db")));
-        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-5-Data.db")));
-        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-6-Data.db")));
-        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-7-Data.db")));
-        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-1-Data.db")));
-        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("META1")));
-        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("META2")));
+        Assertions.assertEquals(8, remoteFiles.size());
+        Assertions.assertTrue(remoteFiles.contains(allFilesMap.get("mc-4-Data.db")));
+        Assertions.assertTrue(remoteFiles.contains(allFilesMap.get("mc-5-Data.db")));
+        Assertions.assertTrue(remoteFiles.contains(allFilesMap.get("mc-6-Data.db")));
+        Assertions.assertTrue(remoteFiles.contains(allFilesMap.get("mc-7-Data.db")));
+        Assertions.assertTrue(remoteFiles.contains(allFilesMap.get("mc-1-Data.db")));
+        Assertions.assertTrue(remoteFiles.contains(allFilesMap.get("META1")));
+        Assertions.assertTrue(remoteFiles.contains(allFilesMap.get("META2")));
         // Remains because of GRACE PERIOD.
-        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-3-Data.db")));
+        Assertions.assertTrue(remoteFiles.contains(allFilesMap.get("mc-3-Data.db")));
 
-        Assert.assertFalse(remoteFiles.contains(allFilesMap.get("mc-2-Data.db")));
-        Assert.assertFalse(remoteFiles.contains(allFilesMap.get("META0")));
+        Assertions.assertFalse(remoteFiles.contains(allFilesMap.get("mc-2-Data.db")));
+        Assertions.assertFalse(remoteFiles.contains(allFilesMap.get("META0")));
     }
 
     @Test
@@ -181,19 +181,19 @@ public class TestBackupTTLTask {
 
         List<String> remoteFiles = getAllFiles();
         // Confirm the files.
-        Assert.assertEquals(6, remoteFiles.size());
-        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-4-Data.db")));
-        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-6-Data.db")));
-        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-7-Data.db")));
-        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("META2")));
+        Assertions.assertEquals(6, remoteFiles.size());
+        Assertions.assertTrue(remoteFiles.contains(allFilesMap.get("mc-4-Data.db")));
+        Assertions.assertTrue(remoteFiles.contains(allFilesMap.get("mc-6-Data.db")));
+        Assertions.assertTrue(remoteFiles.contains(allFilesMap.get("mc-7-Data.db")));
+        Assertions.assertTrue(remoteFiles.contains(allFilesMap.get("META2")));
         // GRACE PERIOD files.
-        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-3-Data.db")));
-        Assert.assertTrue(remoteFiles.contains(allFilesMap.get("mc-5-Data.db")));
+        Assertions.assertTrue(remoteFiles.contains(allFilesMap.get("mc-3-Data.db")));
+        Assertions.assertTrue(remoteFiles.contains(allFilesMap.get("mc-5-Data.db")));
 
-        Assert.assertFalse(remoteFiles.contains(allFilesMap.get("mc-1-Data.db")));
-        Assert.assertFalse(remoteFiles.contains(allFilesMap.get("mc-2-Data.db")));
-        Assert.assertFalse(remoteFiles.contains(allFilesMap.get("META0")));
-        Assert.assertFalse(remoteFiles.contains(allFilesMap.get("META1")));
+        Assertions.assertFalse(remoteFiles.contains(allFilesMap.get("mc-1-Data.db")));
+        Assertions.assertFalse(remoteFiles.contains(allFilesMap.get("mc-2-Data.db")));
+        Assertions.assertFalse(remoteFiles.contains(allFilesMap.get("META0")));
+        Assertions.assertFalse(remoteFiles.contains(allFilesMap.get("META1")));
     }
 
     @Test

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestBackupV2Service.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestBackupV2Service.java
@@ -37,9 +37,9 @@ import java.time.Instant;
 import java.util.Set;
 import mockit.Expectations;
 import mockit.Mocked;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.quartz.SchedulerException;
 
 /** Created by aagrawal on 3/9/19. */
@@ -55,7 +55,7 @@ public class TestBackupV2Service {
         cassandraTunerService = injector.getInstance(CassandraTunerService.class);
     }
 
-    @Before
+    @BeforeEach
     public void cleanup() throws SchedulerException {
         scheduler.getScheduler().clear();
     }
@@ -105,14 +105,14 @@ public class TestBackupV2Service {
                         snapshotMetaTask,
                         cassandraTunerService);
         backupService.scheduleService();
-        Assert.assertTrue(scheduler.getScheduler().getJobGroupNames().isEmpty());
+        Assertions.assertTrue(scheduler.getScheduler().getJobGroupNames().isEmpty());
 
         // snapshot V2 name should not be there.
         Set<Path> backupPaths =
                 AbstractBackup.getBackupDirectories(configuration, AbstractBackup.SNAPSHOT_FOLDER);
         for (Path backupPath : backupPaths) {
-            Assert.assertFalse(Files.exists(Paths.get(backupPath.toString(), snapshotName)));
-            Assert.assertTrue(Files.exists(Paths.get(backupPath.toString(), snapshotV1Name)));
+            Assertions.assertFalse(Files.exists(Paths.get(backupPath.toString(), snapshotName)));
+            Assertions.assertTrue(Files.exists(Paths.get(backupPath.toString(), snapshotV1Name)));
         }
     }
 
@@ -144,7 +144,7 @@ public class TestBackupV2Service {
                         snapshotMetaTask,
                         cassandraTunerService);
         backupService.scheduleService();
-        Assert.assertEquals(4, scheduler.getScheduler().getJobKeys(null).size());
+        Assertions.assertEquals(4, scheduler.getScheduler().getJobKeys(null).size());
     }
 
     @Test
@@ -173,7 +173,7 @@ public class TestBackupV2Service {
                         snapshotMetaTask,
                         cassandraTunerService);
         backupService.scheduleService();
-        Assert.assertEquals(3, scheduler.getScheduler().getJobKeys(null).size());
+        Assertions.assertEquals(3, scheduler.getScheduler().getJobKeys(null).size());
     }
 
     @Test
@@ -210,9 +210,9 @@ public class TestBackupV2Service {
                         snapshotMetaTask,
                         cassandraTunerService);
         backupService.scheduleService();
-        Assert.assertEquals(3, scheduler.getScheduler().getJobKeys(null).size());
+        Assertions.assertEquals(3, scheduler.getScheduler().getJobKeys(null).size());
 
         backupService.onChangeUpdateService();
-        Assert.assertEquals(0, scheduler.getScheduler().getJobKeys(null).size());
+        Assertions.assertEquals(0, scheduler.getScheduler().getJobKeys(null).size());
     }
 }

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestBackupVerificationTask.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestBackupVerificationTask.java
@@ -34,9 +34,9 @@ import java.util.List;
 import java.util.Optional;
 import javax.inject.Inject;
 import mockit.*;
-import org.junit.Before;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Created by aagrawal on 2/1/19. */
 public class TestBackupVerificationTask {
@@ -45,7 +45,7 @@ public class TestBackupVerificationTask {
     @Mocked private BackupVerification backupVerification;
     @Mocked private BackupNotificationMgr backupNotificationMgr;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         new MockBackupVerification();
         new MockBackupNotificationMgr();

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestForgottenFileManager.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestForgottenFileManager.java
@@ -35,10 +35,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Created by aagrawal on 1/1/19. */
 public class TestForgottenFileManager {
@@ -57,7 +57,7 @@ public class TestForgottenFileManager {
         testBackupUtils = injector.getInstance(TestBackupUtils.class);
     }
 
-    @Before
+    @BeforeEach
     public void prep() throws Exception {
         cleanup();
         Instant now = DateUtil.getInstant();
@@ -95,7 +95,7 @@ public class TestForgottenFileManager {
         Files.createLink(Paths.get(snapshotDir.toString(), file4.getFileName().toString()), file4);
     }
 
-    @After
+    @AfterEach
     public void cleanup() throws Exception {
         String dataDir = configuration.getDataFileLocation();
         org.apache.commons.io.FileUtils.cleanDirectory(new File(dataDir));
@@ -116,16 +116,16 @@ public class TestForgottenFileManager {
                 new File(configuration.getDataFileLocation()), files);
 
         // Extra symlinks are deleted.
-        Assert.assertFalse(Files.exists(randomSymlink));
+        Assertions.assertFalse(Files.exists(randomSymlink));
 
         // Symlinks are created for all the files. They are not moved yet.
         Collection<File> symlinkFiles = FileUtils.listFiles(lostFoundDir.toFile(), null, false);
-        Assert.assertEquals(allFiles.size(), symlinkFiles.size());
+        Assertions.assertEquals(allFiles.size(), symlinkFiles.size());
         for (Path file : allFiles) {
             Path symlink = Paths.get(lostFoundDir.toString(), file.getFileName().toString());
-            Assert.assertTrue(symlinkFiles.contains(symlink.toFile()));
-            Assert.assertTrue(Files.isSymbolicLink(symlink));
-            Assert.assertTrue(Files.exists(file));
+            Assertions.assertTrue(symlinkFiles.contains(symlink.toFile()));
+            Assertions.assertTrue(Files.isSymbolicLink(symlink));
+            Assertions.assertTrue(Files.exists(file));
         }
 
         // Lets change the configuration and try again!!
@@ -133,18 +133,18 @@ public class TestForgottenFileManager {
         forgottenFilesManager.moveForgottenFiles(
                 new File(configuration.getDataFileLocation()), files);
         Collection<File> movedFiles = FileUtils.listFiles(lostFoundDir.toFile(), null, false);
-        Assert.assertEquals(allFiles.size(), movedFiles.size());
+        Assertions.assertEquals(allFiles.size(), movedFiles.size());
         movedFiles
                 .stream()
                 .forEach(
                         file -> {
-                            Assert.assertTrue(
+                            Assertions.assertTrue(
                                     Files.isRegularFile(Paths.get(file.getAbsolutePath())));
                         });
         allFiles.stream()
                 .forEach(
                         file -> {
-                            Assert.assertFalse(file.toFile().exists());
+                            Assertions.assertFalse(file.toFile().exists());
                         });
 
         configuration.setGracePeriodForgottenFileInDaysForRead(
@@ -158,10 +158,10 @@ public class TestForgottenFileManager {
         Collection<File> columnfamilyFiles =
                 forgottenFilesManager.getColumnfamilyFiles(
                         snapshotInstant, columnfamilyDir.toFile());
-        Assert.assertEquals(3, columnfamilyFiles.size());
-        Assert.assertTrue(columnfamilyFiles.contains(allFiles.get(0).toFile()));
-        Assert.assertTrue(columnfamilyFiles.contains(allFiles.get(1).toFile()));
-        Assert.assertTrue(columnfamilyFiles.contains(allFiles.get(2).toFile()));
+        Assertions.assertEquals(3, columnfamilyFiles.size());
+        Assertions.assertTrue(columnfamilyFiles.contains(allFiles.get(0).toFile()));
+        Assertions.assertTrue(columnfamilyFiles.contains(allFiles.get(1).toFile()));
+        Assertions.assertTrue(columnfamilyFiles.contains(allFiles.get(2).toFile()));
     }
 
     @Test
@@ -172,24 +172,24 @@ public class TestForgottenFileManager {
 
         // Only one potential forgotten file - file1. It will be symlink here.
         Collection<File> movedFiles = FileUtils.listFiles(lostFoundDir.toFile(), null, false);
-        Assert.assertEquals(1, movedFiles.size());
-        Assert.assertTrue(
+        Assertions.assertEquals(1, movedFiles.size());
+        Assertions.assertTrue(
                 movedFiles
                         .iterator()
                         .next()
                         .getName()
                         .equals(allFiles.get(0).getFileName().toString()));
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 Files.isSymbolicLink(Paths.get(movedFiles.iterator().next().getAbsolutePath())));
 
         // All files still remain in columnfamily dir.
         Collection<File> cfFiles =
                 FileUtils.listFiles(new File(allFiles.get(0).getParent().toString()), null, false);
-        Assert.assertEquals(allFiles.size(), cfFiles.size());
+        Assertions.assertEquals(allFiles.size(), cfFiles.size());
 
         // Snapshot is untouched.
         Collection<File> snapshotFiles = FileUtils.listFiles(snapshotDir.toFile(), null, false);
-        Assert.assertEquals(3, snapshotFiles.size());
+        Assertions.assertEquals(3, snapshotFiles.size());
 
         // Lets change the configuration and try again!!
         configuration.setGracePeriodForgottenFileInDaysForRead(0);
@@ -197,12 +197,12 @@ public class TestForgottenFileManager {
         configuration.setGracePeriodForgottenFileInDaysForRead(
                 ForgottenFilesConfiguration.DEFAULT_GRACE_PERIOD);
         movedFiles = FileUtils.listFiles(lostFoundDir.toFile(), null, false);
-        Assert.assertEquals(1, movedFiles.size());
-        Assert.assertTrue(
+        Assertions.assertEquals(1, movedFiles.size());
+        Assertions.assertTrue(
                 Files.isRegularFile(Paths.get(movedFiles.iterator().next().getAbsolutePath())));
         cfFiles =
                 FileUtils.listFiles(new File(allFiles.get(0).getParent().toString()), null, false);
-        Assert.assertEquals(6, cfFiles.size());
+        Assertions.assertEquals(6, cfFiles.size());
         int temp_file_name = 1;
         for (File file : cfFiles) {
             file.getName().equals(allFiles.get(temp_file_name++).getFileName().toString());
@@ -210,7 +210,7 @@ public class TestForgottenFileManager {
 
         // Snapshot is untouched.
         snapshotFiles = FileUtils.listFiles(snapshotDir.toFile(), null, false);
-        Assert.assertEquals(3, snapshotFiles.size());
+        Assertions.assertEquals(3, snapshotFiles.size());
     }
 
     private class ForgottenFilesConfiguration extends FakeConfiguration {

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestMetaV2Proxy.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestMetaV2Proxy.java
@@ -37,9 +37,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /** Created by aagrawal on 12/5/18. */
 public class TestMetaV2Proxy {
@@ -62,19 +62,19 @@ public class TestMetaV2Proxy {
     @Test
     public void testMetaPrefix() {
         // Null date range
-        Assert.assertEquals(getPrefix() + "/META_V2", metaProxy.getMetaPrefix(null));
+        Assertions.assertEquals(getPrefix() + "/META_V2", metaProxy.getMetaPrefix(null));
         Instant now = Instant.now();
         // No end date.
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 getPrefix() + "/META_V2/" + now.toEpochMilli(),
                 metaProxy.getMetaPrefix(new DateUtil.DateRange(now, null)));
         // No start date
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 getPrefix() + "/META_V2",
                 metaProxy.getMetaPrefix(new DateUtil.DateRange(null, Instant.now())));
         long start = 1834567890L;
         long end = 1834877776L;
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 getPrefix() + "/META_V2/1834",
                 metaProxy.getMetaPrefix(
                         new DateUtil.DateRange(
@@ -88,7 +88,7 @@ public class TestMetaV2Proxy {
         AbstractBackupPath abstractBackupPath = abstractBackupPathProvider.get();
         abstractBackupPath.parseLocal(metaPath.toFile(), AbstractBackupPath.BackupFileType.META_V2);
 
-        Assert.assertTrue(metaProxy.isMetaFileValid(abstractBackupPath).valid);
+        Assertions.assertTrue(metaProxy.isMetaFileValid(abstractBackupPath).valid);
         FileUtils.deleteQuietly(metaPath.toFile());
 
         List<String> fileToAdd = getRemoteFakeFiles();
@@ -105,11 +105,11 @@ public class TestMetaV2Proxy {
                         .toString());
 
         metaPath = backupUtils.createMeta(fileToAdd, snapshotInstant);
-        Assert.assertFalse(metaProxy.isMetaFileValid(abstractBackupPath).valid);
+        Assertions.assertFalse(metaProxy.isMetaFileValid(abstractBackupPath).valid);
         FileUtils.deleteQuietly(metaPath.toFile());
 
         metaPath = Paths.get(configuration.getDataFileLocation(), "meta_v2_201801010000.json");
-        Assert.assertFalse(metaProxy.isMetaFileValid(abstractBackupPath).valid);
+        Assertions.assertFalse(metaProxy.isMetaFileValid(abstractBackupPath).valid);
     }
 
     @Test
@@ -119,7 +119,7 @@ public class TestMetaV2Proxy {
         Path metaPath = backupUtils.createMeta(remoteFiles, snapshotInstant);
         List<String> filesFromMeta = metaProxy.getSSTFilesFromMeta(metaPath);
         filesFromMeta.removeAll(remoteFiles);
-        Assert.assertTrue(filesFromMeta.isEmpty());
+        Assertions.assertTrue(filesFromMeta.isEmpty());
     }
 
     @Test
@@ -131,7 +131,7 @@ public class TestMetaV2Proxy {
             System.out.println(incrementals.next());
             i++;
         }
-        Assert.assertEquals(3, i);
+        Assertions.assertEquals(3, i);
     }
 
     @Test
@@ -141,16 +141,16 @@ public class TestMetaV2Proxy {
                         new DateUtil.DateRange(
                                 Instant.ofEpochMilli(1859824860000L),
                                 Instant.ofEpochMilli(1859828420000L)));
-        Assert.assertEquals(1, metas.size());
-        Assert.assertEquals("meta_v2_202812071801.json", metas.get(0).getFileName());
-        Assert.assertTrue(fs.doesRemoteFileExist(Paths.get(metas.get(0).getRemotePath())));
+        Assertions.assertEquals(1, metas.size());
+        Assertions.assertEquals("meta_v2_202812071801.json", metas.get(0).getFileName());
+        Assertions.assertTrue(fs.doesRemoteFileExist(Paths.get(metas.get(0).getRemotePath())));
 
         metas =
                 metaProxy.findMetaFiles(
                         new DateUtil.DateRange(
                                 Instant.ofEpochMilli(1859824860000L),
                                 Instant.ofEpochMilli(1859828460000L)));
-        Assert.assertEquals(2, metas.size());
+        Assertions.assertEquals(2, metas.size());
     }
 
     @Test
@@ -232,7 +232,7 @@ public class TestMetaV2Proxy {
         return files.stream().map(Path::toString).collect(Collectors.toList());
     }
 
-    @After
+    @AfterEach
     public void cleanup() throws IOException {
         FileUtils.cleanDirectory(new File(configuration.getDataFileLocation()));
     }
@@ -241,14 +241,14 @@ public class TestMetaV2Proxy {
     public void testCleanupOldMetaFiles() throws IOException {
         generateDummyMetaFiles();
         Path dataDir = Paths.get(configuration.getDataFileLocation());
-        Assert.assertEquals(4, dataDir.toFile().listFiles().length);
+        Assertions.assertEquals(4, dataDir.toFile().listFiles().length);
 
         // clean the directory
         metaProxy.cleanupOldMetaFiles();
 
-        Assert.assertEquals(1, dataDir.toFile().listFiles().length);
+        Assertions.assertEquals(1, dataDir.toFile().listFiles().length);
         Path dummy = Paths.get(dataDir.toString(), "dummy.tmp");
-        Assert.assertTrue(dummy.toFile().exists());
+        Assertions.assertTrue(dummy.toFile().exists());
     }
 
     private void generateDummyMetaFiles() throws IOException {

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestSnapshotMetaTask.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestSnapshotMetaTask.java
@@ -29,9 +29,9 @@ import com.netflix.priam.utils.DateUtil;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +56,7 @@ public class TestSnapshotMetaTask {
         instanceInfo = injector.getInstance(InstanceInfo.class);
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         dummyDataDirectoryLocation = Paths.get(configuration.getDataFileLocation());
         BackupFileUtils.cleanupDir(dummyDataDirectoryLocation);
@@ -65,16 +65,16 @@ public class TestSnapshotMetaTask {
     @Test
     public void testSnapshotMetaServiceEnabled() throws Exception {
         TaskTimer taskTimer = SnapshotMetaTask.getTimer(configuration, backupRestoreConfig);
-        Assert.assertNotNull(taskTimer);
+        Assertions.assertNotNull(taskTimer);
     }
 
     @Test
     public void testMetaFileName() throws Exception {
         String fileName = MetaFileInfo.getMetaFileName(DateUtil.getInstant());
         Path path = Paths.get(dummyDataDirectoryLocation.toFile().getAbsolutePath(), fileName);
-        Assert.assertTrue(metaFileReader.isValidMetaFile(path));
+        Assertions.assertTrue(metaFileReader.isValidMetaFile(path));
         path = Paths.get(dummyDataDirectoryLocation.toFile().getAbsolutePath(), fileName + ".tmp");
-        Assert.assertFalse(metaFileReader.isValidMetaFile(path));
+        Assertions.assertFalse(metaFileReader.isValidMetaFile(path));
     }
 
     private void test(int noOfSstables, int noOfKeyspaces, int noOfCf) throws Exception {
@@ -91,10 +91,10 @@ public class TestSnapshotMetaTask {
         snapshotMetaService.setSnapshotName(snapshotName);
         Path metaFileLocation =
                 snapshotMetaService.processSnapshot(snapshotInstant).getMetaFilePath();
-        Assert.assertNotNull(metaFileLocation);
-        Assert.assertTrue(metaFileLocation.toFile().exists());
-        Assert.assertTrue(metaFileLocation.toFile().isFile());
-        Assert.assertEquals(
+        Assertions.assertNotNull(metaFileLocation);
+        Assertions.assertTrue(metaFileLocation.toFile().exists());
+        Assertions.assertTrue(metaFileLocation.toFile().isFile());
+        Assertions.assertEquals(
                 snapshotInstant.getEpochSecond(),
                 (metaFileLocation.toFile().lastModified() / 1000));
 
@@ -103,10 +103,10 @@ public class TestSnapshotMetaTask {
         metaFileReader.readMeta(metaFileLocation);
 
         MetaFileInfo metaFileInfo = metaFileReader.getMetaFileInfo();
-        Assert.assertEquals(1, metaFileInfo.getVersion());
-        Assert.assertEquals(configuration.getAppName(), metaFileInfo.getAppName());
-        Assert.assertEquals(instanceInfo.getRac(), metaFileInfo.getRack());
-        Assert.assertEquals(instanceInfo.getRegion(), metaFileInfo.getRegion());
+        Assertions.assertEquals(1, metaFileInfo.getVersion());
+        Assertions.assertEquals(configuration.getAppName(), metaFileInfo.getAppName());
+        Assertions.assertEquals(instanceInfo.getRac(), metaFileInfo.getRack());
+        Assertions.assertEquals(instanceInfo.getRegion(), metaFileInfo.getRegion());
 
         // Cleanup
         metaFileLocation.toFile().delete();
@@ -133,7 +133,7 @@ public class TestSnapshotMetaTask {
 
         @Override
         public void process(ColumnfamilyResult columnfamilyResult) {
-            Assert.assertEquals(noOfSstables, columnfamilyResult.getSstables().size());
+            Assertions.assertEquals(noOfSstables, columnfamilyResult.getSstables().size());
         }
     }
 }

--- a/priam/src/test/java/com/netflix/priam/cassandra/token/TestDoublingLogic.java
+++ b/priam/src/test/java/com/netflix/priam/cassandra/token/TestDoublingLogic.java
@@ -17,14 +17,14 @@
 
 package com.netflix.priam.cassandra.token;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Seems like skip 3 is the magic number.... this test will make sure to test the same. */
 public class TestDoublingLogic {

--- a/priam/src/test/java/com/netflix/priam/config/PriamConfigurationPersisterTest.java
+++ b/priam/src/test/java/com/netflix/priam/config/PriamConfigurationPersisterTest.java
@@ -16,41 +16,41 @@
  */
 package com.netflix.priam.config;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.netflix.priam.TestModule;
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class PriamConfigurationPersisterTest {
     private static PriamConfigurationPersister persister;
 
-    @Rule public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir public File folder;
 
     private FakeConfiguration fakeConfiguration;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         Injector injector = Guice.createInjector(new TestModule());
         fakeConfiguration = (FakeConfiguration) injector.getInstance(IConfiguration.class);
-        fakeConfiguration.fakeProperties.put("priam_test_config", folder.getRoot().getPath());
+        fakeConfiguration.fakeProperties.put("priam_test_config", folder.getPath());
 
         if (persister == null) persister = injector.getInstance(PriamConfigurationPersister.class);
     }
 
-    @After
+    @AfterEach
     public void cleanUp() {
         fakeConfiguration.fakeProperties.clear();
     }
@@ -58,7 +58,7 @@ public class PriamConfigurationPersisterTest {
     @Test
     @SuppressWarnings("unchecked")
     public void execute() throws Exception {
-        Path structuredJson = Paths.get(folder.getRoot().getPath(), "structured.json");
+        Path structuredJson = Paths.get(folder.getPath(), "structured.json");
 
         persister.execute();
         assertTrue(structuredJson.toFile().exists());

--- a/priam/src/test/java/com/netflix/priam/configSource/AbstractConfigSourceTest.java
+++ b/priam/src/test/java/com/netflix/priam/configSource/AbstractConfigSourceTest.java
@@ -19,8 +19,8 @@ package com.netflix.priam.configSource;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +34,7 @@ public final class AbstractConfigSourceTest {
         source.set("foo", "bar,baz, qux ");
         final List<String> values = source.getList("foo");
         LOGGER.info("Values {}", values);
-        Assert.assertEquals(ImmutableList.of("bar", "baz", "qux"), values);
+        Assertions.assertEquals(ImmutableList.of("bar", "baz", "qux"), values);
     }
 
     @Test
@@ -43,7 +43,7 @@ public final class AbstractConfigSourceTest {
         source.set("foo", "bar");
         final List<String> values = source.getList("foo");
         LOGGER.info("Values {}", values);
-        Assert.assertEquals(ImmutableList.of("bar"), values);
+        Assertions.assertEquals(ImmutableList.of("bar"), values);
     }
 
     @Test
@@ -52,6 +52,6 @@ public final class AbstractConfigSourceTest {
         source.set("foo", "\tbar ");
         final List<String> values = source.getList("foo");
         LOGGER.info("Values {}", values);
-        Assert.assertEquals(ImmutableList.of("bar"), values);
+        Assertions.assertEquals(ImmutableList.of("bar"), values);
     }
 }

--- a/priam/src/test/java/com/netflix/priam/configSource/CompositeConfigSourceTest.java
+++ b/priam/src/test/java/com/netflix/priam/configSource/CompositeConfigSourceTest.java
@@ -17,8 +17,8 @@
 
 package com.netflix.priam.configSource;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,14 +32,14 @@ public final class CompositeConfigSourceTest {
         IConfigSource configSource = new CompositeConfigSource(memoryConfigSource);
         configSource.initialize("foo", "bar");
 
-        Assert.assertEquals(0, configSource.size());
+        Assertions.assertEquals(0, configSource.size());
         configSource.set("foo", "bar");
-        Assert.assertEquals(1, configSource.size());
-        Assert.assertEquals("bar", configSource.get("foo"));
+        Assertions.assertEquals(1, configSource.size());
+        Assertions.assertEquals("bar", configSource.get("foo"));
 
         // verify that the writes went to mem source.
-        Assert.assertEquals(1, memoryConfigSource.size());
-        Assert.assertEquals("bar", memoryConfigSource.get("foo"));
+        Assertions.assertEquals(1, memoryConfigSource.size());
+        Assertions.assertEquals("bar", memoryConfigSource.get("foo"));
     }
 
     @Test
@@ -52,12 +52,12 @@ public final class CompositeConfigSourceTest {
         m3.set("baz", "baz");
 
         IConfigSource configSource = new CompositeConfigSource(m1, m2, m3);
-        Assert.assertEquals(3, configSource.size());
-        Assert.assertEquals("foo", configSource.get("foo"));
-        Assert.assertEquals("bar", configSource.get("bar"));
-        Assert.assertEquals("baz", configSource.get("baz"));
+        Assertions.assertEquals(3, configSource.size());
+        Assertions.assertEquals("foo", configSource.get("foo"));
+        Assertions.assertEquals("bar", configSource.get("bar"));
+        Assertions.assertEquals("baz", configSource.get("baz"));
 
         // read default
-        Assert.assertEquals("test", configSource.get("doesnotexist", "test"));
+        Assertions.assertEquals("test", configSource.get("doesnotexist", "test"));
     }
 }

--- a/priam/src/test/java/com/netflix/priam/configSource/PropertiesConfigSourceTest.java
+++ b/priam/src/test/java/com/netflix/priam/configSource/PropertiesConfigSourceTest.java
@@ -17,8 +17,8 @@
 
 package com.netflix.priam.configSource;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,12 +31,12 @@ public final class PropertiesConfigSourceTest {
         PropertiesConfigSource configSource = new PropertiesConfigSource("conf/Priam.properties");
         configSource.initialize("asgName", "region");
 
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 "\"/tmp/commitlog\"", configSource.get("Priam.backup.commitlog.location"));
-        Assert.assertEquals(7102, configSource.get("Priam.thrift.port", 0));
+        Assertions.assertEquals(7102, configSource.get("Priam.thrift.port", 0));
         // File has 13 lines, but line 6 is "Priam.jmx.port7501", so it gets filtered out with empty
         // string check.
-        Assert.assertEquals(13, configSource.size());
+        Assertions.assertEquals(13, configSource.size());
     }
 
     @Test
@@ -46,16 +46,16 @@ public final class PropertiesConfigSourceTest {
 
         // File has 13 lines, but line 6 is "Priam.jmx.port7501", so it gets filtered out with empty
         // string check.
-        Assert.assertEquals(13, configSource.size());
+        Assertions.assertEquals(13, configSource.size());
 
         configSource.set("foo", "bar");
 
-        Assert.assertEquals(14, configSource.size());
+        Assertions.assertEquals(14, configSource.size());
 
-        Assert.assertEquals("bar", configSource.get("foo"));
+        Assertions.assertEquals("bar", configSource.get("foo"));
 
-        Assert.assertEquals(7102, configSource.get("Priam.thrift.port", 0));
+        Assertions.assertEquals(7102, configSource.get("Priam.thrift.port", 0));
         configSource.set("Priam.thrift.port", Integer.toString(10));
-        Assert.assertEquals(10, configSource.get("Priam.thrift.port", 0));
+        Assertions.assertEquals(10, configSource.get("Priam.thrift.port", 0));
     }
 }

--- a/priam/src/test/java/com/netflix/priam/configSource/SystemPropertiesConfigSourceTest.java
+++ b/priam/src/test/java/com/netflix/priam/configSource/SystemPropertiesConfigSourceTest.java
@@ -17,8 +17,8 @@
 
 package com.netflix.priam.configSource;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,8 +33,8 @@ public final class SystemPropertiesConfigSourceTest {
         configSource.initialize("asgName", "region");
 
         // sys props are filtered to starting with priam, so this should be missing.
-        Assert.assertEquals(null, configSource.get(key));
+        Assertions.assertEquals(null, configSource.get(key));
 
-        Assert.assertEquals(0, configSource.size());
+        Assertions.assertEquals(0, configSource.size());
     }
 }

--- a/priam/src/test/java/com/netflix/priam/connection/TestCassandraOperations.java
+++ b/priam/src/test/java/com/netflix/priam/connection/TestCassandraOperations.java
@@ -30,8 +30,8 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
 import org.apache.cassandra.tools.NodeProbe;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /** Created by aagrawal on 3/1/19. */
 public class TestCassandraOperations {
@@ -66,18 +66,18 @@ public class TestCassandraOperations {
         };
         List<Map<String, String>> gossipInfoList = cassandraOperations.gossipInfo();
         System.out.println(gossipInfoList);
-        Assert.assertEquals(7, gossipInfoList.size());
+        Assertions.assertEquals(7, gossipInfoList.size());
         gossipInfoList
                 .stream()
                 .forEach(
                         gossipInfo -> {
-                            Assert.assertEquals("us-east", gossipInfo.get("DC"));
-                            Assert.assertNotNull(gossipInfo.get("PUBLIC_IP"));
-                            Assert.assertEquals("1565153", gossipInfo.get("HEARTBEAT"));
+                            Assertions.assertEquals("us-east", gossipInfo.get("DC"));
+                            Assertions.assertNotNull(gossipInfo.get("PUBLIC_IP"));
+                            Assertions.assertEquals("1565153", gossipInfo.get("HEARTBEAT"));
                             if (gossipInfo.get("STATUS").equalsIgnoreCase("NORMAL"))
-                                Assert.assertNotNull(gossipInfo.get("TOKENS"));
+                                Assertions.assertNotNull(gossipInfo.get("TOKENS"));
                             if (gossipInfo.get("PUBLIC_IP").equalsIgnoreCase("127.0.0.1"))
-                                Assert.assertEquals("[123,234]", gossipInfo.get("TOKENS"));
+                                Assertions.assertEquals("[123,234]", gossipInfo.get("TOKENS"));
                         });
     }
 }

--- a/priam/src/test/java/com/netflix/priam/defaultimpl/CassandraProcessManagerTest.java
+++ b/priam/src/test/java/com/netflix/priam/defaultimpl/CassandraProcessManagerTest.java
@@ -24,14 +24,14 @@ import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.health.InstanceState;
 import com.netflix.priam.merics.CassMonitorMetrics;
 import java.io.IOException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CassandraProcessManagerTest {
     private CassandraProcessManager cpm;
 
-    @Before
+    @BeforeEach
     public void setup() {
         IConfiguration config = new FakeConfiguration("test_cluster");
         InstanceState instanceState =
@@ -48,7 +48,7 @@ public class CassandraProcessManagerTest {
         try {
             p = new ProcessBuilder("ls", "/tmppppp").start();
             int exitValue = p.waitFor();
-            Assert.assertTrue(0 != exitValue);
+            Assertions.assertTrue(0 != exitValue);
             cpm.logProcessOutput(p);
         } catch (IOException ioe) {
             if (p != null) cpm.logProcessOutput(p);
@@ -60,7 +60,7 @@ public class CassandraProcessManagerTest {
     public void logProcessOutput_GoodApp() throws IOException, InterruptedException {
         Process p = new ProcessBuilder("true").start();
         int exitValue = p.waitFor();
-        Assert.assertEquals(0, exitValue);
+        Assertions.assertEquals(0, exitValue);
         cpm.logProcessOutput(p);
     }
 }

--- a/priam/src/test/java/com/netflix/priam/health/TestCassandraMonitor.java
+++ b/priam/src/test/java/com/netflix/priam/health/TestCassandraMonitor.java
@@ -28,9 +28,9 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import mockit.*;
 import org.apache.cassandra.tools.NodeProbe;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Created by aagrawal on 7/18/17. */
 public class TestCassandraMonitor {
@@ -45,7 +45,7 @@ public class TestCassandraMonitor {
     @Mocked private NodeProbe nodeProbe;
     @Mocked private ICassandraProcess cassProcess;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         Injector injector = Guice.createInjector(new BRTestModule());
         config = injector.getInstance(IConfiguration.class);
@@ -63,13 +63,13 @@ public class TestCassandraMonitor {
     public void testCassandraMonitor() throws Exception {
         monitor.execute();
 
-        Assert.assertFalse(CassandraMonitor.hasCassadraStarted());
+        Assertions.assertFalse(CassandraMonitor.hasCassadraStarted());
 
         CassandraMonitor.setIsCassadraStarted();
-        Assert.assertTrue(CassandraMonitor.hasCassadraStarted());
+        Assertions.assertTrue(CassandraMonitor.hasCassadraStarted());
 
         monitor.execute();
-        Assert.assertFalse(CassandraMonitor.hasCassadraStarted());
+        Assertions.assertFalse(CassandraMonitor.hasCassadraStarted());
     }
 
     @Test
@@ -111,8 +111,8 @@ public class TestCassandraMonitor {
 
         monitor.execute();
 
-        Assert.assertTrue(!instanceState.shouldCassandraBeAlive());
-        Assert.assertTrue(instanceState.isCassandraProcessAlive());
+        Assertions.assertTrue(!instanceState.shouldCassandraBeAlive());
+        Assertions.assertTrue(instanceState.isCassandraProcessAlive());
         new Verifications() {
             {
                 cassProcess.start(anyBoolean);

--- a/priam/src/test/java/com/netflix/priam/health/TestInstanceStatus.java
+++ b/priam/src/test/java/com/netflix/priam/health/TestInstanceStatus.java
@@ -20,15 +20,15 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.netflix.priam.backup.BRTestModule;
 import com.netflix.priam.backup.Status;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Test InstanceState Created by aagrawal on 9/22/17. */
 public class TestInstanceStatus {
     private TestInstanceState testInstanceState;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         Injector injector = Guice.createInjector(new BRTestModule());
         InstanceState instanceState = injector.getInstance(InstanceState.class);
@@ -38,61 +38,61 @@ public class TestInstanceStatus {
     @Test
     public void testHealth() {
         // Verify good health.
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 testInstanceState
                         .setParams(false, true, true, true, true, true, true, true)
                         .isHealthy());
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 testInstanceState
                         .setParams(false, true, true, true, true, false, true, true)
                         .isHealthy());
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 testInstanceState
                         .setParams(false, true, true, true, false, true, true, true)
                         .isHealthy());
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 testInstanceState
                         .setParams(true, false, true, true, false, true, true, true)
                         .isHealthy());
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 testInstanceState
                         .setParams(true, true, false, true, true, true, true, true)
                         .isHealthy());
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 testInstanceState
                         .setParams(true, true, true, false, true, true, true, true)
                         .isHealthy());
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 testInstanceState
                         .setParams(true, true, true, true, true, true, false, true)
                         .isHealthy());
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 testInstanceState
                         .setParams(true, true, true, true, false, false, true, true)
                         .isHealthy());
 
         // Negative health case scenarios.
-        Assert.assertFalse(
+        Assertions.assertFalse(
                 testInstanceState
                         .setParams(false, false, true, true, false, true, true, true)
                         .isHealthy());
-        Assert.assertFalse(
+        Assertions.assertFalse(
                 testInstanceState
                         .setParams(false, true, false, true, true, true, true, true)
                         .isHealthy());
-        Assert.assertFalse(
+        Assertions.assertFalse(
                 testInstanceState
                         .setParams(false, true, true, false, true, true, true, true)
                         .isHealthy());
-        Assert.assertFalse(
+        Assertions.assertFalse(
                 testInstanceState
                         .setParams(false, true, true, true, true, true, false, true)
                         .isHealthy());
-        Assert.assertFalse(
+        Assertions.assertFalse(
                 testInstanceState
                         .setParams(false, true, true, true, false, false, true, true)
                         .isHealthy());
-        Assert.assertFalse(
+        Assertions.assertFalse(
                 testInstanceState
                         .setParams(false, true, true, true, false, false, true, false)
                         .isHealthy());

--- a/priam/src/test/java/com/netflix/priam/health/TestThriftChecker.java
+++ b/priam/src/test/java/com/netflix/priam/health/TestThriftChecker.java
@@ -6,9 +6,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import mockit.Expectations;
 import mockit.Mocked;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestThriftChecker {
     private FakeConfiguration config;
@@ -16,7 +16,7 @@ public class TestThriftChecker {
 
     @Mocked private Process mockProcess;
 
-    @Before
+    @BeforeEach
     public void TestThriftChecker() {
         config = new FakeConfiguration();
         thriftChecker = new ThriftChecker(config);
@@ -25,13 +25,13 @@ public class TestThriftChecker {
     @Test
     public void testThriftServerIsListeningDisabled() {
         config.setCheckThriftServerIsListening(false);
-        Assert.assertTrue(thriftChecker.isThriftServerListening());
+        Assertions.assertTrue(thriftChecker.isThriftServerListening());
     }
 
     @Test
     public void testThriftServerIsNotListening() {
         config.setCheckThriftServerIsListening(true);
-        Assert.assertFalse(thriftChecker.isThriftServerListening());
+        Assertions.assertFalse(thriftChecker.isThriftServerListening());
     }
 
     @Test
@@ -56,7 +56,7 @@ public class TestThriftChecker {
             }
         };
 
-        Assert.assertTrue(thriftChecker.isThriftServerListening());
+        Assertions.assertTrue(thriftChecker.isThriftServerListening());
     }
 
     @Test
@@ -81,6 +81,6 @@ public class TestThriftChecker {
             }
         };
 
-        Assert.assertTrue(thriftChecker.isThriftServerListening());
+        Assertions.assertTrue(thriftChecker.isThriftServerListening());
     }
 }

--- a/priam/src/test/java/com/netflix/priam/identity/token/AssignedTokenRetrieverTest.java
+++ b/priam/src/test/java/com/netflix/priam/identity/token/AssignedTokenRetrieverTest.java
@@ -18,8 +18,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import mockit.Expectations;
 import mockit.Mocked;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class AssignedTokenRetrieverTest {
     public static final String APP = "testapp";

--- a/priam/src/test/java/com/netflix/priam/identity/token/TokenRetrieverTest.java
+++ b/priam/src/test/java/com/netflix/priam/identity/token/TokenRetrieverTest.java
@@ -41,8 +41,8 @@ import java.util.stream.IntStream;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /** Created by aagrawal on 3/1/19. */
 public class TokenRetrieverTest {

--- a/priam/src/test/java/com/netflix/priam/identity/token/TokenRetrieverUtilsTest.java
+++ b/priam/src/test/java/com/netflix/priam/identity/token/TokenRetrieverUtilsTest.java
@@ -13,8 +13,8 @@ import java.util.stream.IntStream;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TokenRetrieverUtilsTest {
     private static final String APP = "testapp";
@@ -65,7 +65,7 @@ public class TokenRetrieverUtilsTest {
 
         TokenRetrieverUtils.InferredTokenOwnership inferredTokenOwnership =
                 TokenRetrieverUtils.inferTokenOwnerFromGossip(instances, "4", "us-east");
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 "127.0.0.4", inferredTokenOwnership.getTokenInformation().getIpAddress());
     }
 
@@ -105,10 +105,10 @@ public class TokenRetrieverUtilsTest {
 
         TokenRetrieverUtils.InferredTokenOwnership inferredTokenOwnership =
                 TokenRetrieverUtils.inferTokenOwnerFromGossip(instances, "4", "us-east");
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 TokenRetrieverUtils.InferredTokenOwnership.TokenInformationStatus.MISMATCH,
                 inferredTokenOwnership.getTokenInformationStatus());
-        Assert.assertTrue(inferredTokenOwnership.getTokenInformation().isLive());
+        Assertions.assertTrue(inferredTokenOwnership.getTokenInformation().isLive());
     }
 
     @Test
@@ -123,10 +123,10 @@ public class TokenRetrieverUtilsTest {
 
         TokenRetrieverUtils.InferredTokenOwnership inferredTokenOwnership =
                 TokenRetrieverUtils.inferTokenOwnerFromGossip(instances, "4", "us-east");
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 TokenRetrieverUtils.InferredTokenOwnership.TokenInformationStatus.GOOD,
                 inferredTokenOwnership.getTokenInformationStatus());
-        Assert.assertTrue(inferredTokenOwnership.getTokenInformation().isLive());
+        Assertions.assertTrue(inferredTokenOwnership.getTokenInformation().isLive());
     }
 
     @Test
@@ -142,10 +142,10 @@ public class TokenRetrieverUtilsTest {
 
         TokenRetrieverUtils.InferredTokenOwnership inferredTokenOwnership =
                 TokenRetrieverUtils.inferTokenOwnerFromGossip(instances, "4", "us-east");
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 TokenRetrieverUtils.InferredTokenOwnership.TokenInformationStatus.UNREACHABLE_NODES,
                 inferredTokenOwnership.getTokenInformationStatus());
-        Assert.assertNull(inferredTokenOwnership.getTokenInformation());
+        Assertions.assertNull(inferredTokenOwnership.getTokenInformation());
     }
 
     private String newGossipRecord(

--- a/priam/src/test/java/com/netflix/priam/notification/TestBackupNotificationMgr.java
+++ b/priam/src/test/java/com/netflix/priam/notification/TestBackupNotificationMgr.java
@@ -18,8 +18,8 @@ import mockit.Capturing;
 import mockit.Expectations;
 import mockit.Mocked;
 import mockit.Verifications;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestBackupNotificationMgr {
     private Injector injector;
@@ -27,7 +27,7 @@ public class TestBackupNotificationMgr {
     private Provider<AbstractBackupPath> abstractBackupPathProvider;
     private IConfiguration configuration;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         if (injector == null) {
             injector = Guice.createInjector(new BRTestModule());

--- a/priam/src/test/java/com/netflix/priam/resources/BackupServletTest.java
+++ b/priam/src/test/java/com/netflix/priam/resources/BackupServletTest.java
@@ -17,7 +17,7 @@
 
 package com.netflix.priam.resources;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -33,8 +33,8 @@ import javax.ws.rs.core.Response;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BackupServletTest {
     private IConfiguration config;
@@ -44,7 +44,7 @@ public class BackupServletTest {
     private RestoreServlet restoreResource;
     private InstanceInfo instanceInfo;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         Injector injector = Guice.createInjector(new BRTestModule());
         config = injector.getInstance(IConfiguration.class);

--- a/priam/src/test/java/com/netflix/priam/resources/BackupServletV2Test.java
+++ b/priam/src/test/java/com/netflix/priam/resources/BackupServletV2Test.java
@@ -1,6 +1,6 @@
 package com.netflix.priam.resources;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -27,8 +27,8 @@ import javax.ws.rs.core.Response;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BackupServletV2Test {
     private IConfiguration config;
@@ -53,7 +53,7 @@ public class BackupServletV2Test {
     private static Provider<AbstractBackupPath> pathProvider;
     private static IConfiguration configuration;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         Injector injector = Guice.createInjector(new BRTestModule());
         config = injector.getInstance(IConfiguration.class);

--- a/priam/src/test/java/com/netflix/priam/resources/CassandraConfigTest.java
+++ b/priam/src/test/java/com/netflix/priam/resources/CassandraConfigTest.java
@@ -17,9 +17,7 @@
 
 package com.netflix.priam.resources;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Guice;
@@ -35,8 +33,8 @@ import java.util.List;
 import javax.ws.rs.core.Response;
 import mockit.Expectations;
 import mockit.Mocked;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CassandraConfigTest {
     private @Mocked PriamServer priamServer;
@@ -44,7 +42,7 @@ public class CassandraConfigTest {
     private CassandraConfig resource;
     private InstanceIdentity instanceIdentity;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         CassMonitorMetrics cassMonitorMetrics =
                 Guice.createInjector(new BRTestModule()).getInstance(CassMonitorMetrics.class);
@@ -264,31 +262,39 @@ public class CassandraConfigTest {
         }
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void doubleRing_ioExceptionInRestore() throws Exception {
-        new Expectations() {
-            {
-                doubleRing.backup();
-                result = new IOException();
-                doubleRing.restore();
-                result = new IOException();
-            }
-        };
+        assertThrows(
+                IOException.class,
+                () -> {
+                    new Expectations() {
+                        {
+                            doubleRing.backup();
+                            result = new IOException();
+                            doubleRing.restore();
+                            result = new IOException();
+                        }
+                    };
 
-        resource.doubleRing();
+                    resource.doubleRing();
+                });
     }
 
-    @Test(expected = ClassNotFoundException.class)
+    @Test
     public void doubleRing_classNotFoundExceptionInRestore() throws Exception {
-        new Expectations() {
-            {
-                doubleRing.backup();
-                result = new IOException();
-                doubleRing.restore();
-                result = new ClassNotFoundException();
-            }
-        };
+        assertThrows(
+                ClassNotFoundException.class,
+                () -> {
+                    new Expectations() {
+                        {
+                            doubleRing.backup();
+                            result = new IOException();
+                            doubleRing.restore();
+                            result = new ClassNotFoundException();
+                        }
+                    };
 
-        resource.doubleRing();
+                    resource.doubleRing();
+                });
     }
 }

--- a/priam/src/test/java/com/netflix/priam/resources/PriamConfigTest.java
+++ b/priam/src/test/java/com/netflix/priam/resources/PriamConfigTest.java
@@ -16,7 +16,7 @@
  */
 package com.netflix.priam.resources;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.netflix.priam.PriamServer;
 import com.netflix.priam.config.FakeConfiguration;
@@ -26,8 +26,8 @@ import java.util.Map;
 import javax.ws.rs.core.Response;
 import mockit.Expectations;
 import mockit.Mocked;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class PriamConfigTest {
     private @Mocked PriamServer priamServer;
@@ -36,7 +36,7 @@ public class PriamConfigTest {
 
     private FakeConfiguration fakeConfiguration;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         resource = new PriamConfig(priamServer);
         fakeConfiguration = new FakeConfiguration("cass_test");

--- a/priam/src/test/java/com/netflix/priam/resources/PriamInstanceResourceTest.java
+++ b/priam/src/test/java/com/netflix/priam/resources/PriamInstanceResourceTest.java
@@ -17,8 +17,8 @@
 
 package com.netflix.priam.resources;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.ImmutableSet;
 import com.netflix.priam.config.IConfiguration;
@@ -29,8 +29,8 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import mockit.Expectations;
 import mockit.Mocked;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class PriamInstanceResourceTest {
     private static final String APP_NAME = "myApp";
@@ -41,7 +41,7 @@ public class PriamInstanceResourceTest {
     private @Mocked InstanceInfo instanceInfo;
     private PriamInstanceResource resource;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         resource = new PriamInstanceResource(config, factory, instanceInfo);
     }

--- a/priam/src/test/java/com/netflix/priam/restore/TestPostRestoreHook.java
+++ b/priam/src/test/java/com/netflix/priam/restore/TestPostRestoreHook.java
@@ -22,15 +22,15 @@ import com.netflix.priam.TestModule;
 import com.netflix.priam.config.IConfiguration;
 import java.io.File;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestPostRestoreHook {
 
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void setup() {
         Injector inject = Guice.createInjector(new TestModule());
         IConfiguration configuration = inject.getInstance(IConfiguration.class);
@@ -55,7 +55,7 @@ public class TestPostRestoreHook {
     public void testPostRestoreHookValidParameters() {
         Injector inject = Guice.createInjector(new TestModule());
         IPostRestoreHook postRestoreHook = inject.getInstance(IPostRestoreHook.class);
-        Assert.assertTrue(postRestoreHook.hasValidParameters());
+        Assertions.assertTrue(postRestoreHook.hasValidParameters());
     }
 
     @Test
@@ -111,7 +111,7 @@ public class TestPostRestoreHook {
                                 // add a delay to heartbeat
                                 Thread.sleep(delayInMs);
                                 if (!heartBeatFile.exists() && !heartBeatFile.createNewFile()) {
-                                    Assert.fail("Unable to create heartbeat file");
+                                    Assertions.fail("Unable to create heartbeat file");
                                 }
                                 for (int i = 0; i < 10; i++) {
                                     FileUtils.touch(heartBeatFile);
@@ -121,7 +121,7 @@ public class TestPostRestoreHook {
                                 File doneFile = new File(doneFileName);
                                 doneFile.createNewFile();
                             } catch (Exception ex) {
-                                Assert.fail(ex.getMessage());
+                                Assertions.fail(ex.getMessage());
                             }
                         });
 

--- a/priam/src/test/java/com/netflix/priam/restore/TestRestore.java
+++ b/priam/src/test/java/com/netflix/priam/restore/TestRestore.java
@@ -29,9 +29,9 @@ import com.netflix.priam.identity.config.InstanceInfo;
 import com.netflix.priam.utils.DateUtil;
 import java.io.IOException;
 import java.util.ArrayList;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestRestore {
     private static FakeBackupFileSystem filesystem;
@@ -41,7 +41,7 @@ public class TestRestore {
     private static Restore restore;
     private static InstanceState instanceState;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws InterruptedException, IOException {
         Injector injector = Guice.createInjector(new BRTestModule());
         if (filesystem == null) filesystem = injector.getInstance(FakeBackupFileSystem.class);
@@ -71,13 +71,13 @@ public class TestRestore {
         populateBackupFileSystem("test_backup");
         String dateRange = "201108110030,201108110530";
         restore.restore(new DateUtil.DateRange(dateRange));
-        Assert.assertTrue(filesystem.downloadedFiles.contains(fileList.get(0)));
-        Assert.assertTrue(filesystem.downloadedFiles.contains(fileList.get(1)));
-        Assert.assertTrue(filesystem.downloadedFiles.contains(fileList.get(2)));
-        Assert.assertTrue(filesystem.downloadedFiles.contains(fileList.get(3)));
-        Assert.assertFalse(filesystem.downloadedFiles.contains(fileList.get(4)));
-        Assert.assertFalse(filesystem.downloadedFiles.contains(fileList.get(5)));
-        Assert.assertEquals(Status.FINISHED, instanceState.getRestoreStatus().getStatus());
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(fileList.get(0)));
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(fileList.get(1)));
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(fileList.get(2)));
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(fileList.get(3)));
+        Assertions.assertFalse(filesystem.downloadedFiles.contains(fileList.get(4)));
+        Assertions.assertFalse(filesystem.downloadedFiles.contains(fileList.get(5)));
+        Assertions.assertEquals(Status.FINISHED, instanceState.getRestoreStatus().getStatus());
     }
 
     @Test
@@ -85,13 +85,13 @@ public class TestRestore {
         populateBackupFileSystem("test_backup");
         String dateRange = "201108110030,201108110730";
         restore.restore(new DateUtil.DateRange(dateRange));
-        Assert.assertTrue(filesystem.downloadedFiles.contains(fileList.get(0)));
-        Assert.assertTrue(filesystem.downloadedFiles.contains(fileList.get(1)));
-        Assert.assertTrue(filesystem.downloadedFiles.contains(fileList.get(2)));
-        Assert.assertTrue(filesystem.downloadedFiles.contains(fileList.get(3)));
-        Assert.assertTrue(filesystem.downloadedFiles.contains(fileList.get(4)));
-        Assert.assertTrue(filesystem.downloadedFiles.contains(fileList.get(5)));
-        Assert.assertEquals(Status.FINISHED, instanceState.getRestoreStatus().getStatus());
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(fileList.get(0)));
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(fileList.get(1)));
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(fileList.get(2)));
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(fileList.get(3)));
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(fileList.get(4)));
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(fileList.get(5)));
+        Assertions.assertEquals(Status.FINISHED, instanceState.getRestoreStatus().getStatus());
     }
 
     @Test
@@ -102,15 +102,15 @@ public class TestRestore {
         filesystem.addFile(metafile);
         String dateRange = "201108110030,201108110530";
         restore.restore(new DateUtil.DateRange(dateRange));
-        Assert.assertFalse(filesystem.downloadedFiles.contains(fileList.get(0)));
-        Assert.assertTrue(filesystem.downloadedFiles.contains(metafile));
-        Assert.assertFalse(filesystem.downloadedFiles.contains(fileList.get(1)));
-        Assert.assertFalse(filesystem.downloadedFiles.contains(fileList.get(2)));
-        Assert.assertFalse(filesystem.downloadedFiles.contains(fileList.get(3)));
-        Assert.assertFalse(filesystem.downloadedFiles.contains(fileList.get(4)));
-        Assert.assertFalse(filesystem.downloadedFiles.contains(fileList.get(5)));
-        Assert.assertEquals(Status.FINISHED, instanceState.getRestoreStatus().getStatus());
-        Assert.assertEquals(metafile, instanceState.getRestoreStatus().getSnapshotMetaFile());
+        Assertions.assertFalse(filesystem.downloadedFiles.contains(fileList.get(0)));
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(metafile));
+        Assertions.assertFalse(filesystem.downloadedFiles.contains(fileList.get(1)));
+        Assertions.assertFalse(filesystem.downloadedFiles.contains(fileList.get(2)));
+        Assertions.assertFalse(filesystem.downloadedFiles.contains(fileList.get(3)));
+        Assertions.assertFalse(filesystem.downloadedFiles.contains(fileList.get(4)));
+        Assertions.assertFalse(filesystem.downloadedFiles.contains(fileList.get(5)));
+        Assertions.assertEquals(Status.FINISHED, instanceState.getRestoreStatus().getStatus());
+        Assertions.assertEquals(metafile, instanceState.getRestoreStatus().getSnapshotMetaFile());
     }
 
     @Test
@@ -124,16 +124,16 @@ public class TestRestore {
         filesystem.addFile(snapFile);
         String dateRange = "201108110030,201108110530";
         restore.restore(new DateUtil.DateRange(dateRange));
-        Assert.assertFalse(filesystem.downloadedFiles.contains(fileList.get(0)));
-        Assert.assertTrue(filesystem.downloadedFiles.contains(metafile));
-        Assert.assertTrue(filesystem.downloadedFiles.contains(snapFile));
-        Assert.assertFalse(filesystem.downloadedFiles.contains(fileList.get(1)));
-        Assert.assertFalse(filesystem.downloadedFiles.contains(fileList.get(2)));
-        Assert.assertFalse(filesystem.downloadedFiles.contains(fileList.get(3)));
-        Assert.assertFalse(filesystem.downloadedFiles.contains(fileList.get(4)));
-        Assert.assertFalse(filesystem.downloadedFiles.contains(fileList.get(5)));
-        Assert.assertEquals(Status.FINISHED, instanceState.getRestoreStatus().getStatus());
-        Assert.assertEquals(metafile, instanceState.getRestoreStatus().getSnapshotMetaFile());
+        Assertions.assertFalse(filesystem.downloadedFiles.contains(fileList.get(0)));
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(metafile));
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(snapFile));
+        Assertions.assertFalse(filesystem.downloadedFiles.contains(fileList.get(1)));
+        Assertions.assertFalse(filesystem.downloadedFiles.contains(fileList.get(2)));
+        Assertions.assertFalse(filesystem.downloadedFiles.contains(fileList.get(3)));
+        Assertions.assertFalse(filesystem.downloadedFiles.contains(fileList.get(4)));
+        Assertions.assertFalse(filesystem.downloadedFiles.contains(fileList.get(5)));
+        Assertions.assertEquals(Status.FINISHED, instanceState.getRestoreStatus().getStatus());
+        Assertions.assertEquals(metafile, instanceState.getRestoreStatus().getSnapshotMetaFile());
     }
 
     @Test
@@ -142,7 +142,7 @@ public class TestRestore {
         filesystem.setupTest(fileList);
         String dateRange = "201109110030,201109110530";
         restore.restore(new DateUtil.DateRange(dateRange));
-        Assert.assertEquals(Status.FAILED, instanceState.getRestoreStatus().getStatus());
+        Assertions.assertEquals(Status.FAILED, instanceState.getRestoreStatus().getStatus());
     }
 
     @Test
@@ -151,12 +151,12 @@ public class TestRestore {
         String dateRange = "201108110030,201108110530";
         restore.restore(new DateUtil.DateRange(dateRange));
         System.out.println("Downloaded files: " + filesystem.downloadedFiles);
-        Assert.assertTrue(filesystem.downloadedFiles.contains(fileList.get(0)));
-        Assert.assertTrue(filesystem.downloadedFiles.contains(fileList.get(1)));
-        Assert.assertTrue(filesystem.downloadedFiles.contains(fileList.get(2)));
-        Assert.assertTrue(filesystem.downloadedFiles.contains(fileList.get(3)));
-        Assert.assertFalse(filesystem.downloadedFiles.contains(fileList.get(4)));
-        Assert.assertFalse(filesystem.downloadedFiles.contains(fileList.get(5)));
-        Assert.assertEquals(Status.FINISHED, instanceState.getRestoreStatus().getStatus());
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(fileList.get(0)));
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(fileList.get(1)));
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(fileList.get(2)));
+        Assertions.assertTrue(filesystem.downloadedFiles.contains(fileList.get(3)));
+        Assertions.assertFalse(filesystem.downloadedFiles.contains(fileList.get(4)));
+        Assertions.assertFalse(filesystem.downloadedFiles.contains(fileList.get(5)));
+        Assertions.assertEquals(Status.FINISHED, instanceState.getRestoreStatus().getStatus());
     }
 }

--- a/priam/src/test/java/com/netflix/priam/scheduler/TestGuiceSingleton.java
+++ b/priam/src/test/java/com/netflix/priam/scheduler/TestGuiceSingleton.java
@@ -21,7 +21,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Singleton;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestGuiceSingleton {
     @Test

--- a/priam/src/test/java/com/netflix/priam/scheduler/TestScheduler.java
+++ b/priam/src/test/java/com/netflix/priam/scheduler/TestScheduler.java
@@ -25,9 +25,9 @@ import com.netflix.priam.TestModule;
 import com.netflix.priam.config.IConfiguration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TestScheduler {
     // yuck, but marginally better than using Thread.sleep
@@ -46,7 +46,7 @@ public class TestScheduler {
     }
 
     @Test
-    @Ignore(
+    @Disabled(
             "not sure what this test really does, except test countdown latch and thread context switching")
     public void testSingleInstanceSchedule() throws Exception {
         latch = new CountDownLatch(3);
@@ -57,10 +57,10 @@ public class TestScheduler {
         // verify 3 tasks run or fail in 1s
         latch.await(2000, TimeUnit.MILLISECONDS);
         scheduler.shutdown();
-        Assert.assertEquals(3, SingleTestTask.count);
+        Assertions.assertEquals(3, SingleTestTask.count);
     }
 
-    @Ignore
+    @Disabled
     public static class TestTask extends Task {
         @Inject
         public TestTask(IConfiguration config) {
@@ -80,7 +80,7 @@ public class TestScheduler {
         }
     }
 
-    @Ignore
+    @Disabled
     @Singleton
     public static class SingleTestTask extends Task {
         @Inject

--- a/priam/src/test/java/com/netflix/priam/stream/StreamingTest.java
+++ b/priam/src/test/java/com/netflix/priam/stream/StreamingTest.java
@@ -25,8 +25,8 @@ import com.netflix.priam.backup.BRTestModule;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.identity.InstanceIdentity;
 import com.netflix.priam.utils.FifoQueue;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StreamingTest {
 
@@ -34,8 +34,8 @@ public class StreamingTest {
     public void testFifoAddAndRemove() {
         FifoQueue<Long> queue = new FifoQueue<>(10);
         for (long i = 0; i < 100; i++) queue.adjustAndAdd(i);
-        Assert.assertEquals(10, queue.size());
-        Assert.assertEquals(new Long(90), queue.first());
+        Assertions.assertEquals(10, queue.size());
+        Assertions.assertEquals(new Long(90), queue.first());
     }
 
     @Test
@@ -94,25 +94,25 @@ public class StreamingTest {
                         + region
                         + "/fakecluster/123456/201108290000"
                         + "/SNAP/ks1/cf2/f129.db");
-        Assert.assertTrue(queue.contains(path));
+        Assertions.assertTrue(queue.contains(path));
         path.parseRemote(
                 "test_backup/"
                         + region
                         + "/fakecluster/123456/201108290000"
                         + "/SNAP/ks1/cf2/f229.db");
-        Assert.assertTrue(queue.contains(path));
+        Assertions.assertTrue(queue.contains(path));
         path.parseRemote(
                 "test_backup/"
                         + region
                         + "/fakecluster/123456/201108290000"
                         + "/SNAP/ks1/cf2/f329.db");
-        Assert.assertTrue(queue.contains(path));
+        Assertions.assertTrue(queue.contains(path));
 
         path.parseRemote(
                 "test_backup/"
                         + region
                         + "/fakecluster/123456/201108260000/SNAP/ks1/cf2/f326.db To: cass/data/ks1/cf2/f326.db");
-        Assert.assertEquals(path, queue.first());
+        Assertions.assertEquals(path, queue.first());
     }
 
     @Test

--- a/priam/src/test/java/com/netflix/priam/tuner/JVMOptionTunerTest.java
+++ b/priam/src/test/java/com/netflix/priam/tuner/JVMOptionTunerTest.java
@@ -17,15 +17,15 @@
 
 package com.netflix.priam.tuner;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.netflix.priam.config.FakeConfiguration;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.scheduler.UnsupportedTypeException;
 import java.util.*;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Created by aagrawal on 8/29/17. */
 public class JVMOptionTunerTest {

--- a/priam/src/test/java/com/netflix/priam/tuner/StandardTunerTest.java
+++ b/priam/src/test/java/com/netflix/priam/tuner/StandardTunerTest.java
@@ -17,7 +17,7 @@
 
 package com.netflix.priam.tuner;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.io.Files;
 import com.google.inject.Guice;
@@ -37,10 +37,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
@@ -103,8 +103,8 @@ public class StandardTunerTest {
         assertEquals(BOP_PARTITIONER, partitioner);
     }
 
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void cleanup() {
         FileUtils.deleteQuietly(target);
     }
@@ -155,12 +155,14 @@ public class StandardTunerTest {
         options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
         Yaml yaml = new Yaml(options);
         Map map = yaml.load(new FileInputStream(target));
-        Assert.assertEquals("your_host", map.get("listen_address"));
-        Assert.assertEquals("true", ((Map) map.get("client_encryption_options")).get("optional"));
-        Assert.assertEquals(
+        Assertions.assertEquals("your_host", map.get("listen_address"));
+        Assertions.assertEquals(
+                "true", ((Map) map.get("client_encryption_options")).get("optional"));
+        Assertions.assertEquals(
                 "test", ((Map) map.get("client_encryption_options")).get("keystore_password"));
-        Assert.assertEquals("randomKeyValue", map.get("randomKey"));
-        Assert.assertEquals("randomGroupValue", ((Map) map.get("randomGroup")).get("randomKey"));
+        Assertions.assertEquals("randomKeyValue", map.get("randomKey"));
+        Assertions.assertEquals(
+                "randomGroupValue", ((Map) map.get("randomGroup")).get("randomKey"));
     }
 
     private class TunerConfiguration extends FakeConfiguration {

--- a/priam/src/test/java/com/netflix/priam/tuner/dse/DseTunerTest.java
+++ b/priam/src/test/java/com/netflix/priam/tuner/dse/DseTunerTest.java
@@ -25,9 +25,9 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Properties;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DseTunerTest {
     private IConfiguration config;
@@ -37,7 +37,7 @@ public class DseTunerTest {
     private File targetFile;
     private File targetDseYamlFile;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
         config = new FakeConfiguration();
         dseConfig = new DseConfigStub();
@@ -58,7 +58,7 @@ public class DseTunerTest {
 
         Properties p = new Properties();
         p.load(new FileReader(targetFile));
-        Assert.assertTrue(p.containsKey(AuditLogTunerLog4J.PRIMARY_AUDIT_LOG_ENTRY));
+        Assertions.assertTrue(p.containsKey(AuditLogTunerLog4J.PRIMARY_AUDIT_LOG_ENTRY));
     }
 
     @Test
@@ -68,7 +68,7 @@ public class DseTunerTest {
 
         Properties p = new Properties();
         p.load(new FileReader(targetFile));
-        Assert.assertFalse(p.containsKey(AuditLogTunerLog4J.PRIMARY_AUDIT_LOG_ENTRY));
+        Assertions.assertFalse(p.containsKey(AuditLogTunerLog4J.PRIMARY_AUDIT_LOG_ENTRY));
     }
 
     /**

--- a/priam/src/test/java/com/netflix/priam/utils/Murmur3TokenManagerTest.java
+++ b/priam/src/test/java/com/netflix/priam/utils/Murmur3TokenManagerTest.java
@@ -19,8 +19,7 @@ package com.netflix.priam.utils;
 
 import static com.netflix.priam.utils.TokenManager.MAXIMUM_TOKEN_MURMUR3;
 import static com.netflix.priam.utils.TokenManager.MINIMUM_TOKEN_MURMUR3;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.ImmutableList;
 import com.netflix.priam.config.FakeConfiguration;
@@ -28,31 +27,43 @@ import com.netflix.priam.config.IConfiguration;
 import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class Murmur3TokenManagerTest {
     private TokenManager tokenManager;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         IConfiguration config = new Murmur3Configuration();
         this.tokenManager = new TokenManager(config);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void initialToken_zeroSize() {
-        tokenManager.initialToken(0, 0, 1);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    tokenManager.initialToken(0, 0, 1);
+                });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void initialToken_negativePosition() {
-        tokenManager.initialToken(1, -1, 1);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    tokenManager.initialToken(1, -1, 1);
+                });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void initialToken_negativeOffset() {
-        tokenManager.initialToken(1, 0, -1);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    tokenManager.initialToken(1, 0, -1);
+                });
     }
 
     @Test
@@ -99,9 +110,13 @@ public class Murmur3TokenManagerTest {
                 tokenManager.createToken(10, 256, "region"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void findClosestToken_emptyTokenList() {
-        tokenManager.findClosestToken(BigInteger.ZERO, Collections.emptyList());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    tokenManager.findClosestToken(BigInteger.ZERO, Collections.emptyList());
+                });
     }
 
     @Test
@@ -177,11 +192,11 @@ public class Murmur3TokenManagerTest {
             for (String region2 : allRegions.split(",")) {
                 if (region1.equals(region2)) continue;
                 assertFalse(
-                        "Diffrence seems to be low",
                         Math.abs(
                                         tokenManager.regionOffset(region1)
                                                 - tokenManager.regionOffset(region2))
-                                < 100);
+                                < 100,
+                        "Diffrence seems to be low");
             }
     }
 

--- a/priam/src/test/java/com/netflix/priam/utils/RandomTokenManagerTest.java
+++ b/priam/src/test/java/com/netflix/priam/utils/RandomTokenManagerTest.java
@@ -19,39 +19,50 @@ package com.netflix.priam.utils;
 
 import static com.netflix.priam.utils.TokenManager.MAXIMUM_TOKEN_RANDOM;
 import static com.netflix.priam.utils.TokenManager.MINIMUM_TOKEN_RANDOM;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.ImmutableList;
 import com.netflix.priam.config.FakeConfiguration;
 import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RandomTokenManagerTest {
     private TokenManager tokenManager;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         FakeConfiguration config = new FakeConfiguration();
         this.tokenManager = new TokenManager(config);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void initialToken_zeroSize() {
-        tokenManager.initialToken(0, 0, 1);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    tokenManager.initialToken(0, 0, 1);
+                });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void initialToken_negativePosition() {
-        tokenManager.initialToken(1, -1, 1);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    tokenManager.initialToken(1, -1, 1);
+                });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void initialToken_negativeOffset() {
-        tokenManager.initialToken(1, 0, -1);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    tokenManager.initialToken(1, 0, -1);
+                });
     }
 
     @Test
@@ -96,9 +107,13 @@ public class RandomTokenManagerTest {
                 tokenManager.createToken(10, 256, "region"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void findClosestToken_emptyTokenList() {
-        tokenManager.findClosestToken(BigInteger.ZERO, Collections.emptyList());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    tokenManager.findClosestToken(BigInteger.ZERO, Collections.emptyList());
+                });
     }
 
     @Test
@@ -175,11 +190,11 @@ public class RandomTokenManagerTest {
             for (String region2 : allRegions.split(",")) {
                 if (region1.equals(region2)) continue;
                 assertFalse(
-                        "Diffrence seems to be low",
                         Math.abs(
                                         tokenManager.regionOffset(region1)
                                                 - tokenManager.regionOffset(region2))
-                                < 100);
+                                < 100,
+                        "Diffrence seems to be low");
             }
     }
 

--- a/priam/src/test/java/com/netflix/priam/utils/TestDateUtils.java
+++ b/priam/src/test/java/com/netflix/priam/utils/TestDateUtils.java
@@ -21,8 +21,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /** Created by aagrawal on 11/29/18. */
 public class TestDateUtils {
@@ -34,7 +34,7 @@ public class TestDateUtils {
         DateUtil.DateRange dateRange = new DateUtil.DateRange(input);
 
         // Start and end should be a day apart.
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 dateRange.getEndTime(), dateRange.getStartTime().plus(1, ChronoUnit.DAYS));
         if (Duration.between(dateRange.getEndTime(), now).getSeconds() > 5)
             throw new AssertionError(
@@ -49,7 +49,7 @@ public class TestDateUtils {
         DateUtil.DateRange dateRange = new DateUtil.DateRange("     ");
 
         // Start and end should be a day apart.
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 dateRange.getEndTime(), dateRange.getStartTime().plus(1, ChronoUnit.DAYS));
         if (Duration.between(dateRange.getEndTime(), now).getSeconds() > 5)
             throw new AssertionError(
@@ -63,21 +63,21 @@ public class TestDateUtils {
         String start = "201801011201";
         String end = "201801051201";
         DateUtil.DateRange dateRange = new DateUtil.DateRange(start + "," + end);
-        Assert.assertEquals(Instant.ofEpochSecond(1514808060), dateRange.getStartTime());
-        Assert.assertEquals(Instant.ofEpochSecond(1515153660), dateRange.getEndTime());
+        Assertions.assertEquals(Instant.ofEpochSecond(1514808060), dateRange.getStartTime());
+        Assertions.assertEquals(Instant.ofEpochSecond(1515153660), dateRange.getEndTime());
 
         start = "20180101";
         end = "20180105";
         dateRange = new DateUtil.DateRange(start + "," + end);
-        Assert.assertEquals(Instant.ofEpochSecond(1514764800), dateRange.getStartTime());
-        Assert.assertEquals(Instant.ofEpochSecond(1515110400), dateRange.getEndTime());
+        Assertions.assertEquals(Instant.ofEpochSecond(1514764800), dateRange.getStartTime());
+        Assertions.assertEquals(Instant.ofEpochSecond(1515110400), dateRange.getEndTime());
     }
 
     @Test
     public void testDateRangeRandom() {
         DateUtil.DateRange dateRange = new DateUtil.DateRange("some,random,values");
-        Assert.assertEquals(null, dateRange.getStartTime());
-        Assert.assertEquals(null, dateRange.getEndTime());
+        Assertions.assertEquals(null, dateRange.getStartTime());
+        Assertions.assertEquals(null, dateRange.getEndTime());
     }
 
     @Test
@@ -85,10 +85,10 @@ public class TestDateUtils {
         Instant dateStart = Instant.ofEpochMilli(1543632497000L);
         Instant dateEnd = Instant.ofEpochMilli(1543819697000L);
         DateUtil.DateRange dateRange = new DateUtil.DateRange(dateStart, dateEnd);
-        Assert.assertEquals("1543", dateRange.match());
+        Assertions.assertEquals("1543", dateRange.match());
 
         dateRange = new DateUtil.DateRange(dateStart, null);
-        Assert.assertEquals(StringUtils.EMPTY, dateRange.match());
+        Assertions.assertEquals(StringUtils.EMPTY, dateRange.match());
     }
 
     @Test
@@ -96,8 +96,8 @@ public class TestDateUtils {
         String start = "202801011201";
         String end = "202801051201";
         DateUtil.DateRange dateRange = new DateUtil.DateRange(start + "," + end);
-        Assert.assertEquals(Instant.ofEpochSecond(1830340860), dateRange.getStartTime());
-        Assert.assertEquals(Instant.ofEpochSecond(1830686460), dateRange.getEndTime());
-        Assert.assertEquals("1830", dateRange.match());
+        Assertions.assertEquals(Instant.ofEpochSecond(1830340860), dateRange.getStartTime());
+        Assertions.assertEquals(Instant.ofEpochSecond(1830686460), dateRange.getEndTime());
+        Assertions.assertEquals("1830", dateRange.match());
     }
 }

--- a/priam/src/test/java/com/netflix/priam/utils/TestGsonJsonSerializer.java
+++ b/priam/src/test/java/com/netflix/priam/utils/TestGsonJsonSerializer.java
@@ -21,8 +21,8 @@ import com.netflix.priam.backup.BackupVersion;
 import com.netflix.priam.health.InstanceState;
 import java.time.LocalDateTime;
 import java.util.Calendar;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,8 +42,8 @@ public class TestGsonJsonSerializer {
         BackupMetadata metadata1 =
                 GsonJsonSerializer.getGson().fromJson(json, BackupMetadata.class);
         LOG.info(metadata1.toString());
-        Assert.assertEquals(metadata.getSnapshotDate(), metadata1.getSnapshotDate());
-        Assert.assertEquals(metadata.getToken(), metadata1.getToken());
+        Assertions.assertEquals(metadata.getSnapshotDate(), metadata1.getSnapshotDate());
+        Assertions.assertEquals(metadata.getToken(), metadata1.getToken());
     }
 
     @Test
@@ -59,9 +59,10 @@ public class TestGsonJsonSerializer {
                         .fromJson(restoreStatus.toString(), InstanceState.RestoreStatus.class);
         LOG.info(restoreStatus1.toString());
 
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 restoreStatus.getExecutionStartTime(), restoreStatus1.getExecutionStartTime());
-        Assert.assertEquals(restoreStatus.getStartDateRange(), restoreStatus1.getStartDateRange());
-        Assert.assertEquals(restoreStatus.getEndDateRange(), restoreStatus1.getEndDateRange());
+        Assertions.assertEquals(
+                restoreStatus.getStartDateRange(), restoreStatus1.getStartDateRange());
+        Assertions.assertEquals(restoreStatus.getEndDateRange(), restoreStatus1.getEndDateRange());
     }
 }

--- a/priam/src/test/java/com/netflix/priam/utils/TestSystemUtils.java
+++ b/priam/src/test/java/com/netflix/priam/utils/TestSystemUtils.java
@@ -17,8 +17,8 @@
 
 package com.netflix.priam.utils;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /** Created by aagrawal on 12/1/18. */
 public class TestSystemUtils {
@@ -27,6 +27,6 @@ public class TestSystemUtils {
     public void testGetDataFromUrl() {
         String dummyurl = "https://jsonplaceholder.typicode.com/todos/1";
         String response = SystemUtils.getDataFromUrl(dummyurl);
-        Assert.assertNotNull(response);
+        Assertions.assertNotNull(response);
     }
 }


### PR DESCRIPTION
👋 Hi team! Hope this helps get you the rest of the way to JUnit 5, eliminating all remaining uses of JUnit 4. 

This PR was created with [OpenRewrite](https://github.com/openrewrite/rewrite), based off a technology that originated at Netflix engineering tools in 2016. It's coming home to help now 😉 .

Co-authored-by: Moderne <team@moderne.io>