### PR TITLE
Change the constructor of the CassandraMonitor to be public

### DIFF
--- a/priam/src/main/java/com/netflix/priam/health/CassandraMonitor.java
+++ b/priam/src/main/java/com/netflix/priam/health/CassandraMonitor.java
@@ -50,7 +50,7 @@ public class CassandraMonitor extends Task {
     private final IThriftChecker thriftChecker;
 
     @Inject
-    protected CassandraMonitor(
+    public CassandraMonitor(
             IConfiguration config,
             InstanceState instanceState,
             ICassandraProcess cassProcess,


### PR DESCRIPTION
Change the constructor of the CassandraMonitor to be public, to enable to create a bean definition for the CassandraMonitor externally. 