### PR TITLE
Backports to get 3.x aligned with 3.11

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/auth/EC2RoleAssumptionCredential.java
+++ b/priam/src/main/java/com/netflix/priam/aws/auth/EC2RoleAssumptionCredential.java
@@ -17,6 +17,7 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.cred.ICredential;
+import com.netflix.priam.identity.config.AWSInstanceInfo;
 import com.netflix.priam.identity.config.InstanceInfo;
 import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
@@ -29,11 +30,10 @@ public class EC2RoleAssumptionCredential implements ICredential {
     private AWSCredentialsProvider stsSessionCredentialsProvider;
 
     @Inject
-    public EC2RoleAssumptionCredential(
-            ICredential cred, IConfiguration config, InstanceInfo instanceInfo) {
+    public EC2RoleAssumptionCredential(ICredential cred, IConfiguration config) {
         this.cred = cred;
         this.config = config;
-        this.instanceInfo = instanceInfo;
+        this.instanceInfo = new AWSInstanceInfo(cred);
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/backup/BackupDynamicRateLimiter.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupDynamicRateLimiter.java
@@ -16,7 +16,7 @@ public class BackupDynamicRateLimiter implements DynamicRateLimiter {
     private final RateLimiter rateLimiter;
 
     @Inject
-    BackupDynamicRateLimiter(IConfiguration config, Clock clock, DirectorySize dirSize) {
+    public BackupDynamicRateLimiter(IConfiguration config, Clock clock, DirectorySize dirSize) {
         this.clock = clock;
         this.config = config;
         this.dirSize = dirSize;

--- a/priam/src/main/java/com/netflix/priam/backup/BackupMetadata.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupMetadata.java
@@ -34,9 +34,9 @@ public final class BackupMetadata implements Serializable {
     private BackupVersion backupVersion;
     private String snapshotLocation;
 
-    public BackupMetadata(BackupVersion backupVersion, String token, Date start) throws Exception {
+    public BackupMetadata(BackupVersion backupVersion, String token, Date start) {
         if (start == null || token == null || StringUtils.isEmpty(token))
-            throw new Exception(
+            throw new IllegalArgumentException(
                     String.format(
                             "Invalid Input: Token: %s or start date: %s is null or empty.",
                             token, start));

--- a/priam/src/main/java/com/netflix/priam/backup/BackupRestoreUtil.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupRestoreUtil.java
@@ -30,17 +30,13 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-/** Created by aagrawal on 8/14/17. */
+/** Helper methods applicable to both backup and restore */
 public class BackupRestoreUtil {
-    private static final Logger logger = LoggerFactory.getLogger(BackupRestoreUtil.class);
     private static final Pattern columnFamilyFilterPattern = Pattern.compile(".\\..");
-    private Map<String, List<String>> includeFilter;
-    private Map<String, List<String>> excludeFilter;
+    private final Map<String, List<String>> includeFilter;
+    private final Map<String, List<String>> excludeFilter;
 
-    public static final List<String> FILTER_KEYSPACE = Collections.singletonList("OpsCenter");
     private static final Map<String, List<String>> FILTER_COLUMN_FAMILY =
             ImmutableMap.of(
                     "system",
@@ -49,43 +45,26 @@ public class BackupRestoreUtil {
 
     @Inject
     public BackupRestoreUtil(String configIncludeFilter, String configExcludeFilter) {
-        setFilters(configIncludeFilter, configExcludeFilter);
-    }
-
-    public BackupRestoreUtil setFilters(String configIncludeFilter, String configExcludeFilter) {
         includeFilter = getFilter(configIncludeFilter);
         excludeFilter = getFilter(configExcludeFilter);
-        logger.info("Exclude filter set: {}", configExcludeFilter);
-        logger.info("Include filter set: {}", configIncludeFilter);
-        return this;
     }
 
     public static Optional<AbstractBackupPath> getLatestValidMetaPath(
             IMetaProxy metaProxy, DateUtil.DateRange dateRange) {
-        // Get a list of manifest files.
-        List<AbstractBackupPath> metas = metaProxy.findMetaFiles(dateRange);
-
-        // Find a valid manifest file.
-        for (AbstractBackupPath meta : metas) {
-            BackupVerificationResult result = metaProxy.isMetaFileValid(meta);
-            if (result.valid) {
-                return Optional.of(meta);
-            }
-        }
-
-        return Optional.empty();
+        return metaProxy
+                .findMetaFiles(dateRange)
+                .stream()
+                .filter(meta -> metaProxy.isMetaFileValid(meta).valid)
+                .findFirst();
     }
 
-    public static List<AbstractBackupPath> getAllFiles(
+    public static List<AbstractBackupPath> getMostRecentSnapshotPaths(
             AbstractBackupPath latestValidMetaFile,
-            DateUtil.DateRange dateRange,
             IMetaProxy metaProxy,
             Provider<AbstractBackupPath> pathProvider)
             throws Exception {
-        // Download the meta.json file.
         Path metaFile = metaProxy.downloadMetaFile(latestValidMetaFile);
-        // Parse meta.json file to find the files required to download from this snapshot.
-        List<AbstractBackupPath> allFiles =
+        List<AbstractBackupPath> snapshotPaths =
                 metaProxy
                         .getSSTFilesFromMeta(metaFile)
                         .stream()
@@ -96,50 +75,43 @@ public class BackupRestoreUtil {
                                     return path;
                                 })
                         .collect(Collectors.toList());
-
         FileUtils.deleteQuietly(metaFile.toFile());
+        return snapshotPaths;
+    }
 
-        // Download incremental SSTables after the snapshot meta file.
+    public static List<AbstractBackupPath> getIncrementalPaths(
+            AbstractBackupPath latestValidMetaFile,
+            DateUtil.DateRange dateRange,
+            IMetaProxy metaProxy) {
         Instant snapshotTime;
         if (metaProxy instanceof MetaV2Proxy) snapshotTime = latestValidMetaFile.getLastModified();
         else snapshotTime = latestValidMetaFile.getTime().toInstant();
-
         DateUtil.DateRange incrementalDateRange =
                 new DateUtil.DateRange(snapshotTime, dateRange.getEndTime());
-        Iterator<AbstractBackupPath> incremental = metaProxy.getIncrementals(incrementalDateRange);
-        while (incremental.hasNext()) allFiles.add(incremental.next());
-
-        return allFiles;
+        List<AbstractBackupPath> incrementalPaths = new ArrayList<>();
+        metaProxy.getIncrementals(incrementalDateRange).forEachRemaining(incrementalPaths::add);
+        return incrementalPaths;
     }
 
-    public static final Map<String, List<String>> getFilter(String inputFilter)
+    public static Map<String, List<String>> getFilter(String inputFilter)
             throws IllegalArgumentException {
         if (StringUtils.isEmpty(inputFilter)) return null;
-
-        final Map<String, List<String>> columnFamilyFilter =
-                new HashMap<>(); // key: keyspace, value: a list of CFs within the keyspace
-
+        final Map<String, List<String>> columnFamilyFilter = new HashMap<>();
         String[] filters = inputFilter.split(",");
-        for (String cfFilter :
-                filters) { // process filter of form keyspace.* or keyspace.columnfamily
+        for (String cfFilter : filters) {
             if (columnFamilyFilterPattern.matcher(cfFilter).find()) {
-
                 String[] filter = cfFilter.split("\\.");
                 String keyspaceName = filter[0];
                 String columnFamilyName = filter[1];
-
                 if (columnFamilyName.contains("-"))
                     columnFamilyName = columnFamilyName.substring(0, columnFamilyName.indexOf("-"));
-
                 List<String> existingCfs =
                         columnFamilyFilter.getOrDefault(keyspaceName, new ArrayList<>());
                 if (!columnFamilyName.equalsIgnoreCase("*")) existingCfs.add(columnFamilyName);
                 columnFamilyFilter.put(keyspaceName, existingCfs);
-
             } else {
                 throw new IllegalArgumentException(
-                        "Column family filter format is not valid.  Format needs to be \"keyspace.columnfamily\".  Invalid input: "
-                                + cfFilter);
+                        "Invalid format: " + cfFilter + ". \"keyspace.columnfamily\" is required.");
             }
         }
         return columnFamilyFilter;
@@ -154,34 +126,19 @@ public class BackupRestoreUtil {
      */
     public final boolean isFiltered(String keyspace, String columnFamilyDir) {
         if (StringUtils.isEmpty(keyspace) || StringUtils.isEmpty(columnFamilyDir)) return false;
-
         String columnFamilyName = columnFamilyDir.split("-")[0];
-        // column family is in list of global CF filter
         if (FILTER_COLUMN_FAMILY.containsKey(keyspace)
                 && FILTER_COLUMN_FAMILY.get(keyspace).contains(columnFamilyName)) return true;
-
         if (excludeFilter != null)
             if (excludeFilter.containsKey(keyspace)
                     && (excludeFilter.get(keyspace).isEmpty()
                             || excludeFilter.get(keyspace).contains(columnFamilyName))) {
-                logger.debug(
-                        "Skipping: keyspace: {}, CF: {} is part of exclude list.",
-                        keyspace,
-                        columnFamilyName);
                 return true;
             }
-
         if (includeFilter != null)
-            if (!(includeFilter.containsKey(keyspace)
+            return !(includeFilter.containsKey(keyspace)
                     && (includeFilter.get(keyspace).isEmpty()
-                            || includeFilter.get(keyspace).contains(columnFamilyName)))) {
-                logger.debug(
-                        "Skipping: keyspace: {}, CF: {} is not part of include list.",
-                        keyspace,
-                        columnFamilyName);
-                return true;
-            }
-
+                            || includeFilter.get(keyspace).contains(columnFamilyName)));
         return false;
     }
 }

--- a/priam/src/main/java/com/netflix/priam/backup/BackupVerification.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupVerification.java
@@ -14,13 +14,15 @@
 package com.netflix.priam.backup;
 
 import com.netflix.priam.backupv2.IMetaProxy;
-import com.netflix.priam.scheduler.UnsupportedTypeException;
 import com.netflix.priam.utils.DateUtil;
 import com.netflix.priam.utils.DateUtil.DateRange;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -66,87 +68,38 @@ public class BackupVerification {
         return null;
     }
 
-    public Optional<BackupVerificationResult> verifyBackup(
+    public Optional<BackupVerificationResult> verifyLatestBackup(
             BackupVersion backupVersion, boolean force, DateRange dateRange)
-            throws UnsupportedTypeException, IllegalArgumentException {
+            throws IllegalArgumentException {
         IMetaProxy metaProxy = getMetaProxy(backupVersion);
-        if (metaProxy == null) {
-            throw new UnsupportedTypeException(
-                    "BackupVersion type: " + backupVersion + " is not supported");
-        }
-
-        if (dateRange == null) {
-            throw new IllegalArgumentException("dateRange provided is null");
-        }
-
-        List<BackupMetadata> metadata =
-                backupStatusMgr.getLatestBackupMetadata(backupVersion, dateRange);
-        if (metadata == null || metadata.isEmpty()) return Optional.empty();
-        for (BackupMetadata backupMetadata : metadata) {
-            if (backupMetadata.getLastValidated() != null && !force) {
-                // Backup is already validated. Nothing to do.
-                latestResult = new BackupVerificationResult();
-                latestResult.valid = true;
-                latestResult.manifestAvailable = true;
-                latestResult.snapshotInstant = backupMetadata.getStart().toInstant();
-                Path snapshotLocation = Paths.get(backupMetadata.getSnapshotLocation());
-                latestResult.remotePath =
-                        snapshotLocation.subpath(1, snapshotLocation.getNameCount()).toString();
+        for (BackupMetadata backupMetadata :
+                backupStatusMgr.getLatestBackupMetadata(backupVersion, dateRange)) {
+            if (backupMetadata.getLastValidated() == null || force) {
+                Optional<BackupVerificationResult> result = verifyBackup(metaProxy, backupMetadata);
+                if (result.isPresent()) {
+                    return result;
+                }
+            } else {
+                updateLatestResult(backupMetadata);
                 return Optional.of(latestResult);
-            }
-            BackupVerificationResult backupVerificationResult =
-                    verifyBackup(metaProxy, backupMetadata);
-            if (logger.isDebugEnabled())
-                logger.debug(
-                        "BackupVerification: metadata: {}, result: {}",
-                        backupMetadata,
-                        backupVerificationResult);
-            if (backupVerificationResult.valid) {
-                backupMetadata.setLastValidated(new Date(DateUtil.getInstant().toEpochMilli()));
-                backupStatusMgr.update(backupMetadata);
-                latestResult = backupVerificationResult;
-                return Optional.of(backupVerificationResult);
             }
         }
         latestResult = null;
         return Optional.empty();
     }
 
-    public List<BackupVerificationResult> verifyAllBackups(
-            BackupVersion backupVersion, DateRange dateRange)
-            throws UnsupportedTypeException, IllegalArgumentException {
+    public List<BackupMetadata> verifyBackupsInRange(
+            BackupVersion backupVersion, DateRange dateRange) throws IllegalArgumentException {
         IMetaProxy metaProxy = getMetaProxy(backupVersion);
-        if (metaProxy == null) {
-            throw new UnsupportedTypeException(
-                    "BackupVersion type: " + backupVersion + " is not supported");
-        }
-
-        if (dateRange == null) {
-            throw new IllegalArgumentException("dateRange provided is null");
-        }
-
-        List<BackupVerificationResult> result = new ArrayList<>();
-
-        List<BackupMetadata> metadata =
-                backupStatusMgr.getLatestBackupMetadata(backupVersion, dateRange);
-        if (metadata == null || metadata.isEmpty()) return result;
-        for (BackupMetadata backupMetadata : metadata) {
-            if (backupMetadata.getLastValidated() == null) {
-                BackupVerificationResult backupVerificationResult =
-                        verifyBackup(metaProxy, backupMetadata);
-                if (logger.isDebugEnabled())
-                    logger.debug(
-                            "BackupVerification: metadata: {}, result: {}",
-                            backupMetadata,
-                            backupVerificationResult);
-                if (backupVerificationResult.valid) {
-                    backupMetadata.setLastValidated(new Date(DateUtil.getInstant().toEpochMilli()));
-                    backupStatusMgr.update(backupMetadata);
-                    result.add(backupVerificationResult);
-                }
+        List<BackupMetadata> results = new ArrayList<>();
+        for (BackupMetadata backupMetadata :
+                backupStatusMgr.getLatestBackupMetadata(backupVersion, dateRange)) {
+            if (backupMetadata.getLastValidated() != null
+                    || verifyBackup(metaProxy, backupMetadata).isPresent()) {
+                results.add(backupMetadata);
             }
         }
-        return result;
+        return results;
     }
 
     /** returns the latest valid backup verification result if we have found one within the SLO * */
@@ -154,12 +107,33 @@ public class BackupVerification {
         return latestResult == null ? Optional.empty() : Optional.of(latestResult.snapshotInstant);
     }
 
-    private BackupVerificationResult verifyBackup(
+    private Optional<BackupVerificationResult> verifyBackup(
             IMetaProxy metaProxy, BackupMetadata latestBackupMetaData) {
         Path metadataLocation = Paths.get(latestBackupMetaData.getSnapshotLocation());
         metadataLocation = metadataLocation.subpath(1, metadataLocation.getNameCount());
         AbstractBackupPath abstractBackupPath = abstractBackupPathProvider.get();
         abstractBackupPath.parseRemote(metadataLocation.toString());
-        return metaProxy.isMetaFileValid(abstractBackupPath);
+        BackupVerificationResult result = metaProxy.isMetaFileValid(abstractBackupPath);
+        if (result.valid) {
+            updateLatestResult(latestBackupMetaData);
+            Date now = new Date(DateUtil.getInstant().toEpochMilli());
+            latestBackupMetaData.setLastValidated(now);
+            backupStatusMgr.update(latestBackupMetaData);
+            return Optional.of(result);
+        }
+        return Optional.empty();
+    }
+
+    private void updateLatestResult(BackupMetadata backupMetadata) {
+        Instant snapshotInstant = backupMetadata.getStart().toInstant();
+        if (latestResult == null || latestResult.snapshotInstant.isBefore(snapshotInstant)) {
+            latestResult = new BackupVerificationResult();
+            latestResult.valid = true;
+            latestResult.manifestAvailable = true;
+            latestResult.snapshotInstant = backupMetadata.getStart().toInstant();
+            Path snapshotLocation = Paths.get(backupMetadata.getSnapshotLocation());
+            latestResult.remotePath =
+                    snapshotLocation.subpath(1, snapshotLocation.getNameCount()).toString();
+        }
     }
 }

--- a/priam/src/main/java/com/netflix/priam/backup/BackupVerification.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupVerification.java
@@ -46,7 +46,7 @@ public class BackupVerification {
     private BackupVerificationResult latestResult;
 
     @Inject
-    BackupVerification(
+    public BackupVerification(
             @Named("v1") IMetaProxy metaV1Proxy,
             @Named("v2") IMetaProxy metaV2Proxy,
             IBackupStatusMgr backupStatusMgr,

--- a/priam/src/main/java/com/netflix/priam/backupv2/BackupV2Service.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/BackupV2Service.java
@@ -68,20 +68,19 @@ public class BackupV2Service implements IService {
             // restart.
             snapshotMetaTask.uploadFiles();
 
-            // Schedule the TTL service
-            TaskTimer timer =
-                    BackupTTLTask.getTimer(backupRestoreConfig, tokenRetriever.getRingPosition());
-            scheduleTask(scheduler, BackupTTLTask.class, timer);
-
             // Schedule the backup verification service
             scheduleTask(
                     scheduler,
                     BackupVerificationTask.class,
                     BackupVerificationTask.getTimer(backupRestoreConfig));
         } else {
-            scheduler.deleteTask(BackupTTLTask.JOBNAME);
             scheduler.deleteTask(BackupVerificationTask.JOBNAME);
         }
+
+        // Schedule the TTL service
+        TaskTimer timer =
+                BackupTTLTask.getTimer(backupRestoreConfig, tokenRetriever.getRingPosition());
+        scheduleTask(scheduler, BackupTTLTask.class, timer);
 
         // Start the Incremental backup schedule if enabled
         scheduleTask(

--- a/priam/src/main/java/com/netflix/priam/backupv2/IMetaProxy.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/IMetaProxy.java
@@ -77,10 +77,8 @@ public interface IMetaProxy {
      *
      * @param dateRange the time period to scan in the remote file system for incremental files.
      * @return iterator containing the list of path on the remote file system satisfying criteria.
-     * @throws BackupRestoreException if there is an issue contacting remote file system.
      */
-    Iterator<AbstractBackupPath> getIncrementals(DateUtil.DateRange dateRange)
-            throws BackupRestoreException;
+    Iterator<AbstractBackupPath> getIncrementals(DateUtil.DateRange dateRange);
 
     /**
      * Validate that all the files mentioned in the meta file actually exists on remote file system.

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaFileWriterBuilder.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaFileWriterBuilder.java
@@ -52,7 +52,7 @@ public class MetaFileWriterBuilder {
     private static final Logger logger = LoggerFactory.getLogger(MetaFileWriterBuilder.class);
 
     @Inject
-    MetaFileWriterBuilder(MetaFileWriter metaFileWriter) {
+    public MetaFileWriterBuilder(MetaFileWriter metaFileWriter) {
         this.metaFileWriter = metaFileWriter;
     }
 
@@ -93,7 +93,7 @@ public class MetaFileWriterBuilder {
         private Path metaFilePath;
 
         @Inject
-        private MetaFileWriter(
+        public MetaFileWriter(
                 IConfiguration configuration,
                 InstanceIdentity instanceIdentity,
                 Provider<AbstractBackupPath> pathFactory,

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaV1Proxy.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaV1Proxy.java
@@ -41,7 +41,7 @@ public class MetaV1Proxy implements IMetaProxy {
     private final IBackupFileSystem fs;
 
     @Inject
-    MetaV1Proxy(IConfiguration configuration, IFileSystemContext backupFileSystemCtx) {
+    public MetaV1Proxy(IConfiguration configuration, IFileSystemContext backupFileSystemCtx) {
         fs = backupFileSystemCtx.getFileStrategy(configuration);
     }
 

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaV1Proxy.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaV1Proxy.java
@@ -169,8 +169,7 @@ public class MetaV1Proxy implements IMetaProxy {
     }
 
     @Override
-    public Iterator<AbstractBackupPath> getIncrementals(DateUtil.DateRange dateRange)
-            throws BackupRestoreException {
+    public Iterator<AbstractBackupPath> getIncrementals(DateUtil.DateRange dateRange) {
         String prefix = fs.getPrefix().toString();
         Iterator<AbstractBackupPath> iterator =
                 fs.list(

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaV2Proxy.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaV2Proxy.java
@@ -45,7 +45,7 @@ public class MetaV2Proxy implements IMetaProxy {
     private final Provider<AbstractBackupPath> abstractBackupPathProvider;
 
     @Inject
-    MetaV2Proxy(
+    public MetaV2Proxy(
             IConfiguration configuration,
             IFileSystemContext backupFileSystemCtx,
             Provider<AbstractBackupPath> abstractBackupPathProvider) {

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaV2Proxy.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaV2Proxy.java
@@ -79,8 +79,7 @@ public class MetaV2Proxy implements IMetaProxy {
     }
 
     @Override
-    public Iterator<AbstractBackupPath> getIncrementals(DateUtil.DateRange dateRange)
-            throws BackupRestoreException {
+    public Iterator<AbstractBackupPath> getIncrementals(DateUtil.DateRange dateRange) {
         String incrementalPrefix = getMatch(dateRange, AbstractBackupPath.BackupFileType.SST_V2);
         String marker =
                 getMatch(

--- a/priam/src/main/java/com/netflix/priam/backupv2/SnapshotMetaTask.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/SnapshotMetaTask.java
@@ -99,7 +99,7 @@ public class SnapshotMetaTask extends AbstractBackup {
     private MetaStep metaStep = MetaStep.META_GENERATION;
 
     @Inject
-    SnapshotMetaTask(
+    public SnapshotMetaTask(
             IConfiguration config,
             BackupHelper backupHelper,
             MetaFileWriterBuilder metaFileWriter,

--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -1174,6 +1174,11 @@ public interface IConfiguration {
     /** @return whether to enable auto_snapshot */
     boolean getAutoSnapshot();
 
+    /** @return whether incremental backups should be skipped in a restore */
+    default boolean skipIncrementalRestore() {
+        return false;
+    }
+
     /**
      * Escape hatch for getting any arbitrary property by key This is useful so we don't have to
      * keep adding methods to this interface for every single configuration option ever. Also

--- a/priam/src/main/java/com/netflix/priam/connection/CassandraOperations.java
+++ b/priam/src/main/java/com/netflix/priam/connection/CassandraOperations.java
@@ -30,7 +30,7 @@ public class CassandraOperations implements ICassandraOperations {
     private final IConfiguration configuration;
 
     @Inject
-    CassandraOperations(IConfiguration configuration) {
+    public CassandraOperations(IConfiguration configuration) {
         this.configuration = configuration;
     }
 

--- a/priam/src/main/java/com/netflix/priam/health/InstanceState.java
+++ b/priam/src/main/java/com/netflix/priam/health/InstanceState.java
@@ -53,7 +53,7 @@ public class InstanceState {
     private final RestoreStatus restoreStatus;
 
     @Inject
-    InstanceState(RestoreStatus restoreStatus) {
+    public InstanceState(RestoreStatus restoreStatus) {
         this.restoreStatus = restoreStatus;
     }
 

--- a/priam/src/main/java/com/netflix/priam/resources/BackupServlet.java
+++ b/priam/src/main/java/com/netflix/priam/resources/BackupServlet.java
@@ -219,7 +219,8 @@ public class BackupServlet {
             throws Exception {
         DateUtil.DateRange dateRange = new DateUtil.DateRange(daterange);
         Optional<BackupVerificationResult> result =
-                backupVerification.verifyBackup(BackupVersion.SNAPSHOT_BACKUP, force, dateRange);
+                backupVerification.verifyLatestBackup(
+                        BackupVersion.SNAPSHOT_BACKUP, force, dateRange);
         if (!result.isPresent()) {
             return Response.noContent()
                     .entity("No valid meta found for provided time range")

--- a/priam/src/main/java/com/netflix/priam/resources/BackupServletV2.java
+++ b/priam/src/main/java/com/netflix/priam/resources/BackupServletV2.java
@@ -147,8 +147,11 @@ public class BackupServletV2 {
             return Response.ok("No valid meta found!").build();
         }
         List<AbstractBackupPath> allFiles =
-                BackupRestoreUtil.getAllFiles(
-                        latestValidMetaFile.get(), dateRange, metaProxy, pathProvider);
+                BackupRestoreUtil.getMostRecentSnapshotPaths(
+                        latestValidMetaFile.get(), metaProxy, pathProvider);
+        allFiles.addAll(
+                BackupRestoreUtil.getIncrementalPaths(
+                        latestValidMetaFile.get(), dateRange, metaProxy));
 
         return Response.ok(
                         GsonJsonSerializer.getGson()

--- a/priam/src/main/java/com/netflix/priam/resources/BackupServletV2.java
+++ b/priam/src/main/java/com/netflix/priam/resources/BackupServletV2.java
@@ -125,7 +125,7 @@ public class BackupServletV2 {
             throws Exception {
         DateUtil.DateRange dateRange = new DateUtil.DateRange(daterange);
         Optional<BackupVerificationResult> result =
-                backupVerification.verifyBackup(
+                backupVerification.verifyLatestBackup(
                         BackupVersion.SNAPSHOT_META_SERVICE, force, dateRange);
         if (!result.isPresent()) {
             return Response.noContent()

--- a/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
@@ -114,10 +114,6 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
         return (isRestoreMode && isBackedupRac);
     }
 
-    public void setRestoreConfiguration(String restoreIncludeCFList, String restoreExcludeCFList) {
-        backupRestoreUtil.setFilters(restoreIncludeCFList, restoreExcludeCFList);
-    }
-
     private List<Future<Path>> download(
             Iterator<AbstractBackupPath> fsIterator, boolean waitForCompletion) throws Exception {
         List<Future<Path>> futureList = new ArrayList<>();
@@ -247,8 +243,13 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
                     .setSnapshotMetaFile(latestValidMetaFile.get().getRemotePath());
 
             List<AbstractBackupPath> allFiles =
-                    BackupRestoreUtil.getAllFiles(
-                            latestValidMetaFile.get(), dateRange, metaProxy, pathProvider);
+                    BackupRestoreUtil.getMostRecentSnapshotPaths(
+                            latestValidMetaFile.get(), metaProxy, pathProvider);
+            if (!config.skipIncrementalRestore()) {
+                allFiles.addAll(
+                        BackupRestoreUtil.getIncrementalPaths(
+                                latestValidMetaFile.get(), dateRange, metaProxy));
+            }
 
             // Download snapshot which is listed in the meta file.
             List<Future<Path>> futureList = new ArrayList<>();

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackupVerification.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackupVerification.java
@@ -24,7 +24,6 @@ import com.netflix.priam.backupv2.IMetaProxy;
 import com.netflix.priam.backupv2.MetaV1Proxy;
 import com.netflix.priam.backupv2.MetaV2Proxy;
 import com.netflix.priam.config.IConfiguration;
-import com.netflix.priam.scheduler.UnsupportedTypeException;
 import com.netflix.priam.utils.DateUtil;
 import com.netflix.priam.utils.DateUtil.DateRange;
 import java.io.File;
@@ -92,36 +91,16 @@ public class TestBackupVerification {
     }
 
     @Test
-    public void illegalDateRange() throws UnsupportedTypeException {
-        try {
-            backupVerification.verifyBackup(BackupVersion.SNAPSHOT_BACKUP, false, null);
-            Assert.assertTrue(false);
-        } catch (IllegalArgumentException e) {
-            Assert.assertTrue(true);
-        }
-    }
-
-    @Test
-    public void illegalDateRangeBackupDateRange() throws UnsupportedTypeException {
-        try {
-            backupVerification.verifyAllBackups(BackupVersion.SNAPSHOT_BACKUP, null);
-            Assert.assertTrue(false);
-        } catch (IllegalArgumentException e) {
-            Assert.assertTrue(true);
-        }
-    }
-
-    @Test
     public void noBackup() throws Exception {
         Optional<BackupVerificationResult> backupVerificationResultOptinal =
-                backupVerification.verifyBackup(
+                backupVerification.verifyLatestBackup(
                         BackupVersion.SNAPSHOT_BACKUP,
                         false,
                         new DateRange(Instant.now(), Instant.now()));
         Assert.assertFalse(backupVerificationResultOptinal.isPresent());
 
         backupVerificationResultOptinal =
-                backupVerification.verifyBackup(
+                backupVerification.verifyLatestBackup(
                         BackupVersion.SNAPSHOT_META_SERVICE,
                         false,
                         new DateRange(Instant.now(), Instant.now()));
@@ -130,13 +109,13 @@ public class TestBackupVerification {
 
     @Test
     public void noBackupDateRange() throws Exception {
-        List<BackupVerificationResult> backupVerificationResults =
-                backupVerification.verifyAllBackups(
+        List<BackupMetadata> backupVerificationResults =
+                backupVerification.verifyBackupsInRange(
                         BackupVersion.SNAPSHOT_BACKUP, new DateRange(Instant.now(), Instant.now()));
         Assert.assertFalse(backupVerificationResults.size() > 0);
 
         backupVerificationResults =
-                backupVerification.verifyAllBackups(
+                backupVerification.verifyBackupsInRange(
                         BackupVersion.SNAPSHOT_META_SERVICE,
                         new DateRange(Instant.now(), Instant.now()));
         Assert.assertFalse(backupVerificationResults.size() > 0);
@@ -174,7 +153,7 @@ public class TestBackupVerification {
         setUp();
         // Verify for backup version 1.0
         Optional<BackupVerificationResult> backupVerificationResultOptinal =
-                backupVerification.verifyBackup(
+                backupVerification.verifyLatestBackup(
                         BackupVersion.SNAPSHOT_BACKUP,
                         false,
                         new DateRange(backupDate + "," + backupDate));
@@ -205,15 +184,12 @@ public class TestBackupVerification {
     public void verifyBackupVersion1DateRange() throws Exception {
         setUp();
         // Verify for backup version 1.0
-        List<BackupVerificationResult> backupVerificationResults =
-                backupVerification.verifyAllBackups(
+        List<BackupMetadata> backupVerificationResults =
+                backupVerification.verifyBackupsInRange(
                         BackupVersion.SNAPSHOT_BACKUP,
                         new DateRange(backupDate + "," + backupDateEnd));
         Assert.assertTrue(!backupVerificationResults.isEmpty());
         Assert.assertTrue(backupVerificationResults.size() == numFakeBackups);
-        backupVerificationResults
-                .stream()
-                .forEach(b -> Assert.assertEquals(Instant.EPOCH, b.snapshotInstant));
         List<BackupMetadata> backupMetadata =
                 backupStatusMgr.getLatestBackupMetadata(
                         BackupVersion.SNAPSHOT_BACKUP,
@@ -236,7 +212,7 @@ public class TestBackupVerification {
         setUp();
         // Verify for backup version 2.0
         Optional<BackupVerificationResult> backupVerificationResultOptinal =
-                backupVerification.verifyBackup(
+                backupVerification.verifyLatestBackup(
                         BackupVersion.SNAPSHOT_META_SERVICE,
                         false,
                         new DateRange(backupDate + "," + backupDate));
@@ -256,7 +232,7 @@ public class TestBackupVerification {
 
         // Retry the verification, it should not try and re-verify
         backupVerificationResultOptinal =
-                backupVerification.verifyBackup(
+                backupVerification.verifyLatestBackup(
                         BackupVersion.SNAPSHOT_META_SERVICE,
                         false,
                         new DateRange(backupDate + "," + backupDate));
@@ -284,15 +260,12 @@ public class TestBackupVerification {
     public void verifyBackupVersion2DateRange() throws Exception {
         setUp();
         // Verify for backup version 2.0
-        List<BackupVerificationResult> backupVerificationResults =
-                backupVerification.verifyAllBackups(
+        List<BackupMetadata> backupVerificationResults =
+                backupVerification.verifyBackupsInRange(
                         BackupVersion.SNAPSHOT_META_SERVICE,
                         new DateRange(backupDate + "," + backupDateEnd));
         Assert.assertTrue(!backupVerificationResults.isEmpty());
         Assert.assertTrue(backupVerificationResults.size() == numFakeBackups);
-        backupVerificationResults
-                .stream()
-                .forEach(b -> Assert.assertEquals(Instant.EPOCH, b.snapshotInstant));
         List<BackupMetadata> backupMetadata =
                 backupStatusMgr.getLatestBackupMetadata(
                         BackupVersion.SNAPSHOT_META_SERVICE,

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestBackupV2Service.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestBackupV2Service.java
@@ -17,6 +17,7 @@
 
 package com.netflix.priam.backupv2;
 
+import com.google.common.truth.Truth;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.netflix.priam.backup.AbstractBackup;
@@ -72,6 +73,8 @@ public class TestBackupV2Service {
             {
                 backupRestoreConfig.getSnapshotMetaServiceCronExpression();
                 result = "-1";
+                backupRestoreConfig.getBackupTTLMonitorPeriodInSec();
+                result = 600;
                 configuration.getDataFileLocation();
                 result = "target/data";
             }
@@ -109,7 +112,7 @@ public class TestBackupV2Service {
                         cassandraTunerService,
                         tokenRetriever);
         backupService.scheduleService();
-        Assert.assertTrue(scheduler.getScheduler().getJobGroupNames().isEmpty());
+        Truth.assertThat(scheduler.getScheduler().getJobGroupNames()).hasSize(1);
 
         // snapshot V2 name should not be there.
         Set<Path> backupPaths =
@@ -220,6 +223,6 @@ public class TestBackupV2Service {
         Assert.assertEquals(3, scheduler.getScheduler().getJobKeys(null).size());
 
         backupService.onChangeUpdateService();
-        Assert.assertEquals(0, scheduler.getScheduler().getJobKeys(null).size());
+        Assert.assertEquals(1, scheduler.getScheduler().getJobKeys(null).size());
     }
 }

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestMetaV2Proxy.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestMetaV2Proxy.java
@@ -39,6 +39,7 @@ import javax.inject.Provider;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /** Created by aagrawal on 12/5/18. */
@@ -57,6 +58,11 @@ public class TestMetaV2Proxy {
         backupUtils = new TestBackupUtils();
         metaProxy = injector.getInstance(MetaV2Proxy.class);
         abstractBackupPathProvider = injector.getProvider(AbstractBackupPath.class);
+    }
+
+    @Before
+    public void setUp() {
+        new File(configuration.getDataFileLocation()).mkdirs();
     }
 
     @Test

--- a/priam/src/test/java/com/netflix/priam/notification/TestBackupNotificationMgr.java
+++ b/priam/src/test/java/com/netflix/priam/notification/TestBackupNotificationMgr.java
@@ -5,7 +5,6 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.netflix.priam.backup.AbstractBackupPath;
 import com.netflix.priam.backup.BRTestModule;
-import com.netflix.priam.backup.BackupVerificationResult;
 import com.netflix.priam.config.IBackupRestoreConfig;
 import com.netflix.priam.config.IConfiguration;
 import java.nio.file.Path;
@@ -296,23 +295,12 @@ public class TestBackupNotificationMgr {
                 maxTimes = 1;
             }
         };
-        BackupVerificationResult backupVerificationResult = getBackupVerificationResult();
-        backupNotificationMgr.notify(backupVerificationResult);
+        backupNotificationMgr.notify("some_random", Instant.EPOCH);
         new Verifications() {
             {
                 notificationService.notify(anyString, (Map<String, MessageAttributeValue>) any);
                 maxTimes = 1;
             }
         };
-    }
-
-    private static BackupVerificationResult getBackupVerificationResult() {
-        BackupVerificationResult result = new BackupVerificationResult();
-        result.valid = true;
-        result.manifestAvailable = true;
-        result.remotePath = "some_random";
-        result.filesMatched = 123;
-        result.snapshotInstant = Instant.EPOCH;
-        return result;
     }
 }

--- a/priam/src/test/java/com/netflix/priam/resources/BackupServletV2Test.java
+++ b/priam/src/test/java/com/netflix/priam/resources/BackupServletV2Test.java
@@ -157,7 +157,7 @@ public class BackupServletV2Test {
     public void testValidate() throws Exception {
         new Expectations() {
             {
-                backupVerification.verifyBackup(
+                backupVerification.verifyLatestBackup(
                         BackupVersion.SNAPSHOT_META_SERVICE,
                         anyBoolean,
                         new DateUtil.DateRange((Instant) any, (Instant) any));
@@ -177,7 +177,7 @@ public class BackupServletV2Test {
     public void testValidateNoBackups() throws Exception {
         new Expectations() {
             {
-                backupVerification.verifyBackup(
+                backupVerification.verifyLatestBackup(
                         BackupVersion.SNAPSHOT_META_SERVICE,
                         anyBoolean,
                         new DateUtil.DateRange((Instant) any, (Instant) any));
@@ -196,7 +196,7 @@ public class BackupServletV2Test {
     public void testValidateV2SnapshotByDate() throws Exception {
         new Expectations() {
             {
-                backupVerification.verifyBackup(
+                backupVerification.verifyLatestBackup(
                         BackupVersion.SNAPSHOT_META_SERVICE,
                         anyBoolean,
                         new DateUtil.DateRange((Instant) any, (Instant) any));


### PR DESCRIPTION
72479646 2023-04-15 | Always TTL backups. (#1038) (HEAD -> 3.11, origin/3.11) [mattl-netflix]
05900e45 2023-04-11 | remove the instance info from the DI (#1042) [Cheng Wang]
c489748c 2023-03-30 | make the constructor public [Cheng Wang]
f48fc9e2 2023-03-29 | minor code modifications to simplify the nfpriam spring boot migration (origin/chengw/fix-for-sbn) [Cheng Wang]
36321c41 2023-03-29 | Reveal hook to allow operators to restore just to the most recent snapshot (#1035) [mattl-netflix]
0fb87f94 2023-03-27 | Fix backup verification race condition causing missing notifications (#1034) [mattl-netflix]