### PR TITLE
Rollback #1042: Change the interface of EC2RoleAssumptionCredential

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/auth/EC2RoleAssumptionCredential.java
+++ b/priam/src/main/java/com/netflix/priam/aws/auth/EC2RoleAssumptionCredential.java
@@ -17,7 +17,6 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.cred.ICredential;
-import com.netflix.priam.identity.config.AWSInstanceInfo;
 import com.netflix.priam.identity.config.InstanceInfo;
 import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
@@ -30,10 +29,11 @@ public class EC2RoleAssumptionCredential implements ICredential {
     private AWSCredentialsProvider stsSessionCredentialsProvider;
 
     @Inject
-    public EC2RoleAssumptionCredential(ICredential cred, IConfiguration config) {
+    public EC2RoleAssumptionCredential(
+            ICredential cred, IConfiguration config, InstanceInfo instanceInfo) {
         this.cred = cred;
         this.config = config;
-        this.instanceInfo = new AWSInstanceInfo(cred);
+        this.instanceInfo = instanceInfo;
     }
 
     @Override


### PR DESCRIPTION
https://github.com/Netflix/Priam/commit/05900e458ac79b495c4e302e2b9ce3e1ee9591f5 2023-04-11 | remove the instance info from the DI (https://github.com/Netflix/Priam/pull/1042) [Cheng Wang]