### PR TITLE
Spread deletes over the interval depending on where the node is in the ring.

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backupv2/BackupTTLTask.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/BackupTTLTask.java
@@ -20,14 +20,11 @@ package com.netflix.priam.backupv2;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
-import com.netflix.priam.backup.AbstractBackupPath;
-import com.netflix.priam.backup.BackupRestoreException;
-import com.netflix.priam.backup.IBackupFileSystem;
-import com.netflix.priam.backup.IFileSystemContext;
-import com.netflix.priam.backup.Status;
+import com.netflix.priam.backup.*;
 import com.netflix.priam.config.IBackupRestoreConfig;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.health.InstanceState;
+import com.netflix.priam.identity.token.TokenRetriever;
 import com.netflix.priam.scheduler.SimpleTimer;
 import com.netflix.priam.scheduler.Task;
 import com.netflix.priam.scheduler.TaskTimer;
@@ -41,6 +38,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import javax.inject.Named;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.math.Fraction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,6 +67,7 @@ public class BackupTTLTask extends Task {
     private static final Lock lock = new ReentrantLock();
     private final int BATCH_SIZE = 1000;
     private final Instant start_of_feature = DateUtil.parseInstant("201801010000");
+    private final int maxWaitSeconds;
 
     @Inject
     public BackupTTLTask(
@@ -77,13 +76,18 @@ public class BackupTTLTask extends Task {
             @Named("v2") IMetaProxy metaProxy,
             IFileSystemContext backupFileSystemCtx,
             Provider<AbstractBackupPath> abstractBackupPathProvider,
-            InstanceState instanceState) {
+            InstanceState instanceState,
+            TokenRetriever tokenRetriever)
+            throws Exception {
         super(configuration);
         this.backupRestoreConfig = backupRestoreConfig;
         this.metaProxy = metaProxy;
         this.fileSystem = backupFileSystemCtx.getFileStrategy(configuration);
         this.abstractBackupPathProvider = abstractBackupPathProvider;
         this.instanceState = instanceState;
+        this.maxWaitSeconds =
+                backupRestoreConfig.getBackupTTLMonitorPeriodInSec()
+                        / tokenRetriever.getRingPosition().getDenominator();
     }
 
     @Override
@@ -101,6 +105,9 @@ public class BackupTTLTask extends Task {
             logger.warn("{} is already running! Try again later.", JOBNAME);
             throw new Exception(JOBNAME + " already running");
         }
+
+        // Sleep a random amount but not so long that it will spill into the next token's turn.
+        if (maxWaitSeconds > 0) Thread.sleep(new Random().nextInt(maxWaitSeconds));
 
         try {
             filesInMeta.clear();
@@ -239,9 +246,11 @@ public class BackupTTLTask extends Task {
      * @throws Exception if the configuration is not set correctly or are not valid. This is to
      *     ensure we fail-fast.
      */
-    public static TaskTimer getTimer(IBackupRestoreConfig backupRestoreConfig) throws Exception {
-        return SimpleTimer.getSimpleTimer(
-                JOBNAME, backupRestoreConfig.getBackupTTLMonitorPeriodInSec() * 1000);
+    public static TaskTimer getTimer(
+            IBackupRestoreConfig backupRestoreConfig, Fraction ringPosition) throws Exception {
+        int period = backupRestoreConfig.getBackupTTLMonitorPeriodInSec();
+        Instant start = Instant.ofEpochSecond((long) (period * ringPosition.doubleValue()));
+        return new SimpleTimer(JOBNAME, period, start);
     }
 
     private class MetaFileWalker extends MetaFileReader {

--- a/priam/src/main/java/com/netflix/priam/identity/token/ITokenRetriever.java
+++ b/priam/src/main/java/com/netflix/priam/identity/token/ITokenRetriever.java
@@ -3,13 +3,18 @@ package com.netflix.priam.identity.token;
 import com.google.inject.ImplementedBy;
 import com.netflix.priam.identity.PriamInstance;
 import java.util.Optional;
+import org.apache.commons.lang3.math.Fraction;
 
 /** Fetches PriamInstances and other data which is convenient at the time */
 @ImplementedBy(TokenRetriever.class)
 public interface ITokenRetriever {
     PriamInstance get() throws Exception;
-    /** Gets the IP address of the dead instance to which we will acquire its token */
+
+    /** Gets the IP address of the dead instance whose token we will acquire. */
     Optional<String> getReplacedIp();
 
     boolean isTokenPregenerated();
+
+    /** returns the percentage of tokens in the ring which come before this node's token */
+    Fraction getRingPosition() throws Exception;
 }

--- a/priam/src/main/java/com/netflix/priam/identity/token/TokenRetriever.java
+++ b/priam/src/main/java/com/netflix/priam/identity/token/TokenRetriever.java
@@ -19,6 +19,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import org.apache.commons.lang3.math.Fraction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +40,7 @@ public class TokenRetriever implements ITokenRetriever {
     private InstanceInfo myInstanceInfo;
     private boolean isTokenPregenerated = false;
     private String replacedIp;
+    private PriamInstance priamInstance;
 
     @Inject
     public TokenRetriever(
@@ -59,15 +61,17 @@ public class TokenRetriever implements ITokenRetriever {
 
     @Override
     public PriamInstance get() throws Exception {
-        PriamInstance myInstance = grabPreAssignedToken();
-        if (myInstance == null) {
-            myInstance = grabExistingToken();
+        if (priamInstance == null) {
+            priamInstance = grabPreAssignedToken();
         }
-        if (myInstance == null) {
-            myInstance = grabNewToken();
+        if (priamInstance == null) {
+            priamInstance = grabExistingToken();
         }
-        logger.info("My instance: {}", myInstance);
-        return myInstance;
+        if (priamInstance == null) {
+            priamInstance = grabNewToken();
+        }
+        logger.info("My instance: {}", priamInstance);
+        return priamInstance;
     }
 
     @Override
@@ -78,6 +82,18 @@ public class TokenRetriever implements ITokenRetriever {
     @Override
     public boolean isTokenPregenerated() {
         return isTokenPregenerated;
+    }
+
+    @Override
+    public Fraction getRingPosition() throws Exception {
+        get();
+        long tokenAsLong = Long.parseLong(priamInstance.getToken());
+        ImmutableSet<PriamInstance> nodes = factory.getAllIds(config.getAppName());
+        long ringPosition =
+                nodes.stream()
+                        .filter(node -> Long.parseLong(node.getToken()) < tokenAsLong)
+                        .count();
+        return Fraction.getFraction(Math.toIntExact(ringPosition), nodes.size());
     }
 
     private PriamInstance grabPreAssignedToken() throws Exception {

--- a/priam/src/main/java/com/netflix/priam/scheduler/SimpleTimer.java
+++ b/priam/src/main/java/com/netflix/priam/scheduler/SimpleTimer.java
@@ -16,12 +16,11 @@
  */
 package com.netflix.priam.scheduler;
 
+import com.google.common.base.Preconditions;
 import java.text.ParseException;
+import java.time.Instant;
 import java.util.Date;
-import org.quartz.Scheduler;
-import org.quartz.SimpleScheduleBuilder;
-import org.quartz.Trigger;
-import org.quartz.TriggerBuilder;
+import org.quartz.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +41,21 @@ public class SimpleTimer implements TaskTimer {
                                         .withIntervalInMilliseconds(interval)
                                         .repeatForever()
                                         .withMisfireHandlingInstructionFireNow())
+                        .build();
+    }
+
+    /** Run forever every @period seconds starting at @start */
+    public SimpleTimer(String name, int period, Instant start) {
+        Preconditions.checkArgument(period > 0);
+        Preconditions.checkArgument(start.compareTo(Instant.EPOCH) >= 0);
+        this.trigger =
+                TriggerBuilder.newTrigger()
+                        .withIdentity(name)
+                        .withSchedule(
+                                CalendarIntervalScheduleBuilder.calendarIntervalSchedule()
+                                        .withMisfireHandlingInstructionFireAndProceed()
+                                        .withIntervalInSeconds(period))
+                        .startAt(Date.from(start))
                         .build();
     }
 

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestBackupV2Service.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestBackupV2Service.java
@@ -25,6 +25,7 @@ import com.netflix.priam.config.IBackupRestoreConfig;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.connection.JMXNodeTool;
 import com.netflix.priam.defaultimpl.IService;
+import com.netflix.priam.identity.token.ITokenRetriever;
 import com.netflix.priam.scheduler.PriamScheduler;
 import com.netflix.priam.tuner.CassandraTunerService;
 import com.netflix.priam.tuner.TuneCassandra;
@@ -47,12 +48,14 @@ public class TestBackupV2Service {
     private final PriamScheduler scheduler;
     private final SnapshotMetaTask snapshotMetaTask;
     private final CassandraTunerService cassandraTunerService;
+    private final ITokenRetriever tokenRetriever;
 
     public TestBackupV2Service() {
         Injector injector = Guice.createInjector(new BRTestModule());
         scheduler = injector.getInstance(PriamScheduler.class);
         snapshotMetaTask = injector.getInstance(SnapshotMetaTask.class);
         cassandraTunerService = injector.getInstance(CassandraTunerService.class);
+        tokenRetriever = injector.getInstance(ITokenRetriever.class);
     }
 
     @Before
@@ -103,7 +106,8 @@ public class TestBackupV2Service {
                         backupRestoreConfig,
                         scheduler,
                         snapshotMetaTask,
-                        cassandraTunerService);
+                        cassandraTunerService,
+                        tokenRetriever);
         backupService.scheduleService();
         Assert.assertTrue(scheduler.getScheduler().getJobGroupNames().isEmpty());
 
@@ -142,7 +146,8 @@ public class TestBackupV2Service {
                         backupRestoreConfig,
                         scheduler,
                         snapshotMetaTask,
-                        cassandraTunerService);
+                        cassandraTunerService,
+                        tokenRetriever);
         backupService.scheduleService();
         Assert.assertEquals(4, scheduler.getScheduler().getJobKeys(null).size());
     }
@@ -171,7 +176,8 @@ public class TestBackupV2Service {
                         backupRestoreConfig,
                         scheduler,
                         snapshotMetaTask,
-                        cassandraTunerService);
+                        cassandraTunerService,
+                        tokenRetriever);
         backupService.scheduleService();
         Assert.assertEquals(3, scheduler.getScheduler().getJobKeys(null).size());
     }
@@ -208,7 +214,8 @@ public class TestBackupV2Service {
                         backupRestoreConfig,
                         scheduler,
                         snapshotMetaTask,
-                        cassandraTunerService);
+                        cassandraTunerService,
+                        tokenRetriever);
         backupService.scheduleService();
         Assert.assertEquals(3, scheduler.getScheduler().getJobKeys(null).size());
 

--- a/priam/src/test/java/com/netflix/priam/config/FakeBackupRestoreConfig.java
+++ b/priam/src/test/java/com/netflix/priam/config/FakeBackupRestoreConfig.java
@@ -29,4 +29,9 @@ public class FakeBackupRestoreConfig implements IBackupRestoreConfig {
     public boolean enableV2Restore() {
         return false;
     }
+
+    @Override
+    public int getBackupTTLMonitorPeriodInSec() {
+        return 0; // avoids sleeping altogether in tests.
+    }
 }

--- a/priam/src/test/java/com/netflix/priam/scheduler/TestSimpleTimer.java
+++ b/priam/src/test/java/com/netflix/priam/scheduler/TestSimpleTimer.java
@@ -1,0 +1,59 @@
+package com.netflix.priam.scheduler;
+
+import com.google.common.truth.Truth;
+import java.text.ParseException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import org.junit.Assert;
+import org.junit.Test;
+import org.quartz.Trigger;
+
+public class TestSimpleTimer {
+    private static final int PERIOD = 10;
+    private static final Instant START = Instant.EPOCH.plus(5, ChronoUnit.SECONDS);
+
+    @Test
+    public void sunnyDay() throws ParseException {
+        assertions(new SimpleTimer("foo", PERIOD, START).getTrigger(), START);
+    }
+
+    @Test
+    public void startBeforeEpoch() {
+        Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> new SimpleTimer("foo", PERIOD, Instant.EPOCH.minus(5, ChronoUnit.SECONDS)));
+    }
+
+    @Test
+    public void startAtEpoch() throws ParseException {
+        assertions(new SimpleTimer("foo", PERIOD, Instant.EPOCH).getTrigger(), Instant.EPOCH);
+    }
+
+    @Test
+    public void startMoreThanOnePeriodAfterEpoch() throws ParseException {
+        Instant start = Instant.EPOCH.plus(2 * PERIOD, ChronoUnit.SECONDS);
+        assertions(new SimpleTimer("foo", PERIOD, start).getTrigger(), start);
+    }
+
+    @Test
+    public void negativePeriod() {
+        Assert.assertThrows(
+                IllegalArgumentException.class, () -> new SimpleTimer("foo", -PERIOD, START));
+    }
+
+    @Test
+    public void zeroPeriod() {
+        Assert.assertThrows(IllegalArgumentException.class, () -> new SimpleTimer("foo", 0, START));
+    }
+
+    private void assertions(Trigger trigger, Instant start) {
+        Instant now = Instant.now();
+        Instant nextFireTime = trigger.getFireTimeAfter(Date.from(now)).toInstant();
+        Truth.assertThat(nextFireTime.getEpochSecond() % PERIOD)
+                .isEqualTo(start.getEpochSecond() % PERIOD);
+        Truth.assertThat(nextFireTime).isAtMost(Instant.now().plus(PERIOD, ChronoUnit.SECONDS));
+        Truth.assertThat(trigger.getFinalFireTime()).isNull();
+        Truth.assertThat(trigger.getEndTime()).isNull();
+    }
+}


### PR DESCRIPTION
Today, a node attempts to delete backups every backupTTLMonitorPeriod seconds from when Priam was started. This can lead to bunching across the fleet or a long time between attempts if Priam is restarted often enough. This PR makes the backupTTLTask take into account a node's position within the ring and use that to schedule its backup deletion as far away from other nodes. It also adds a random wait to ensure that if you're running a fleet with many clusters with a common topology, nodes in the same relative position don't fire all at the same time.