### PR TITLE
Change the interface of PriamScheduler

### DIFF
--- a/priam/src/main/java/com/netflix/priam/scheduler/GuiceJobFactory.java
+++ b/priam/src/main/java/com/netflix/priam/scheduler/GuiceJobFactory.java
@@ -22,7 +22,6 @@ import org.quartz.Job;
 import org.quartz.JobDetail;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
-import org.quartz.spi.JobFactory;
 import org.quartz.spi.TriggerFiredBundle;
 
 public class GuiceJobFactory implements PriamJobFactory {

--- a/priam/src/main/java/com/netflix/priam/scheduler/GuiceJobFactory.java
+++ b/priam/src/main/java/com/netflix/priam/scheduler/GuiceJobFactory.java
@@ -25,7 +25,7 @@ import org.quartz.SchedulerException;
 import org.quartz.spi.JobFactory;
 import org.quartz.spi.TriggerFiredBundle;
 
-public class GuiceJobFactory implements JobFactory {
+public class GuiceJobFactory implements PriamJobFactory {
     public final Injector guice;
 
     @Inject
@@ -36,7 +36,11 @@ public class GuiceJobFactory implements JobFactory {
     @Override
     public Job newJob(TriggerFiredBundle bundle, Scheduler scheduler) throws SchedulerException {
         JobDetail jobDetail = bundle.getJobDetail();
-        Class<?> jobClass = jobDetail.getJobClass();
+        return newJob((Class<? extends Task>) jobDetail.getJobClass());
+    }
+
+    @Override
+    public Job newJob(Class<? extends Task> jobClass) {
         Job job = (Job) guice.getInstance(jobClass);
         guice.injectMembers(job);
         return job;

--- a/priam/src/main/java/com/netflix/priam/scheduler/PriamJobFactory.java
+++ b/priam/src/main/java/com/netflix/priam/scheduler/PriamJobFactory.java
@@ -1,0 +1,10 @@
+package com.netflix.priam.scheduler;
+
+import org.quartz.Job;
+import org.quartz.spi.JobFactory;
+
+import java.util.function.Function;
+
+public interface PriamJobFactory extends JobFactory {
+    Job newJob(Class<? extends Task> jobClass);
+}

--- a/priam/src/main/java/com/netflix/priam/scheduler/PriamJobFactory.java
+++ b/priam/src/main/java/com/netflix/priam/scheduler/PriamJobFactory.java
@@ -1,8 +1,10 @@
 package com.netflix.priam.scheduler;
 
+import com.google.inject.ImplementedBy;
 import org.quartz.Job;
 import org.quartz.spi.JobFactory;
 
+@ImplementedBy(GuiceJobFactory.class)
 public interface PriamJobFactory extends JobFactory {
     Job newJob(Class<? extends Task> jobClass);
 }

--- a/priam/src/main/java/com/netflix/priam/scheduler/PriamJobFactory.java
+++ b/priam/src/main/java/com/netflix/priam/scheduler/PriamJobFactory.java
@@ -3,8 +3,6 @@ package com.netflix.priam.scheduler;
 import org.quartz.Job;
 import org.quartz.spi.JobFactory;
 
-import java.util.function.Function;
-
 public interface PriamJobFactory extends JobFactory {
     Job newJob(Class<? extends Task> jobClass);
 }

--- a/priam/src/main/java/com/netflix/priam/scheduler/PriamScheduler.java
+++ b/priam/src/main/java/com/netflix/priam/scheduler/PriamScheduler.java
@@ -29,15 +29,15 @@ import org.slf4j.LoggerFactory;
 public class PriamScheduler {
     private static final Logger logger = LoggerFactory.getLogger(PriamScheduler.class);
     private final Scheduler scheduler;
-    private final GuiceJobFactory jobFactory;
+    private final PriamJobFactory jobProvider;
     private final Sleeper sleeper;
 
     @Inject
-    public PriamScheduler(SchedulerFactory factory, GuiceJobFactory jobFactory, Sleeper sleeper) {
+    public PriamScheduler(SchedulerFactory factory, PriamJobFactory jobProvider, Sleeper sleeper) {
         try {
             this.scheduler = factory.getScheduler();
-            this.scheduler.setJobFactory(jobFactory);
-            this.jobFactory = jobFactory;
+            this.scheduler.setJobFactory(jobProvider);
+            this.jobProvider = jobProvider;
         } catch (SchedulerException e) {
             throw new RuntimeException(e);
         }
@@ -100,7 +100,7 @@ public class PriamScheduler {
     }
 
     public void runTaskNow(Class<? extends Task> taskclass) throws Exception {
-        jobFactory.guice.getInstance(taskclass).execute(null);
+        jobProvider.newJob(taskclass).execute(null);
     }
 
     public void deleteTask(String name) throws SchedulerException {


### PR DESCRIPTION
This pull request modifies the interface of the PriamScheduler class by introducing a more general PriamJobFactory that replaces the GuiceJobFactory. This update eliminates the need to expose the Guice module and enhances compatibility with the Spring Boot framework.