### PR TITLE
Return missing files from snapshot verification continuing to marginalize BackupVerificationResult. 

### DIFF
--- a/priam/src/main/java/com/netflix/priam/resources/BackupServlet.java
+++ b/priam/src/main/java/com/netflix/priam/resources/BackupServlet.java
@@ -16,6 +16,8 @@
  */
 package com.netflix.priam.resources;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.netflix.priam.backup.*;
 import com.netflix.priam.backup.AbstractBackupPath.BackupFileType;
 import com.netflix.priam.config.IBackupRestoreConfig;
@@ -23,6 +25,7 @@ import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.scheduler.PriamScheduler;
 import com.netflix.priam.utils.DateUtil;
 import com.netflix.priam.utils.DateUtil.DateRange;
+import com.netflix.priam.utils.GsonJsonSerializer;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -215,19 +218,12 @@ public class BackupServlet {
     @Produces(MediaType.APPLICATION_JSON)
     public Response validateSnapshotByDate(
             @PathParam("daterange") String daterange,
-            @DefaultValue("false") @QueryParam("force") boolean force)
-            throws Exception {
+            @DefaultValue("false") @QueryParam("force") boolean force) {
         DateUtil.DateRange dateRange = new DateUtil.DateRange(daterange);
-        Optional<BackupVerificationResult> result =
-                backupVerification.verifyLatestBackup(
+        ImmutableMap<BackupMetadata, ImmutableSet<String>> result =
+                backupVerification.findMissingBackupFilesInRange(
                         BackupVersion.SNAPSHOT_BACKUP, force, dateRange);
-        if (!result.isPresent()) {
-            return Response.noContent()
-                    .entity("No valid meta found for provided time range")
-                    .build();
-        }
-
-        return Response.ok(result.get().toString()).build();
+        return Response.ok(GsonJsonSerializer.getGson().toJson(result)).build();
     }
 
     /*

--- a/priam/src/main/java/com/netflix/priam/resources/BackupServletV2.java
+++ b/priam/src/main/java/com/netflix/priam/resources/BackupServletV2.java
@@ -17,6 +17,8 @@
 
 package com.netflix.priam.resources;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.netflix.priam.backup.*;
 import com.netflix.priam.backupv2.BackupTTLTask;
 import com.netflix.priam.backupv2.BackupV2Service;
@@ -121,19 +123,12 @@ public class BackupServletV2 {
     @Path("/validate/{daterange}")
     public Response validateV2SnapshotByDate(
             @PathParam("daterange") String daterange,
-            @DefaultValue("false") @QueryParam("force") boolean force)
-            throws Exception {
+            @DefaultValue("false") @QueryParam("force") boolean force) {
         DateUtil.DateRange dateRange = new DateUtil.DateRange(daterange);
-        Optional<BackupVerificationResult> result =
-                backupVerification.verifyLatestBackup(
+        ImmutableMap<BackupMetadata, ImmutableSet<String>> result =
+                backupVerification.findMissingBackupFilesInRange(
                         BackupVersion.SNAPSHOT_META_SERVICE, force, dateRange);
-        if (!result.isPresent()) {
-            return Response.noContent()
-                    .entity("No valid meta found for provided time range")
-                    .build();
-        }
-
-        return Response.ok(result.get().toString()).build();
+        return Response.ok(GsonJsonSerializer.getGson().toJson(result)).build();
     }
 
     @GET


### PR DESCRIPTION
Return all results valid or otherwise.