### PR TITLE
Add constructor for BackupFileSystemContext

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backup/BackupFileSystemContext.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupFileSystemContext.java
@@ -30,6 +30,10 @@ public class BackupFileSystemContext implements IFileSystemContext {
         this.encryptedFs = encryptedFs;
     }
 
+    public BackupFileSystemContext(@Named("backup") IBackupFileSystem fs) {
+        this.fs = fs;
+    }
+
     public IBackupFileSystem getFileStrategy(IConfiguration config) {
 
         if (!config.isEncryptBackupEnabled()) {


### PR DESCRIPTION
A new constructor has been added for the BackupFileSystemContext. This has been done to circumvent the bean definition related to encrypted backup.