### PR TITLE
Minor name change in the PriamScheduler

### DIFF
--- a/priam/src/main/java/com/netflix/priam/scheduler/PriamScheduler.java
+++ b/priam/src/main/java/com/netflix/priam/scheduler/PriamScheduler.java
@@ -29,15 +29,15 @@ import org.slf4j.LoggerFactory;
 public class PriamScheduler {
     private static final Logger logger = LoggerFactory.getLogger(PriamScheduler.class);
     private final Scheduler scheduler;
-    private final PriamJobFactory jobProvider;
+    private final PriamJobFactory jobFactory;
     private final Sleeper sleeper;
 
     @Inject
-    public PriamScheduler(SchedulerFactory factory, PriamJobFactory jobProvider, Sleeper sleeper) {
+    public PriamScheduler(SchedulerFactory factory, PriamJobFactory jobFactory, Sleeper sleeper) {
         try {
             this.scheduler = factory.getScheduler();
-            this.scheduler.setJobFactory(jobProvider);
-            this.jobProvider = jobProvider;
+            this.scheduler.setJobFactory(jobFactory);
+            this.jobFactory = jobFactory;
         } catch (SchedulerException e) {
             throw new RuntimeException(e);
         }
@@ -100,7 +100,7 @@ public class PriamScheduler {
     }
 
     public void runTaskNow(Class<? extends Task> taskclass) throws Exception {
-        jobProvider.newJob(taskclass).execute(null);
+        jobFactory.newJob(taskclass).execute(null);
     }
 
     public void deleteTask(String name) throws SchedulerException {


### PR DESCRIPTION
As per the PR comments in [1049](https://github.com/Netflix/Priam/pull/1049), the PriamScheduler's jobProvider has been renamed to jobFactory. This is a minor name change that has been implemented.