### PR TITLE
Configurable Async Snapshot and Addition of New Constructor for BackupFileSystemContext

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backup/BackupFileSystemContext.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupFileSystemContext.java
@@ -31,8 +31,7 @@ public class BackupFileSystemContext implements IFileSystemContext {
     }
 
     @Inject
-    public BackupFileSystemContext(
-            @Named("backup") IBackupFileSystem fs) {
+    public BackupFileSystemContext(@Named("backup") IBackupFileSystem fs) {
         this.fs = fs;
     }
 

--- a/priam/src/main/java/com/netflix/priam/backup/BackupFileSystemContext.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupFileSystemContext.java
@@ -30,6 +30,12 @@ public class BackupFileSystemContext implements IFileSystemContext {
         this.encryptedFs = encryptedFs;
     }
 
+    @Inject
+    public BackupFileSystemContext(
+            @Named("backup") IBackupFileSystem fs) {
+        this.fs = fs;
+    }
+
     public IBackupFileSystem getFileStrategy(IConfiguration config) {
 
         if (!config.isEncryptBackupEnabled()) {

--- a/priam/src/main/java/com/netflix/priam/backupv2/SnapshotMetaTask.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/SnapshotMetaTask.java
@@ -288,14 +288,14 @@ public class SnapshotMetaTask extends AbstractBackup {
                 // is to ensure that next run happens on time.
                 AbstractBackupPath.BackupFileType type = AbstractBackupPath.BackupFileType.SST_V2;
                 backupHelper
-                        .uploadAndDeleteAllFiles(snapshotDirectory, type, target, true)
+                        .uploadAndDeleteAllFiles(snapshotDirectory, type, target, config.enableAsyncSnapshot())
                         .forEach(future -> addCallback(future, snapshotDirectory));
 
                 // Next, upload secondary indexes
                 type = AbstractBackupPath.BackupFileType.SECONDARY_INDEX_V2;
                 ImmutableList<ListenableFuture<AbstractBackupPath>> futures;
                 for (File subDir : getSecondaryIndexDirectories(snapshotDirectory)) {
-                    futures = backupHelper.uploadAndDeleteAllFiles(subDir, type, target, true);
+                    futures = backupHelper.uploadAndDeleteAllFiles(subDir, type, target, config.enableAsyncSnapshot());
                     if (futures.isEmpty()) {
                         deleteIfEmpty(subDir);
                     }

--- a/priam/src/main/java/com/netflix/priam/backupv2/SnapshotMetaTask.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/SnapshotMetaTask.java
@@ -288,14 +288,17 @@ public class SnapshotMetaTask extends AbstractBackup {
                 // is to ensure that next run happens on time.
                 AbstractBackupPath.BackupFileType type = AbstractBackupPath.BackupFileType.SST_V2;
                 backupHelper
-                        .uploadAndDeleteAllFiles(snapshotDirectory, type, target, config.enableAsyncSnapshot())
+                        .uploadAndDeleteAllFiles(
+                                snapshotDirectory, type, target, config.enableAsyncSnapshot())
                         .forEach(future -> addCallback(future, snapshotDirectory));
 
                 // Next, upload secondary indexes
                 type = AbstractBackupPath.BackupFileType.SECONDARY_INDEX_V2;
                 ImmutableList<ListenableFuture<AbstractBackupPath>> futures;
                 for (File subDir : getSecondaryIndexDirectories(snapshotDirectory)) {
-                    futures = backupHelper.uploadAndDeleteAllFiles(subDir, type, target, config.enableAsyncSnapshot());
+                    futures =
+                            backupHelper.uploadAndDeleteAllFiles(
+                                    subDir, type, target, config.enableAsyncSnapshot());
                     if (futures.isEmpty()) {
                         deleteIfEmpty(subDir);
                     }


### PR DESCRIPTION
This PR contains two fixes:
1. The previously hard-coded value of 'enableAsyncSnapshot' set as 'true' has been removed. Now, the value is derived from the configuration settings.
2. A new constructor has been added for the BackupFileSystemContext. This has been done to circumvent the bean definition related to encrypted backup.
