### PR TITLE
Change some constructors to public to simplify the nfpriam spring boot migration

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backup/BackupDynamicRateLimiter.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupDynamicRateLimiter.java
@@ -16,7 +16,7 @@ public class BackupDynamicRateLimiter implements DynamicRateLimiter {
     private final RateLimiter rateLimiter;
 
     @Inject
-    BackupDynamicRateLimiter(IConfiguration config, Clock clock, DirectorySize dirSize) {
+    public BackupDynamicRateLimiter(IConfiguration config, Clock clock, DirectorySize dirSize) {
         this.clock = clock;
         this.config = config;
         this.dirSize = dirSize;

--- a/priam/src/main/java/com/netflix/priam/backup/BackupVerification.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupVerification.java
@@ -44,7 +44,7 @@ public class BackupVerification {
     private BackupVerificationResult latestResult;
 
     @Inject
-    BackupVerification(
+    public BackupVerification(
             @Named("v1") IMetaProxy metaV1Proxy,
             @Named("v2") IMetaProxy metaV2Proxy,
             IBackupStatusMgr backupStatusMgr,

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaFileWriterBuilder.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaFileWriterBuilder.java
@@ -52,7 +52,7 @@ public class MetaFileWriterBuilder {
     private static final Logger logger = LoggerFactory.getLogger(MetaFileWriterBuilder.class);
 
     @Inject
-    MetaFileWriterBuilder(MetaFileWriter metaFileWriter) {
+    public MetaFileWriterBuilder(MetaFileWriter metaFileWriter) {
         this.metaFileWriter = metaFileWriter;
     }
 
@@ -93,7 +93,7 @@ public class MetaFileWriterBuilder {
         private Path metaFilePath;
 
         @Inject
-        private MetaFileWriter(
+        public MetaFileWriter(
                 IConfiguration configuration,
                 InstanceIdentity instanceIdentity,
                 Provider<AbstractBackupPath> pathFactory,

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaV1Proxy.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaV1Proxy.java
@@ -41,7 +41,7 @@ public class MetaV1Proxy implements IMetaProxy {
     private final IBackupFileSystem fs;
 
     @Inject
-    MetaV1Proxy(IConfiguration configuration, IFileSystemContext backupFileSystemCtx) {
+    public MetaV1Proxy(IConfiguration configuration, IFileSystemContext backupFileSystemCtx) {
         fs = backupFileSystemCtx.getFileStrategy(configuration);
     }
 

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaV2Proxy.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaV2Proxy.java
@@ -45,7 +45,7 @@ public class MetaV2Proxy implements IMetaProxy {
     private final Provider<AbstractBackupPath> abstractBackupPathProvider;
 
     @Inject
-    MetaV2Proxy(
+    public MetaV2Proxy(
             IConfiguration configuration,
             IFileSystemContext backupFileSystemCtx,
             Provider<AbstractBackupPath> abstractBackupPathProvider) {

--- a/priam/src/main/java/com/netflix/priam/backupv2/SnapshotMetaTask.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/SnapshotMetaTask.java
@@ -103,7 +103,7 @@ public class SnapshotMetaTask extends AbstractBackup {
     private MetaStep metaStep = MetaStep.META_GENERATION;
 
     @Inject
-    SnapshotMetaTask(
+    public SnapshotMetaTask(
             IConfiguration config,
             BackupHelper backupHelper,
             MetaFileWriterBuilder metaFileWriter,

--- a/priam/src/main/java/com/netflix/priam/health/InstanceState.java
+++ b/priam/src/main/java/com/netflix/priam/health/InstanceState.java
@@ -53,7 +53,7 @@ public class InstanceState {
     private final RestoreStatus restoreStatus;
 
     @Inject
-    InstanceState(RestoreStatus restoreStatus) {
+    public InstanceState(RestoreStatus restoreStatus) {
         this.restoreStatus = restoreStatus;
     }
 

--- a/priam/src/main/java/com/netflix/priam/notification/INotificationService.java
+++ b/priam/src/main/java/com/netflix/priam/notification/INotificationService.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 /** Service to notify of a message. Created by vinhn on 11/3/16. */
 @ImplementedBy(AWSSnsNotificationService.class)
-interface INotificationService {
+public interface INotificationService {
     /**
      * Notify the message.
      *


### PR DESCRIPTION
Changed some constructors to public, which then can be initialized in the nfpriam application.  