### PR TITLE
Restore incremental backups of secondary index sstables.

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/RemoteBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/aws/RemoteBackupPath.java
@@ -26,7 +26,6 @@ import com.netflix.priam.identity.InstanceIdentity;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
-import java.util.Date;
 import java.util.List;
 import javax.inject.Inject;
 
@@ -147,14 +146,6 @@ public class RemoteBackupPath extends AbstractBackupPath {
         region = remotePath.getName(1).toString();
         clusterName = remotePath.getName(2).toString();
         token = remotePath.getName(3).toString();
-    }
-
-    @Override
-    public String remotePrefix(Date start, Date end, String location) {
-        return PATH_JOINER.join(
-                clusterPrefix(location),
-                instanceIdentity.getInstance().getToken(),
-                match(start, end));
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
@@ -47,7 +47,6 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
             ImmutableMap.of(BackupFolder.BACKUPS, 3, BackupFolder.SNAPSHOTS, 4);
 
     public enum BackupFileType {
-        CL,
         META_V2,
         SECONDARY_INDEX_V2,
         SNAPSHOT_VERIFIED,
@@ -149,9 +148,6 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
         File return_;
         String dataDir = config.getDataFileLocation();
         switch (type) {
-            case CL:
-                return_ = new File(PATH_JOINER.join(config.getBackupCommitLogLocation(), fileName));
-                break;
             case SECONDARY_INDEX_V2:
                 String restoreFileName =
                         PATH_JOINER.join(dataDir, keyspace, columnFamily, indexDir, fileName);

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
@@ -184,11 +184,6 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
     /** Parses paths with just token prefixes */
     public abstract void parsePartialPrefix(String remoteFilePath);
 
-    /**
-     * Provides a common prefix that matches all objects that fall between the start and end time
-     */
-    public abstract String remotePrefix(Date start, Date end, String location);
-
     public abstract Path remoteV2Prefix(Path location, BackupFileType fileType);
 
     /** Provides the cluster prefix */

--- a/priam/src/main/java/com/netflix/priam/backup/BackupRestoreUtil.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupRestoreUtil.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableMap;
 import com.netflix.priam.backupv2.IMetaProxy;
 import com.netflix.priam.utils.DateUtil;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -81,19 +80,6 @@ public class BackupRestoreUtil {
                         .collect(Collectors.toList());
         FileUtils.deleteQuietly(metaFile.toFile());
         return snapshotPaths;
-    }
-
-    public static List<AbstractBackupPath> getIncrementalPaths(
-            AbstractBackupPath latestValidMetaFile,
-            DateUtil.DateRange dateRange,
-            IMetaProxy metaProxy) {
-        Instant snapshotTime;
-        snapshotTime = latestValidMetaFile.getLastModified();
-        DateUtil.DateRange incrementalDateRange =
-                new DateUtil.DateRange(snapshotTime, dateRange.getEndTime());
-        List<AbstractBackupPath> incrementalPaths = new ArrayList<>();
-        metaProxy.getIncrementals(incrementalDateRange).forEachRemaining(incrementalPaths::add);
-        return incrementalPaths;
     }
 
     public static Map<String, List<String>> getFilter(String inputFilter)

--- a/priam/src/main/java/com/netflix/priam/backup/BackupStatusMgr.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupStatusMgr.java
@@ -209,18 +209,7 @@ public abstract class BackupStatusMgr implements IBackupStatusMgr {
                 .stream()
                 .filter(Objects::nonNull)
                 .filter(backupMetadata -> backupMetadata.getStatus() == Status.FINISHED)
-                .filter(
-                        backupMetadata ->
-                                backupMetadata
-                                                        .getStart()
-                                                        .toInstant()
-                                                        .compareTo(dateRange.getStartTime())
-                                                >= 0
-                                        && backupMetadata
-                                                        .getStart()
-                                                        .toInstant()
-                                                        .compareTo(dateRange.getEndTime())
-                                                <= 0)
+                .filter(backupMetadata -> dateRange.contains(backupMetadata.getStart().toInstant()))
                 .sorted(Comparator.comparing(BackupMetadata::getStart).reversed())
                 .collect(Collectors.toList());
     }

--- a/priam/src/main/java/com/netflix/priam/backupv2/IMetaProxy.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/IMetaProxy.java
@@ -17,12 +17,12 @@
 
 package com.netflix.priam.backupv2;
 
+import com.google.common.collect.ImmutableList;
 import com.netflix.priam.backup.AbstractBackupPath;
 import com.netflix.priam.backup.BackupRestoreException;
 import com.netflix.priam.backup.BackupVerificationResult;
 import com.netflix.priam.utils.DateUtil;
 import java.nio.file.Path;
-import java.util.Iterator;
 import java.util.List;
 
 /** Proxy to do management tasks for meta files. Created by aagrawal on 12/18/18. */
@@ -78,7 +78,7 @@ public interface IMetaProxy {
      * @param dateRange the time period to scan in the remote file system for incremental files.
      * @return iterator containing the list of path on the remote file system satisfying criteria.
      */
-    Iterator<AbstractBackupPath> getIncrementals(DateUtil.DateRange dateRange);
+    ImmutableList<AbstractBackupPath> getIncrementals(DateUtil.DateRange dateRange);
 
     /**
      * Validate that all the files mentioned in the meta file actually exists on remote file system.

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaV2Proxy.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaV2Proxy.java
@@ -107,17 +107,7 @@ public class MetaV2Proxy implements IMetaProxy {
 
         return new FilterIterator<>(
                 transformIterator,
-                abstractBackupPath ->
-                        (abstractBackupPath.getLastModified().isAfter(dateRange.getStartTime())
-                                        && abstractBackupPath
-                                                .getLastModified()
-                                                .isBefore(dateRange.getEndTime()))
-                                || abstractBackupPath
-                                        .getLastModified()
-                                        .equals(dateRange.getStartTime())
-                                || abstractBackupPath
-                                        .getLastModified()
-                                        .equals(dateRange.getEndTime()));
+                abstractBackupPath -> dateRange.contains(abstractBackupPath.getLastModified()));
     }
 
     @Override
@@ -136,10 +126,7 @@ public class MetaV2Proxy implements IMetaProxy {
             AbstractBackupPath abstractBackupPath = abstractBackupPathProvider.get();
             abstractBackupPath.parseRemote(iterator.next());
             logger.debug("Meta file found: {}", abstractBackupPath);
-            if (abstractBackupPath.getLastModified().toEpochMilli()
-                            >= dateRange.getStartTime().toEpochMilli()
-                    && abstractBackupPath.getLastModified().toEpochMilli()
-                            <= dateRange.getEndTime().toEpochMilli()) {
+            if (dateRange.contains(abstractBackupPath.getLastModified())) {
                 metas.add(abstractBackupPath);
             }
         }

--- a/priam/src/main/java/com/netflix/priam/backupv2/MetaV2Proxy.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/MetaV2Proxy.java
@@ -84,11 +84,18 @@ public class MetaV2Proxy implements IMetaProxy {
 
     @Override
     public ImmutableList<AbstractBackupPath> getIncrementals(DateUtil.DateRange dateRange) {
-        String incrementalPrefix = getMatch(dateRange, AbstractBackupPath.BackupFileType.SST_V2);
-        String marker =
-                getMatch(
-                        new DateUtil.DateRange(dateRange.getStartTime(), null),
-                        AbstractBackupPath.BackupFileType.SST_V2);
+        return new ImmutableList.Builder<AbstractBackupPath>()
+                .addAll(getIncrementals(dateRange, AbstractBackupPath.BackupFileType.SST_V2))
+                .addAll(
+                        getIncrementals(
+                                dateRange, AbstractBackupPath.BackupFileType.SECONDARY_INDEX_V2))
+                .build();
+    }
+
+    private ImmutableList<AbstractBackupPath> getIncrementals(
+            DateUtil.DateRange dateRange, AbstractBackupPath.BackupFileType type) {
+        String incrementalPrefix = getMatch(dateRange, type);
+        String marker = getMatch(new DateUtil.DateRange(dateRange.getStartTime(), null), type);
         logger.info(
                 "Listing filesystem with prefix: {}, marker: {}, daterange: {}",
                 incrementalPrefix,

--- a/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
@@ -220,9 +220,11 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
                     BackupRestoreUtil.getMostRecentSnapshotPaths(
                             latestValidMetaFile.get(), metaProxy, pathProvider);
             if (!config.skipIncrementalRestore()) {
-                allFiles.addAll(
-                        BackupRestoreUtil.getIncrementalPaths(
-                                latestValidMetaFile.get(), dateRange, metaProxy));
+                DateUtil.DateRange incrementalDateRange =
+                        new DateUtil.DateRange(
+                                latestValidMetaFile.get().getLastModified(),
+                                dateRange.getEndTime());
+                allFiles.addAll(metaProxy.getIncrementals(incrementalDateRange));
             }
 
             // Download snapshot which is listed in the meta file.

--- a/priam/src/main/java/com/netflix/priam/utils/DateUtil.java
+++ b/priam/src/main/java/com/netflix/priam/utils/DateUtil.java
@@ -215,6 +215,10 @@ public class DateUtil {
             return endTime;
         }
 
+        public boolean contains(Instant instant) {
+            return startTime.compareTo(instant) <= 0 && endTime.compareTo(instant) >= 0;
+        }
+
         public String toString() {
             return GsonJsonSerializer.getGson().toJson(this);
         }

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestMetaV2Proxy.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestMetaV2Proxy.java
@@ -17,6 +17,7 @@
 
 package com.netflix.priam.backupv2;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.truth.Truth;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -131,7 +132,16 @@ public class TestMetaV2Proxy {
     @Test
     public void testGetIncrementalFiles() throws Exception {
         DateUtil.DateRange dateRange = new DateUtil.DateRange("202812071820,20281229");
-        Truth.assertThat(metaProxy.getIncrementals(dateRange)).hasSize(3);
+        ImmutableList<AbstractBackupPath> paths = metaProxy.getIncrementals(dateRange);
+        Truth.assertThat(paths).hasSize(4);
+    }
+
+    @Test
+    public void testGetIncrementalFilesIncludesSecondaryIndexes() throws Exception {
+        DateUtil.DateRange dateRange = new DateUtil.DateRange("202812071820,20281229");
+        ImmutableList<AbstractBackupPath> paths = metaProxy.getIncrementals(dateRange);
+        Truth.assertThat(paths.get(3).getType())
+                .isEqualTo(AbstractBackupPath.BackupFileType.SECONDARY_INDEX_V2);
     }
 
     @Test
@@ -221,6 +231,17 @@ public class TestMetaV2Proxy {
                         "SNAPPY",
                         "PLAINTEXT",
                         "file4-Data.db"));
+        files.add(
+                Paths.get(
+                        getPrefix(),
+                        AbstractBackupPath.BackupFileType.SECONDARY_INDEX_V2.toString(),
+                        "1859828420000",
+                        "keyspace1",
+                        "columnfamily1",
+                        "index1",
+                        "SNAPPY",
+                        "PLAINTEXT",
+                        "file5-Data.db"));
         files.add(
                 Paths.get(
                         getPrefix(),

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestMetaV2Proxy.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestMetaV2Proxy.java
@@ -17,6 +17,7 @@
 
 package com.netflix.priam.backupv2;
 
+import com.google.common.truth.Truth;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.netflix.priam.backup.AbstractBackupPath;
@@ -32,7 +33,6 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.inject.Provider;
@@ -131,13 +131,7 @@ public class TestMetaV2Proxy {
     @Test
     public void testGetIncrementalFiles() throws Exception {
         DateUtil.DateRange dateRange = new DateUtil.DateRange("202812071820,20281229");
-        Iterator<AbstractBackupPath> incrementals = metaProxy.getIncrementals(dateRange);
-        int i = 0;
-        while (incrementals.hasNext()) {
-            System.out.println(incrementals.next());
-            i++;
-        }
-        Assert.assertEquals(3, i);
+        Truth.assertThat(metaProxy.getIncrementals(dateRange)).hasSize(3);
     }
 
     @Test

--- a/priam/src/test/java/com/netflix/priam/utils/TestDateUtils.java
+++ b/priam/src/test/java/com/netflix/priam/utils/TestDateUtils.java
@@ -17,6 +17,7 @@
 
 package com.netflix.priam.utils;
 
+import com.google.common.truth.Truth;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -99,5 +100,35 @@ public class TestDateUtils {
         Assert.assertEquals(Instant.ofEpochSecond(1830340860), dateRange.getStartTime());
         Assert.assertEquals(Instant.ofEpochSecond(1830686460), dateRange.getEndTime());
         Assert.assertEquals("1830", dateRange.match());
+    }
+
+    @Test
+    public void testContainsInstantBeforeStartTime() {
+        DateUtil.DateRange dateRange = new DateUtil.DateRange("202404301200,202405011200");
+        Truth.assertThat(dateRange.contains(Instant.parse("2024-04-29T12:00:00Z"))).isFalse();
+    }
+
+    @Test
+    public void testContainsInstantEqualToStartTime() {
+        DateUtil.DateRange dateRange = new DateUtil.DateRange("202404301200,202405011200");
+        Truth.assertThat(dateRange.contains(Instant.parse("2024-04-30T12:00:00Z"))).isTrue();
+    }
+
+    @Test
+    public void testContainsInstantBetweenStartAndEndTimes() {
+        DateUtil.DateRange dateRange = new DateUtil.DateRange("202404301200,202405011200");
+        Truth.assertThat(dateRange.contains(Instant.parse("2024-05-01T00:00:00Z"))).isTrue();
+    }
+
+    @Test
+    public void testContainsInstantEqualToEndTime() {
+        DateUtil.DateRange dateRange = new DateUtil.DateRange("202404301200,202405011200");
+        Truth.assertThat(dateRange.contains(Instant.parse("2024-05-01T12:00:00Z"))).isTrue();
+    }
+
+    @Test
+    public void testContainsInstantAfterEndTime() {
+        DateUtil.DateRange dateRange = new DateUtil.DateRange("202404301200,202405011200");
+        Truth.assertThat(dateRange.contains(Instant.parse("2024-05-02T12:00:00Z"))).isFalse();
     }
 }


### PR DESCRIPTION
b4294992 2024-05-01 | Include incremental secondary index files in restore.
c1b751fd 2024-05-01 | Change IMetaProxy API to return an ImmutableList of AbstractBackupPaths when fetching incrementals. The iterators are always fully materialized. Also, remove the now-redundant method from BackupRestoreUtil that merely wrapped the MetaProxy call.
5539ebe7 2024-05-01 | Create DateRange::contains to consolidate recurring logic in a consistent way.