### PR TITLE
Dynamic Rate Limiting of Snapshots

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/S3EncryptedFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3EncryptedFileSystem.java
@@ -19,6 +19,7 @@ import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.PartETag;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
@@ -26,6 +27,7 @@ import com.google.inject.name.Named;
 import com.netflix.priam.backup.AbstractBackupPath;
 import com.netflix.priam.backup.BackupRestoreException;
 import com.netflix.priam.backup.RangeReadInputStream;
+import com.netflix.priam.backup.RateLimiterFactory;
 import com.netflix.priam.compress.ChunkedStream;
 import com.netflix.priam.compress.ICompression;
 import com.netflix.priam.config.IConfiguration;
@@ -37,6 +39,7 @@ import com.netflix.priam.notification.BackupNotificationMgr;
 import java.io.*;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
@@ -97,7 +100,8 @@ public class S3EncryptedFileSystem extends S3FileSystemBase {
     }
 
     @Override
-    protected long uploadFileImpl(AbstractBackupPath path) throws BackupRestoreException {
+    protected long uploadFileImpl(AbstractBackupPath path, Instant target)
+            throws BackupRestoreException {
         Path localPath = Paths.get(path.getBackupFile().getAbsolutePath());
         String remotePath = path.getRemotePath();
 

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -20,7 +20,6 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.S3ResponseMetadata;
 import com.amazonaws.services.s3.model.*;
 import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.RateLimiter;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
@@ -28,8 +27,8 @@ import com.google.inject.name.Named;
 import com.netflix.priam.aws.auth.IS3Credential;
 import com.netflix.priam.backup.AbstractBackupPath;
 import com.netflix.priam.backup.BackupRestoreException;
+import com.netflix.priam.backup.DynamicRateLimiter;
 import com.netflix.priam.backup.RangeReadInputStream;
-import com.netflix.priam.backup.RateLimiterFactory;
 import com.netflix.priam.compress.ChunkedStream;
 import com.netflix.priam.compress.CompressionType;
 import com.netflix.priam.compress.ICompression;
@@ -56,6 +55,7 @@ import org.slf4j.LoggerFactory;
 public class S3FileSystem extends S3FileSystemBase {
     private static final Logger logger = LoggerFactory.getLogger(S3FileSystem.class);
     private static final long MAX_BUFFER_SIZE = 5L * 1024L * 1024L;
+    private final DynamicRateLimiter dynamicRateLimiter;
 
     @Inject
     public S3FileSystem(
@@ -65,13 +65,15 @@ public class S3FileSystem extends S3FileSystemBase {
             final IConfiguration config,
             BackupMetrics backupMetrics,
             BackupNotificationMgr backupNotificationMgr,
-            InstanceInfo instanceInfo) {
+            InstanceInfo instanceInfo,
+            DynamicRateLimiter dynamicRateLimiter) {
         super(pathProvider, compress, config, backupMetrics, backupNotificationMgr);
         s3Client =
                 AmazonS3Client.builder()
                         .withCredentials(cred.getAwsCredentialProvider())
                         .withRegion(instanceInfo.getRegion())
                         .build();
+        this.dynamicRateLimiter = dynamicRateLimiter;
     }
 
     @Override
@@ -141,6 +143,7 @@ public class S3FileSystem extends S3FileSystemBase {
             while (chunks.hasNext()) {
                 byte[] chunk = chunks.next();
                 rateLimiter.acquire(chunk.length);
+                dynamicRateLimiter.acquire(path, target, chunk.length);
                 DataPart dp = new DataPart(++partNum, chunk, prefix, remotePath, uploadId);
                 S3PartUploader partUploader = new S3PartUploader(s3Client, dp, partETags, partsPut);
                 compressedFileSize += chunk.length;
@@ -189,6 +192,7 @@ public class S3FileSystem extends S3FileSystemBase {
             // C* snapshots may have empty files. That is probably unintentional.
             if (chunk.length > 0) {
                 rateLimiter.acquire(chunk.length);
+                dynamicRateLimiter.acquire(path, target, chunk.length);
             }
             ObjectMetadata objectMetadata = getObjectMetadata(localFile);
             objectMetadata.setContentLength(chunk.length);

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystemBase.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystemBase.java
@@ -137,11 +137,11 @@ public abstract class S3FileSystemBase extends AbstractFileSystem {
         public void visit(LifecycleTagPredicate lifecycleTagPredicate) {}
 
         @Override
-        public void visit(LifecycleAndOperator lifecycleAndOperator) {}
-
-        @Override
         public void visit(
                 LifecycleObjectSizeGreaterThanPredicate lifecycleObjectSizeGreaterThanPredicate) {}
+
+        @Override
+        public void visit(LifecycleAndOperator lifecycleAndOperator) {}
 
         @Override
         public void visit(

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractFileSystem.java
@@ -191,7 +191,7 @@ public abstract class AbstractFileSystem implements IBackupFileSystem, EventGene
                             new BoundedExponentialRetryCallable<Long>(500, 10000, retry) {
                                 @Override
                                 public Long retriableCall() throws Exception {
-                                    return uploadFileImpl(path);
+                                    return uploadFileImpl(path, target);
                                 }
                             }.call();
 
@@ -272,7 +272,7 @@ public abstract class AbstractFileSystem implements IBackupFileSystem, EventGene
 
     protected abstract boolean doesRemoteFileExist(Path remotePath);
 
-    protected abstract long uploadFileImpl(final AbstractBackupPath path)
+    protected abstract long uploadFileImpl(final AbstractBackupPath path, Instant target)
             throws BackupRestoreException;
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractFileSystem.java
@@ -38,6 +38,7 @@ import com.netflix.spectator.api.patterns.PolledMeter;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -157,16 +158,17 @@ public abstract class AbstractFileSystem implements IBackupFileSystem, EventGene
 
     @Override
     public ListenableFuture<AbstractBackupPath> asyncUploadAndDelete(
-            final AbstractBackupPath path, final int retry) throws RejectedExecutionException {
+            final AbstractBackupPath path, final int retry, Instant target)
+            throws RejectedExecutionException {
         return fileUploadExecutor.submit(
                 () -> {
-                    uploadAndDelete(path, retry);
+                    uploadAndDelete(path, retry, target);
                     return path;
                 });
     }
 
     @Override
-    public void uploadAndDelete(final AbstractBackupPath path, final int retry)
+    public void uploadAndDelete(final AbstractBackupPath path, final int retry, Instant target)
             throws BackupRestoreException {
         Path localPath = Paths.get(path.getBackupFile().getAbsolutePath());
         File localFile = localPath.toFile();

--- a/priam/src/main/java/com/netflix/priam/backup/BackupDynamicRateLimiter.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupDynamicRateLimiter.java
@@ -1,0 +1,91 @@
+package com.netflix.priam.backup;
+
+import com.google.common.util.concurrent.RateLimiter;
+import com.netflix.priam.config.IConfiguration;
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import javax.inject.Inject;
+
+public class BackupDynamicRateLimiter implements DynamicRateLimiter {
+
+    private final Clock clock;
+    private final IConfiguration config;
+    private final RateLimiter rateLimiter;
+
+    @Inject
+    BackupDynamicRateLimiter(IConfiguration config, Clock clock) {
+        this.clock = clock;
+        this.config = config;
+        this.rateLimiter = RateLimiter.create(Double.MAX_VALUE);
+    }
+
+    @Override
+    public void acquire(AbstractBackupPath path, Instant target, int permits) {
+        if (target.equals(Instant.EPOCH)
+                || !path.getBackupFile()
+                        .getAbsolutePath()
+                        .contains(AbstractBackup.SNAPSHOT_FOLDER)) {
+            return;
+        }
+        long secondsRemaining = Duration.between(clock.instant(), target).getSeconds();
+        if (secondsRemaining < 1) {
+            // skip file system checks when unnecessary
+            return;
+        }
+        long bytesRemaining = getBytesRemaining();
+        if (bytesRemaining < 1) {
+            return;
+        }
+        double newRate = (double) bytesRemaining / secondsRemaining;
+        double oldRate = rateLimiter.getRate();
+        if ((Math.abs(newRate - oldRate) / oldRate) > config.getRateLimitChangeThreshold()) {
+            rateLimiter.setRate(newRate);
+        }
+        rateLimiter.acquire(permits);
+    }
+
+    private long getBytesRemaining() {
+        BackupFileVisitor fileVisitor = new BackupFileVisitor();
+        try {
+            Files.walkFileTree(Paths.get(config.getDataFileLocation()), fileVisitor);
+        } catch (IOException e) {
+            // BackupFileVisitor is happy with an estimate and won't produce these in practice.
+        }
+        return fileVisitor.getTotalBytes() / config.getBackupThreads();
+    }
+
+    private static final class BackupFileVisitor implements FileVisitor<Path> {
+        private long totalBytes;
+
+        @Override
+        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            if (file.toString().contains(AbstractBackup.SNAPSHOT_FOLDER) && attrs.isRegularFile()) {
+                totalBytes += attrs.size();
+            }
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFileFailed(Path file, IOException exc) {
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
+            return FileVisitResult.CONTINUE;
+        }
+
+        long getTotalBytes() {
+            return totalBytes;
+        }
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/backup/BackupDynamicRateLimiter.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupDynamicRateLimiter.java
@@ -1,10 +1,8 @@
 package com.netflix.priam.backup;
 
+import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.RateLimiter;
 import com.netflix.priam.config.IConfiguration;
-import java.io.IOException;
-import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -14,12 +12,14 @@ public class BackupDynamicRateLimiter implements DynamicRateLimiter {
 
     private final Clock clock;
     private final IConfiguration config;
+    private final DirectorySize dirSize;
     private final RateLimiter rateLimiter;
 
     @Inject
-    BackupDynamicRateLimiter(IConfiguration config, Clock clock) {
+    BackupDynamicRateLimiter(IConfiguration config, Clock clock, DirectorySize dirSize) {
         this.clock = clock;
         this.config = config;
+        this.dirSize = dirSize;
         this.rateLimiter = RateLimiter.create(Double.MAX_VALUE);
     }
 
@@ -36,56 +36,17 @@ public class BackupDynamicRateLimiter implements DynamicRateLimiter {
             // skip file system checks when unnecessary
             return;
         }
-        long bytesRemaining = getBytesRemaining();
-        if (bytesRemaining < 1) {
+        int backupThreads = config.getBackupThreads();
+        Preconditions.checkState(backupThreads > 0);
+        long bytesPerThread = this.dirSize.getBytes(config.getDataFileLocation()) / backupThreads;
+        if (bytesPerThread < 1) {
             return;
         }
-        double newRate = (double) bytesRemaining / secondsRemaining;
+        double newRate = (double) bytesPerThread / secondsRemaining;
         double oldRate = rateLimiter.getRate();
         if ((Math.abs(newRate - oldRate) / oldRate) > config.getRateLimitChangeThreshold()) {
             rateLimiter.setRate(newRate);
         }
         rateLimiter.acquire(permits);
-    }
-
-    private long getBytesRemaining() {
-        BackupFileVisitor fileVisitor = new BackupFileVisitor();
-        try {
-            Files.walkFileTree(Paths.get(config.getDataFileLocation()), fileVisitor);
-        } catch (IOException e) {
-            // BackupFileVisitor is happy with an estimate and won't produce these in practice.
-        }
-        return fileVisitor.getTotalBytes() / config.getBackupThreads();
-    }
-
-    private static final class BackupFileVisitor implements FileVisitor<Path> {
-        private long totalBytes;
-
-        @Override
-        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
-            return FileVisitResult.CONTINUE;
-        }
-
-        @Override
-        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-            if (file.toString().contains(AbstractBackup.SNAPSHOT_FOLDER) && attrs.isRegularFile()) {
-                totalBytes += attrs.size();
-            }
-            return FileVisitResult.CONTINUE;
-        }
-
-        @Override
-        public FileVisitResult visitFileFailed(Path file, IOException exc) {
-            return FileVisitResult.CONTINUE;
-        }
-
-        @Override
-        public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
-            return FileVisitResult.CONTINUE;
-        }
-
-        long getTotalBytes() {
-            return totalBytes;
-        }
     }
 }

--- a/priam/src/main/java/com/netflix/priam/backup/DirectorySize.java
+++ b/priam/src/main/java/com/netflix/priam/backup/DirectorySize.java
@@ -1,0 +1,10 @@
+package com.netflix.priam.backup;
+
+import com.google.inject.ImplementedBy;
+
+/** estimates the number of bytes remaining to upload in a snapshot */
+@ImplementedBy(SnapshotDirectorySize.class)
+public interface DirectorySize {
+    /** return the total bytes of all snapshot files south of location in the filesystem */
+    long getBytes(String location);
+}

--- a/priam/src/main/java/com/netflix/priam/backup/DynamicRateLimiter.java
+++ b/priam/src/main/java/com/netflix/priam/backup/DynamicRateLimiter.java
@@ -1,0 +1,9 @@
+package com.netflix.priam.backup;
+
+import com.google.inject.ImplementedBy;
+import java.time.Instant;
+
+@ImplementedBy(BackupDynamicRateLimiter.class)
+public interface DynamicRateLimiter {
+    void acquire(AbstractBackupPath dir, Instant target, int tokens);
+}

--- a/priam/src/main/java/com/netflix/priam/backup/IncrementalBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/IncrementalBackup.java
@@ -93,7 +93,7 @@ public class IncrementalBackup extends AbstractBackup {
                             && (SnapshotBackup.isBackupEnabled(configuration)
                                     || (backupRestoreConfig.enableV2Backups()
                                             && SnapshotMetaTask.isBackupEnabled(
-                                                    configuration, backupRestoreConfig))));
+                                                    backupRestoreConfig))));
             logger.info("Incremental backups are enabled: {}", enabled);
 
             if (!enabled) {

--- a/priam/src/main/java/com/netflix/priam/backup/SnapshotDirectorySize.java
+++ b/priam/src/main/java/com/netflix/priam/backup/SnapshotDirectorySize.java
@@ -1,0 +1,50 @@
+package com.netflix.priam.backup;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+
+/** Estimates remaining bytes to upload in a backup by looking at the file system */
+public class SnapshotDirectorySize implements DirectorySize {
+
+    public long getBytes(String location) {
+        SummingFileVisitor fileVisitor = new SummingFileVisitor();
+        try {
+            Files.walkFileTree(Paths.get(location), fileVisitor);
+        } catch (IOException e) {
+            // BackupFileVisitor is happy with an estimate and won't produce these in practice.
+        }
+        return fileVisitor.getTotalBytes();
+    }
+
+    private static final class SummingFileVisitor implements FileVisitor<Path> {
+        private long totalBytes;
+
+        @Override
+        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            if (file.toString().contains(AbstractBackup.SNAPSHOT_FOLDER) && attrs.isRegularFile()) {
+                totalBytes += attrs.size();
+            }
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFileFailed(Path file, IOException exc) {
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
+            return FileVisitResult.CONTINUE;
+        }
+
+        long getTotalBytes() {
+            return totalBytes;
+        }
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/backupv2/BackupV2Service.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/BackupV2Service.java
@@ -56,7 +56,10 @@ public class BackupV2Service implements IService {
 
     @Override
     public void scheduleService() throws Exception {
-        TaskTimer snapshotMetaTimer = SnapshotMetaTask.getTimer(configuration, backupRestoreConfig);
+        TaskTimer snapshotMetaTimer = SnapshotMetaTask.getTimer(backupRestoreConfig);
+        if (snapshotMetaTimer == null) {
+            SnapshotMetaTask.cleanOldBackups(configuration);
+        }
         scheduleTask(scheduler, SnapshotMetaTask.class, snapshotMetaTimer);
 
         if (snapshotMetaTimer != null) {

--- a/priam/src/main/java/com/netflix/priam/backupv2/FileUploadResult.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/FileUploadResult.java
@@ -73,6 +73,14 @@ public class FileUploadResult {
         isUploaded = uploaded;
     }
 
+    public Boolean getIsUploaded() {
+        return isUploaded;
+    }
+
+    public Path getFileName() {
+        return fileName;
+    }
+
     public String getBackupPath() {
         return backupPath;
     }

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaFileWriterBuilder.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaFileWriterBuilder.java
@@ -65,7 +65,7 @@ public class MetaFileWriterBuilder {
     }
 
     public interface DataStep {
-        DataStep addColumnfamilyResult(
+        ColumnfamilyResult addColumnfamilyResult(
                 String keyspace,
                 String columnFamily,
                 ImmutableMultimap<String, AbstractBackupPath> sstables)
@@ -142,7 +142,7 @@ public class MetaFileWriterBuilder {
          *
          * @throws IOException if unable to write to the file or if JSON is not valid
          */
-        public DataStep addColumnfamilyResult(
+        public ColumnfamilyResult addColumnfamilyResult(
                 String keyspace,
                 String columnFamily,
                 ImmutableMultimap<String, AbstractBackupPath> sstables)
@@ -151,8 +151,9 @@ public class MetaFileWriterBuilder {
             if (jsonWriter == null)
                 throw new NullPointerException(
                         "addColumnfamilyResult: Json Writer in MetaFileWriter is null. This should not happen!");
-            jsonWriter.jsonValue(toColumnFamilyResult(keyspace, columnFamily, sstables).toString());
-            return this;
+            ColumnfamilyResult result = toColumnFamilyResult(keyspace, columnFamily, sstables);
+            jsonWriter.jsonValue(result.toString());
+            return result;
         }
 
         /**

--- a/priam/src/main/java/com/netflix/priam/backupv2/SnapshotMetaTask.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/SnapshotMetaTask.java
@@ -264,17 +264,19 @@ public class SnapshotMetaTask extends AbstractBackup {
                     continue;
                 }
 
+                Instant target = getUploadTarget();
+
                 // Process each snapshot of SNAPSHOT_PREFIX
                 // We do not want to wait for completion and we just want to add them to queue. This
                 // is to ensure that next run happens on time.
                 AbstractBackupPath.BackupFileType type = AbstractBackupPath.BackupFileType.SST_V2;
-                uploadAndDeleteAllFiles(snapshotDirectory, type, true);
+                uploadAndDeleteAllFiles(snapshotDirectory, type, true, target);
 
                 // Next, upload secondary indexes
                 type = AbstractBackupPath.BackupFileType.SECONDARY_INDEX_V2;
                 ImmutableList<ListenableFuture<AbstractBackupPath>> futures;
                 for (File subDir : getSecondaryIndexDirectories(snapshotDirectory)) {
-                    futures = uploadAndDeleteAllFiles(subDir, type, true);
+                    futures = uploadAndDeleteAllFiles(subDir, type, true, target);
                     if (futures.isEmpty()) {
                         deleteIfEmpty(subDir);
                     }
@@ -282,6 +284,10 @@ public class SnapshotMetaTask extends AbstractBackup {
                 }
             }
         }
+    }
+
+    private Instant getUploadTarget() {
+        return Instant.EPOCH;
     }
 
     private Void deleteIfEmpty(File dir) {

--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -1148,6 +1148,19 @@ public interface IConfiguration {
         return false;
     }
 
+    /** returns how long a snapshot backup should take to upload in minutes */
+    default int getTargetMinutesToCompleteSnaphotUpload() {
+        return 0;
+    }
+
+    /**
+     * @return the percentage off of the old rate that the current rate must be to trigger a new
+     *     rate in the dynamic rate limiter
+     */
+    default double getRateLimitChangeThreshold() {
+        return 0.1;
+    }
+
     /**
      * Escape hatch for getting any arbitrary property by key This is useful so we don't have to
      * keep adding methods to this interface for every single configuration option ever. Also

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -789,4 +789,14 @@ public class PriamConfiguration implements IConfiguration {
     public boolean permitDirectTokenAssignmentWithGossipMismatch() {
         return config.get(PRIAM_PRE + ".permitDirectTokenAssignmentWithGossipMismatch", false);
     }
+
+    @Override
+    public int getTargetMinutesToCompleteSnaphotUpload() {
+        return config.get(PRIAM_PRE + ".snapshotUploadDuration", 0);
+    }
+
+    @Override
+    public double getRateLimitChangeThreshold() {
+        return config.get(PRIAM_PRE + ".rateLimitChangeThreshold", 0.1);
+    }
 }

--- a/priam/src/main/java/com/netflix/priam/google/GoogleEncryptedFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/google/GoogleEncryptedFileSystem.java
@@ -34,6 +34,7 @@ import com.netflix.priam.merics.BackupMetrics;
 import com.netflix.priam.notification.BackupNotificationMgr;
 import java.io.*;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -236,7 +237,8 @@ public class GoogleEncryptedFileSystem extends AbstractFileSystem {
     }
 
     @Override
-    protected long uploadFileImpl(AbstractBackupPath path) throws BackupRestoreException {
+    protected long uploadFileImpl(AbstractBackupPath path, Instant target)
+            throws BackupRestoreException {
         throw new UnsupportedOperationException();
     }
 

--- a/priam/src/test/java/com/netflix/priam/backup/BRTestModule.java
+++ b/priam/src/test/java/com/netflix/priam/backup/BRTestModule.java
@@ -34,7 +34,10 @@ import com.netflix.priam.cryptography.IFileCryptography;
 import com.netflix.priam.cryptography.pgp.PgpCryptography;
 import com.netflix.priam.defaultimpl.FakeCassandraProcess;
 import com.netflix.priam.defaultimpl.ICassandraProcess;
-import com.netflix.priam.identity.*;
+import com.netflix.priam.identity.FakeMembership;
+import com.netflix.priam.identity.FakePriamInstanceFactory;
+import com.netflix.priam.identity.IMembership;
+import com.netflix.priam.identity.IPriamInstanceFactory;
 import com.netflix.priam.identity.config.FakeInstanceInfo;
 import com.netflix.priam.identity.config.InstanceInfo;
 import com.netflix.priam.restore.IPostRestoreHook;
@@ -42,6 +45,9 @@ import com.netflix.priam.utils.FakeSleeper;
 import com.netflix.priam.utils.Sleeper;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Collections;
 import org.junit.Ignore;
 import org.quartz.SchedulerFactory;
@@ -83,5 +89,7 @@ public class BRTestModule extends AbstractModule {
         bind(Registry.class).toInstance(new DefaultRegistry());
         bind(IMetaProxy.class).annotatedWith(Names.named("v1")).to(MetaV1Proxy.class);
         bind(IMetaProxy.class).annotatedWith(Names.named("v2")).to(MetaV2Proxy.class);
+        bind(DynamicRateLimiter.class).to(FakeDynamicRateLimiter.class);
+        bind(Clock.class).toInstance(Clock.fixed(Instant.EPOCH, ZoneId.systemDefault()));
     }
 }

--- a/priam/src/test/java/com/netflix/priam/backup/FakeBackupFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/FakeBackupFileSystem.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.*;
 import org.json.simple.JSONArray;
 
@@ -166,7 +167,8 @@ public class FakeBackupFileSystem extends AbstractFileSystem {
     }
 
     @Override
-    protected long uploadFileImpl(AbstractBackupPath path) throws BackupRestoreException {
+    protected long uploadFileImpl(AbstractBackupPath path, Instant target)
+            throws BackupRestoreException {
         uploadedFiles.add(path.getBackupFile().getAbsolutePath());
         addFile(path.getRemotePath());
         return path.getBackupFile().length();

--- a/priam/src/test/java/com/netflix/priam/backup/FakeDynamicRateLimiter.java
+++ b/priam/src/test/java/com/netflix/priam/backup/FakeDynamicRateLimiter.java
@@ -1,0 +1,8 @@
+package com.netflix.priam.backup;
+
+import java.time.Instant;
+
+public class FakeDynamicRateLimiter implements DynamicRateLimiter {
+    @Override
+    public void acquire(AbstractBackupPath dir, Instant target, int tokens) {}
+}

--- a/priam/src/test/java/com/netflix/priam/backup/NullBackupFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/NullBackupFileSystem.java
@@ -23,6 +23,7 @@ import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.merics.BackupMetrics;
 import com.netflix.priam.notification.BackupNotificationMgr;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -72,7 +73,8 @@ public class NullBackupFileSystem extends AbstractFileSystem {
     }
 
     @Override
-    protected long uploadFileImpl(AbstractBackupPath path) throws BackupRestoreException {
+    protected long uploadFileImpl(AbstractBackupPath path, Instant target)
+            throws BackupRestoreException {
         return 0;
     }
 }

--- a/priam/src/test/java/com/netflix/priam/backup/TestAbstractFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestAbstractFileSystem.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.ParseException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -284,7 +285,8 @@ public class TestAbstractFileSystem {
         }
 
         @Override
-        protected long uploadFileImpl(AbstractBackupPath path) throws BackupRestoreException {
+        protected long uploadFileImpl(AbstractBackupPath path, Instant target)
+                throws BackupRestoreException {
             throw new BackupRestoreException(
                     "User injected failure file system error for testing upload. Local path: "
                             + path.getBackupFile().getAbsolutePath());
@@ -315,7 +317,8 @@ public class TestAbstractFileSystem {
         }
 
         @Override
-        protected long uploadFileImpl(AbstractBackupPath path) throws BackupRestoreException {
+        protected long uploadFileImpl(AbstractBackupPath path, Instant target)
+                throws BackupRestoreException {
             try {
                 Thread.sleep(random.nextInt(20));
             } catch (InterruptedException e) {

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackupDynamicRateLimiter.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackupDynamicRateLimiter.java
@@ -1,0 +1,159 @@
+package com.netflix.priam.backup;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.truth.Truth;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.netflix.priam.aws.RemoteBackupPath;
+import com.netflix.priam.config.FakeConfiguration;
+import java.nio.file.Paths;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestBackupDynamicRateLimiter {
+    private static final Instant NOW = Instant.ofEpochMilli(1 << 16);
+    private static final Instant LATER = NOW.plusMillis(Duration.ofHours(1).toMillis());
+    private static final int DIR_SIZE = 1 << 16;
+
+    private BackupDynamicRateLimiter rateLimiter;
+    private FakeConfiguration config;
+    private Injector injector;
+
+    @Before
+    public void setUp() {
+        injector = Guice.createInjector(new BRTestModule());
+        config = injector.getInstance(FakeConfiguration.class);
+    }
+
+    @Test
+    public void sunnyDay() {
+        rateLimiter = getRateLimiter(ImmutableMap.of("Priam.backup.threads", 1), NOW, DIR_SIZE);
+        Stopwatch timer = timePermitAcquisition(getBackupPath(), LATER, 21);
+        Truth.assertThat(timer.elapsed(TimeUnit.MILLISECONDS)).isAtLeast(1_000);
+        Truth.assertThat(timer.elapsed(TimeUnit.MILLISECONDS)).isAtMost(2_000);
+    }
+
+    @Test
+    public void targetSetToEpoch() {
+        rateLimiter = getRateLimiter(ImmutableMap.of("Priam.backup.threads", 1), NOW, DIR_SIZE);
+        Stopwatch timer = timePermitAcquisition(getBackupPath(), Instant.EPOCH, 20);
+        assertNoRateLimiting(timer);
+    }
+
+    @Test
+    public void pathIsNotASnapshot() {
+        rateLimiter = getRateLimiter(ImmutableMap.of("Priam.backup.threads", 1), NOW, DIR_SIZE);
+        AbstractBackupPath path =
+                getBackupPath(
+                        "target/data/Keyspace1/Standard1/backups/Keyspace1-Standard1-ia-4-Data.db");
+        Stopwatch timer = timePermitAcquisition(path, LATER, 20);
+        assertNoRateLimiting(timer);
+    }
+
+    @Test
+    public void targetIsNow() {
+        rateLimiter = getRateLimiter(ImmutableMap.of("Priam.backup.threads", 1), NOW, DIR_SIZE);
+        Stopwatch timer = timePermitAcquisition(getBackupPath(), NOW, 20);
+        assertNoRateLimiting(timer);
+    }
+
+    @Test
+    public void targetIsInThePast() {
+        rateLimiter = getRateLimiter(ImmutableMap.of("Priam.backup.threads", 1), NOW, DIR_SIZE);
+        Instant target = NOW.minus(Duration.ofHours(1L));
+        Stopwatch timer = timePermitAcquisition(getBackupPath(), target, 20);
+        assertNoRateLimiting(timer);
+    }
+
+    @Test
+    public void noBackupThreads() {
+        rateLimiter = getRateLimiter(ImmutableMap.of("Priam.backup.threads", 0), NOW, DIR_SIZE);
+        Assert.assertThrows(
+                IllegalStateException.class,
+                () -> timePermitAcquisition(getBackupPath(), LATER, 20));
+    }
+
+    @Test
+    public void negativeBackupThreads() {
+        rateLimiter = getRateLimiter(ImmutableMap.of("Priam.backup.threads", -1), NOW, DIR_SIZE);
+        Assert.assertThrows(
+                IllegalStateException.class,
+                () -> timePermitAcquisition(getBackupPath(), LATER, 20));
+    }
+
+    @Test
+    public void noData() {
+        rateLimiter = getRateLimiter(ImmutableMap.of("Priam.backup.threads", 1), NOW, 0);
+        Stopwatch timer = timePermitAcquisition(getBackupPath(), LATER, 20);
+        assertNoRateLimiting(timer);
+    }
+
+    @Test
+    public void noPermitsRequested() {
+        rateLimiter = getRateLimiter(ImmutableMap.of("Priam.backup.threads", 1), NOW, DIR_SIZE);
+        Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> timePermitAcquisition(getBackupPath(), LATER, 0));
+    }
+
+    @Test
+    public void negativePermitsRequested() {
+        rateLimiter = getRateLimiter(ImmutableMap.of("Priam.backup.threads", 1), NOW, DIR_SIZE);
+        Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> timePermitAcquisition(getBackupPath(), LATER, -1));
+    }
+
+    private RemoteBackupPath getBackupPath() {
+        return getBackupPath(
+                "target/data/Keyspace1/Standard1/snapshots/snap_v2_202201010000/.STANDARD1_field1_idx_1/Keyspace1-Standard1-ia-4-Data.db");
+    }
+
+    private RemoteBackupPath getBackupPath(String filePath) {
+        RemoteBackupPath path = injector.getInstance(RemoteBackupPath.class);
+        path.parseLocal(Paths.get(filePath).toFile(), AbstractBackupPath.BackupFileType.SST_V2);
+        return path;
+    }
+
+    private Stopwatch timePermitAcquisition(AbstractBackupPath path, Instant now, int permits) {
+        rateLimiter.acquire(path, now, permits); // Do this once first or else it won't throttle.
+        Stopwatch timer = Stopwatch.createStarted();
+        rateLimiter.acquire(path, now, permits);
+        timer.stop();
+        return timer;
+    }
+
+    private BackupDynamicRateLimiter getRateLimiter(
+            Map<String, Object> properties, Instant now, long directorySize) {
+        properties.forEach(config::setFakeConfig);
+        return new BackupDynamicRateLimiter(
+                config,
+                Clock.fixed(now, ZoneId.systemDefault()),
+                new FakeDirectorySize(directorySize));
+    }
+
+    private void assertNoRateLimiting(Stopwatch timer) {
+        Truth.assertThat(timer.elapsed(TimeUnit.MILLISECONDS)).isAtMost(1);
+    }
+
+    private static final class FakeDirectorySize implements DirectorySize {
+        private final long size;
+
+        FakeDirectorySize(long size) {
+            this.size = size;
+        }
+
+        @Override
+        public long getBytes(String location) {
+            return size;
+        }
+    }
+}

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestSnapshotMetaTask.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestSnapshotMetaTask.java
@@ -64,7 +64,7 @@ public class TestSnapshotMetaTask {
 
     @Test
     public void testSnapshotMetaServiceEnabled() throws Exception {
-        TaskTimer taskTimer = SnapshotMetaTask.getTimer(configuration, backupRestoreConfig);
+        TaskTimer taskTimer = SnapshotMetaTask.getTimer(backupRestoreConfig);
         Assert.assertNotNull(taskTimer);
     }
 

--- a/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
@@ -285,4 +285,11 @@ public class FakeConfiguration implements IConfiguration {
     public void setSkipIngressUnlessIPIsPublic(boolean skipIngressUnlessIPIsPublic) {
         this.skipIngressUnlessIPIsPublic = skipIngressUnlessIPIsPublic;
     }
+
+    @Override
+    public int getBackupThreads() {
+        return (Integer)
+                fakeConfig.getOrDefault(
+                        "Priam.backup.threads", IConfiguration.super.getBackupThreads());
+    }
 }


### PR DESCRIPTION
Create a rate limiter that dynamically adjusts its throttle based on the bytes still to upload in all remaining snapshots and a user-specified target time. 

Adjust the throttle only when we've deviated by a user-configurable threshold to ensure the rate limiter is not constantly adjusted. In that case, it would be redundant as it does not throttle the subsequent file after an adjustment. 

Ensure that the target does not exceed the earlier of the next scheduled snapshot or the time at which we would fail to meet our backup verification SLO. 

One significant change of note is that we begin leveraging our call to AWS to determine whether a file exists when creating the meta file. Previously, we would perform a second redundant check when attempting to upload the file. Now we just delete files that are already there.