### PR TITLE
Quick fix that re-enables local bootstrapping

### DIFF
--- a/priam/src/main/java/com/netflix/priam/identity/token/TokenRetrieverUtils.java
+++ b/priam/src/main/java/com/netflix/priam/identity/token/TokenRetrieverUtils.java
@@ -39,7 +39,7 @@ public class TokenRetrieverUtils {
         // Avoid other regions instances to avoid communication over public ip address.
         List<? extends PriamInstance> eligibleInstances =
                 allIds.stream()
-                        .filter(priamInstance -> !priamInstance.getToken().equalsIgnoreCase(token))
+                        .filter(priamInstance -> !token.equalsIgnoreCase(priamInstance.getToken()))
                         .filter(priamInstance -> priamInstance.getDC().equalsIgnoreCase(dc))
                         .collect(Collectors.toList());
         // We want to get IP from min 1, max 3 instances to ensure we are not relying on


### PR DESCRIPTION
When booting from a local file other instances' tokens are not known at the time of bootstrap. The original code throws a NPE.