### PR TITLE
Rollback #1042: Change the interface of EC2RoleAssumptionCredential

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/auth/EC2RoleAssumptionCredential.java
+++ b/priam/src/main/java/com/netflix/priam/aws/auth/EC2RoleAssumptionCredential.java
@@ -29,10 +29,10 @@ public class EC2RoleAssumptionCredential implements ICredential {
     private AWSCredentialsProvider stsSessionCredentialsProvider;
 
     @Inject
-    public EC2RoleAssumptionCredential(ICredential cred, IConfiguration config) {
+    public EC2RoleAssumptionCredential(ICredential cred, IConfiguration config, InstanceInfo instanceInfo) {
         this.cred = cred;
         this.config = config;
-        this.instanceInfo = new AWSInstanceInfo(cred);
+        this.instanceInfo = instanceInfo;
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/aws/auth/EC2RoleAssumptionCredential.java
+++ b/priam/src/main/java/com/netflix/priam/aws/auth/EC2RoleAssumptionCredential.java
@@ -17,7 +17,6 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.cred.ICredential;
-import com.netflix.priam.identity.config.AWSInstanceInfo;
 import com.netflix.priam.identity.config.InstanceInfo;
 import javax.inject.Inject;
 
@@ -29,7 +28,8 @@ public class EC2RoleAssumptionCredential implements ICredential {
     private AWSCredentialsProvider stsSessionCredentialsProvider;
 
     @Inject
-    public EC2RoleAssumptionCredential(ICredential cred, IConfiguration config, InstanceInfo instanceInfo) {
+    public EC2RoleAssumptionCredential(
+            ICredential cred, IConfiguration config, InstanceInfo instanceInfo) {
         this.cred = cred;
         this.config = config;
         this.instanceInfo = instanceInfo;


### PR DESCRIPTION
Rollback the  [#1042](https://github.com/Netflix/Priam/pull/1042) since it breaks the downstream consumers. 