### PR TITLE
Use synchronized list for thread-safety

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/S3EncryptedFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3EncryptedFileSystem.java
@@ -18,7 +18,6 @@ import com.amazonaws.services.s3.model.CompleteMultipartUploadResult;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.PartETag;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
@@ -39,6 +38,8 @@ import java.io.*;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
@@ -116,7 +117,7 @@ public class S3EncryptedFileSystem extends S3FileSystemBase {
         DataPart part =
                 new DataPart(config.getBackupPrefix(), remotePath, initResponse.getUploadId());
         // Metadata on number of parts to be uploaded
-        List<PartETag> partETags = Lists.newArrayList();
+        List<PartETag> partETags = Collections.synchronizedList(new ArrayList<>());
 
         // Read chunks from src, compress it, and write to temp file
         File compressedDstFile = new File(localPath.toString() + ".compressed");


### PR DESCRIPTION
This list of PartETag is modified on multiple threads, so it needs to be thread-safe.
S3FileSystem already uses a synchronized list, so do the same here.