### PR TITLE
Remove unsupported method and subtle logic change from recent backports.

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -176,11 +176,8 @@ public class S3FileSystem extends S3FileSystemBase {
         File localFile = Paths.get(path.getBackupFile().getAbsolutePath()).toFile();
         if (localFile.length() >= config.getBackupChunkSize()) return uploadMultipart(path, target);
         byte[] chunk = getFileContents(path);
-        // C* snapshots may have empty files. That is probably unintentional.
-        if (chunk.length > 0) {
-            rateLimiter.acquire(chunk.length);
-            dynamicRateLimiter.acquire(path, target, chunk.length);
-        }
+        rateLimiter.acquire(chunk.length);
+        dynamicRateLimiter.acquire(path, target, chunk.length);
         try {
             new BoundedExponentialRetryCallable<PutObjectResult>(1000, 10000, 5) {
                 @Override

--- a/priam/src/main/java/com/netflix/priam/backup/IncrementalBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/IncrementalBackup.java
@@ -17,9 +17,7 @@
 package com.netflix.priam.backup;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
@@ -127,6 +125,8 @@ public class IncrementalBackup extends AbstractBackup {
         // upload SSTables and components
         ImmutableList<ListenableFuture<AbstractBackupPath>> futures =
                 uploadAndDeleteAllFiles(backupDir, fileType, config.enableAsyncIncremental());
-        Futures.whenAllComplete(futures).call(() -> null, MoreExecutors.directExecutor());
+        for (ListenableFuture<AbstractBackupPath> future : futures) {
+            future.get();
+        }
     }
 }


### PR DESCRIPTION
Remove dependency on whenAllComplete method which is not supported in the maximum allowed version of Guava in 2.1. Also, cease attempting to upload empty files. To adhere to our original logic, they should be deleted before we reach that point.