### PR TITLE
Reveal hook to assume meta file validity on restore. This speeds rest…

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaV2Proxy.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaV2Proxy.java
@@ -43,6 +43,7 @@ public class MetaV2Proxy implements IMetaProxy {
     private final Path metaFileDirectory;
     private final IBackupFileSystem fs;
     private final Provider<AbstractBackupPath> abstractBackupPathProvider;
+    private final IConfiguration config;
 
     @Inject
     public MetaV2Proxy(
@@ -52,6 +53,7 @@ public class MetaV2Proxy implements IMetaProxy {
         fs = backupFileSystemCtx.getFileStrategy(configuration);
         this.abstractBackupPathProvider = abstractBackupPathProvider;
         metaFileDirectory = Paths.get(configuration.getDataFileLocation());
+        this.config = configuration;
     }
 
     @Override
@@ -196,7 +198,9 @@ public class MetaV2Proxy implements IMetaProxy {
             metaFile = downloadMetaFile(metaBackupPath);
             result.manifestAvailable = true;
 
-            metaFileBackupValidator.readMeta(metaFile);
+            if (!config.skipMetaFileValidationOnRestore()) {
+                metaFileBackupValidator.readMeta(metaFile);
+            }
             result.valid = (result.filesInMetaOnly.isEmpty());
         } catch (FileNotFoundException fne) {
             logger.error(fne.getLocalizedMessage());

--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -1183,4 +1183,8 @@ public interface IConfiguration {
      * @return The result for the property, or the defaultValue if provided (null otherwise)
      */
     String getProperty(String key, String defaultValue);
+
+    default boolean skipMetaFileValidationOnRestore() {
+        return false;
+    }
 }


### PR DESCRIPTION
…ores when meta files are large and known to be valid. A more-correct solution of using the BackupStatusMgr is forthcoming.