### PR TITLE
Change the CassandraOperations constructor to be public

### DIFF
--- a/priam/src/main/java/com/netflix/priam/connection/CassandraOperations.java
+++ b/priam/src/main/java/com/netflix/priam/connection/CassandraOperations.java
@@ -30,7 +30,7 @@ public class CassandraOperations implements ICassandraOperations {
     private final IConfiguration configuration;
 
     @Inject
-    CassandraOperations(IConfiguration configuration) {
+    public CassandraOperations(IConfiguration configuration) {
         this.configuration = configuration;
     }
 


### PR DESCRIPTION
Change the CassandraOperations constructor to be public for better dependency injection. 