### PR TITLE
inject jvm options

### DIFF
--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -74,6 +74,10 @@ public interface IConfiguration {
         return StringUtils.EMPTY;
     }
 
+    default String getJVMInjectSet() {
+        return StringUtils.EMPTY;
+    }
+
     /** @return Path to Cassandra startup script */
     default String getCassStartupScript() {
         return "/etc/init.d/cassandra start";

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -224,6 +224,11 @@ public class PriamConfiguration implements IConfiguration {
     }
 
     @Override
+    public String getJVMInjectSet() {
+        return config.get(PRIAM_PRE + ".jvm.options.inject");
+    }
+
+    @Override
     public String getFlushCronExpression() {
         return config.get(PRIAM_PRE + ".flush.cron", "-1");
     }

--- a/priam/src/main/java/com/netflix/priam/tuner/JVMOptionsTuner.java
+++ b/priam/src/main/java/com/netflix/priam/tuner/JVMOptionsTuner.java
@@ -153,6 +153,9 @@ public class JVMOptionsTuner {
                             .collect(Collectors.toList()));
         }
 
+        final String injectSet = config.getJVMInjectSet();
+        if (injectSet != null && !injectSet.trim().isEmpty()) configuredOptions.add(injectSet);
+
         HashMap<String, List<String>> options = new HashMap<String, List<String>>() {};
         options.put("configuredJVMOptions", configuredOptions);
         options.put("configuredJVMVersionOptions", configuredVersionOptions);


### PR DESCRIPTION
upsert uses commas as the delimiter between options which doesn't work for a few C* options that use commas in the value.

Inject works by taking the string and adding it to the end of the jvm-server.options file verbatim. While the comments in that file say it expects one option per line there is nothing that actually enforces that rule. The line only needs to start with a '-'

Code that parses the options file:
```
JVM_OPTS_FILE=$CASSANDRA_CONF/jvm${jvmoptions_variant:--clients}.options if [ $JAVA_VERSION -ge 11 ] ; then
    JVM_DEP_OPTS_FILE=$CASSANDRA_CONF/jvm11${jvmoptions_variant:--clients}.options
else
    JVM_DEP_OPTS_FILE=$CASSANDRA_CONF/jvm8${jvmoptions_variant:--clients}.options
fi

for opt in `grep "^-" $JVM_OPTS_FILE` `grep "^-" $JVM_DEP_OPTS_FILE` do
  JVM_OPTS="$JVM_OPTS $opt"
done
```