### PR TITLE
CASS-2201 Ensure SI backup directories are deleted when empty

### DIFF
--- a/priam/src/test/java/com/netflix/priam/backup/TestBackup.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackup.java
@@ -26,9 +26,13 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.stream.Stream;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.cassandra.tools.NodeProbe;
@@ -96,6 +100,10 @@ public class TestBackup {
         Assert.assertEquals(5, filesystem.uploadedFiles.size());
         for (String filePath : expectedFiles)
             Assert.assertTrue(filesystem.uploadedFiles.contains(filePath));
+        try (Stream<Path> entries =
+                Files.list(Paths.get("target/data/Keyspace1/Standard1/backups/"))) {
+            Assert.assertEquals(0, entries.count());
+        }
     }
 
     @Test


### PR DESCRIPTION
Futures.whenAllComplete does not fire for collections of already complete futures. Correcting logic to accommodate this.