### PR TITLE
Allow for in-place restores.

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackup.java
@@ -21,13 +21,7 @@ import com.netflix.priam.scheduler.Task;
 import com.netflix.priam.utils.SystemUtils;
 import java.io.File;
 import java.io.FileFilter;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
 import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,40 +88,6 @@ public abstract class AbstractBackup extends Task {
      * @throws Exception throws exception if there is any error in process the directory.
      */
     protected abstract void processColumnFamily(File backupDir) throws Exception;
-
-    /**
-     * Get all the backup directories for Cassandra.
-     *
-     * @param config to get the location of the data folder.
-     * @param monitoringFolder folder where cassandra backup's are configured.
-     * @return Set of the path(s) containing the backup folder for each columnfamily.
-     * @throws Exception incase of IOException.
-     */
-    public static Set<Path> getBackupDirectories(IConfiguration config, String monitoringFolder)
-            throws Exception {
-        HashSet<Path> backupPaths = new HashSet<>();
-        if (config.getDataFileLocation() == null) return backupPaths;
-        Path dataPath = Paths.get(config.getDataFileLocation());
-        if (Files.exists(dataPath) && Files.isDirectory(dataPath))
-            try (DirectoryStream<Path> directoryStream =
-                    Files.newDirectoryStream(dataPath, path -> Files.isDirectory(path))) {
-                for (Path keyspaceDirPath : directoryStream) {
-                    try (DirectoryStream<Path> keyspaceStream =
-                            Files.newDirectoryStream(
-                                    keyspaceDirPath, path -> Files.isDirectory(path))) {
-                        for (Path columnfamilyDirPath : keyspaceStream) {
-                            Path backupDirPath =
-                                    Paths.get(columnfamilyDirPath.toString(), monitoringFolder);
-                            if (Files.exists(backupDirPath) && Files.isDirectory(backupDirPath)) {
-                                logger.debug("Backup folder: {}", backupDirPath);
-                                backupPaths.add(backupDirPath);
-                            }
-                        }
-                    }
-                }
-            }
-        return backupPaths;
-    }
 
     protected static File[] getSecondaryIndexDirectories(File backupDir) {
         FileFilter filter = (file) -> file.getName().startsWith(".") && isAReadableDirectory(file);

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
@@ -137,24 +137,24 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
 
     /** Local restore file */
     public File newRestoreFile() {
-        File return_;
+        File file;
         String dataDir = config.getRestoreDataLocation();
         switch (type) {
             case SECONDARY_INDEX_V2:
-                return_ =
+                file =
                         new File(
                                 PATH_JOINER.join(
                                         dataDir, keyspace, columnFamily, indexDir, fileName));
                 break;
             case META_V2:
-                return_ = new File(PATH_JOINER.join(config.getDataFileLocation(), fileName));
+                file = new File(PATH_JOINER.join(config.getDataFileLocation(), fileName));
                 break;
             default:
-                return_ = new File(PATH_JOINER.join(dataDir, keyspace, columnFamily, fileName));
+                file = new File(PATH_JOINER.join(dataDir, keyspace, columnFamily, fileName));
         }
-        File parent = new File(return_.getParent());
+        File parent = new File(file.getParent());
         if (!parent.exists()) parent.mkdirs();
-        return return_;
+        return file;
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/backup/AbstractBackupPath.java
@@ -138,12 +138,13 @@ public abstract class AbstractBackupPath implements Comparable<AbstractBackupPat
     /** Local restore file */
     public File newRestoreFile() {
         File return_;
-        String dataDir = config.getDataFileLocation();
+        String dataDir = config.getRestoreDataLocation();
         switch (type) {
             case SECONDARY_INDEX_V2:
-                String restoreFileName =
-                        PATH_JOINER.join(dataDir, keyspace, columnFamily, indexDir, fileName);
-                return_ = new File(restoreFileName);
+                return_ =
+                        new File(
+                                PATH_JOINER.join(
+                                        dataDir, keyspace, columnFamily, indexDir, fileName));
                 break;
             case META_V2:
                 return_ = new File(PATH_JOINER.join(config.getDataFileLocation(), fileName));

--- a/priam/src/main/java/com/netflix/priam/backup/BackupRestoreUtil.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupRestoreUtil.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.priam.backupv2.IMetaProxy;
 import com.netflix.priam.utils.DateUtil;
+import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -141,19 +142,18 @@ public class BackupRestoreUtil {
      * @param dataDirectory the location of the data folder.
      * @param monitoringFolder folder where cassandra backup's are configured.
      * @return Set of the path(s) containing the backup folder for each columnfamily.
-     * @throws Exception incase of IOException.
+     * @throws IOException
      */
     public static ImmutableSet<Path> getBackupDirectories(
-            String dataDirectory, String monitoringFolder) throws Exception {
+            String dataDirectory, String monitoringFolder) throws IOException {
         ImmutableSet.Builder<Path> backupPaths = ImmutableSet.builder();
         Path dataPath = Paths.get(dataDirectory);
         if (Files.exists(dataPath) && Files.isDirectory(dataPath))
             try (DirectoryStream<Path> directoryStream =
-                    Files.newDirectoryStream(dataPath, path -> Files.isDirectory(path))) {
+                    Files.newDirectoryStream(dataPath, Files::isDirectory)) {
                 for (Path keyspaceDirPath : directoryStream) {
                     try (DirectoryStream<Path> keyspaceStream =
-                            Files.newDirectoryStream(
-                                    keyspaceDirPath, path -> Files.isDirectory(path))) {
+                            Files.newDirectoryStream(keyspaceDirPath, Files::isDirectory)) {
                         for (Path columnfamilyDirPath : keyspaceStream) {
                             Path backupDirPath =
                                     Paths.get(columnfamilyDirPath.toString(), monitoringFolder);

--- a/priam/src/main/java/com/netflix/priam/backup/BackupRestoreUtil.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupRestoreUtil.java
@@ -155,8 +155,7 @@ public class BackupRestoreUtil {
                     try (DirectoryStream<Path> keyspaceStream =
                             Files.newDirectoryStream(keyspaceDirPath, Files::isDirectory)) {
                         for (Path columnfamilyDirPath : keyspaceStream) {
-                            Path backupDirPath =
-                                    Paths.get(columnfamilyDirPath.toString(), monitoringFolder);
+                            Path backupDirPath = columnfamilyDirPath.resolve(monitoringFolder);
                             if (Files.isDirectory(backupDirPath)) {
                                 backupPaths.add(backupDirPath);
                             }

--- a/priam/src/main/java/com/netflix/priam/backup/BackupRestoreUtil.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupRestoreUtil.java
@@ -148,7 +148,7 @@ public class BackupRestoreUtil {
             String dataDirectory, String monitoringFolder) throws IOException {
         ImmutableSet.Builder<Path> backupPaths = ImmutableSet.builder();
         Path dataPath = Paths.get(dataDirectory);
-        if (Files.exists(dataPath) && Files.isDirectory(dataPath))
+        if (Files.isDirectory(dataPath))
             try (DirectoryStream<Path> directoryStream =
                     Files.newDirectoryStream(dataPath, Files::isDirectory)) {
                 for (Path keyspaceDirPath : directoryStream) {
@@ -157,7 +157,7 @@ public class BackupRestoreUtil {
                         for (Path columnfamilyDirPath : keyspaceStream) {
                             Path backupDirPath =
                                     Paths.get(columnfamilyDirPath.toString(), monitoringFolder);
-                            if (Files.exists(backupDirPath) && Files.isDirectory(backupDirPath)) {
+                            if (Files.isDirectory(backupDirPath)) {
                                 backupPaths.add(backupDirPath);
                             }
                         }

--- a/priam/src/main/java/com/netflix/priam/backup/IncrementalBackup.java
+++ b/priam/src/main/java/com/netflix/priam/backup/IncrementalBackup.java
@@ -79,7 +79,8 @@ public class IncrementalBackup extends AbstractBackup {
 
     private static void cleanOldBackups(IConfiguration configuration) throws Exception {
         Set<Path> backupPaths =
-                AbstractBackup.getBackupDirectories(configuration, INCREMENTAL_BACKUP_FOLDER);
+                BackupRestoreUtil.getBackupDirectories(
+                        configuration.getDataFileLocation(), INCREMENTAL_BACKUP_FOLDER);
         for (Path backupDirPath : backupPaths) {
             FileUtils.cleanDirectory(backupDirPath.toFile());
         }

--- a/priam/src/main/java/com/netflix/priam/backupv2/BackupTTLTask.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/BackupTTLTask.java
@@ -108,9 +108,7 @@ public class BackupTTLTask extends Task {
 
     @Override
     public void execute() throws Exception {
-        if (instanceState.getRestoreStatus() != null
-                && instanceState.getRestoreStatus().getStatus() != null
-                && instanceState.getRestoreStatus().getStatus() == Status.STARTED) {
+        if (instanceState.isRestoring()) {
             logger.info("Not executing the TTL Task for backups as Priam is in restore mode.");
             return;
         }

--- a/priam/src/main/java/com/netflix/priam/backupv2/BackupVerificationTask.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/BackupVerificationTask.java
@@ -74,9 +74,7 @@ public class BackupVerificationTask extends Task {
             return;
         }
 
-        if (instanceState.getRestoreStatus() != null
-                && instanceState.getRestoreStatus().getStatus() != null
-                && instanceState.getRestoreStatus().getStatus() == Status.STARTED) {
+        if (instanceState.isRestoring()) {
             logger.info("Skipping backup verification. Priam is in restore mode.");
             return;
         }

--- a/priam/src/main/java/com/netflix/priam/backupv2/SnapshotMetaTask.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/SnapshotMetaTask.java
@@ -138,7 +138,9 @@ public class SnapshotMetaTask extends AbstractBackup {
 
     static void cleanOldBackups(IConfiguration config) throws Exception {
         // Clean up all the backup directories, if any.
-        Set<Path> backupPaths = AbstractBackup.getBackupDirectories(config, SNAPSHOT_FOLDER);
+        Set<Path> backupPaths =
+                BackupRestoreUtil.getBackupDirectories(
+                        config.getDataFileLocation(), SNAPSHOT_FOLDER);
         for (Path backupDirPath : backupPaths)
             try (DirectoryStream<Path> directoryStream =
                     Files.newDirectoryStream(backupDirPath, Files::isDirectory)) {

--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -398,6 +398,10 @@ public interface IConfiguration {
         return StringUtils.EMPTY;
     }
 
+    default String getRestoreDataLocation() {
+        return getCassandraBaseDirectory() + "/restore";
+    }
+
     /** @return Get the region to connect to SDB for instance identity */
     default String getSDBInstanceIdentityRegion() {
         return "us-east-1";

--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -125,11 +125,6 @@ public interface IConfiguration {
         return 0;
     }
 
-    /** @return Get list of racs to backup. Backup all racs if empty */
-    default List<String> getBackupRacs() {
-        return Collections.EMPTY_LIST;
-    }
-
     /**
      * Backup location i.e. remote file system to upload backups. e.g. for S3 it will be s3 bucket
      * name

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -279,6 +279,11 @@ public class PriamConfiguration implements IConfiguration {
     }
 
     @Override
+    public String getRestoreDataLocation() {
+        return config.get(PRIAM_PRE + ".restore.data.location");
+    }
+
+    @Override
     public boolean isRestoreEncrypted() {
         return config.get(PRIAM_PRE + ".encrypted.restore.enabled", false);
     }

--- a/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/PriamConfiguration.java
@@ -93,11 +93,6 @@ public class PriamConfiguration implements IConfiguration {
     }
 
     @Override
-    public List<String> getBackupRacs() {
-        return config.getList(PRIAM_PRE + ".backup.racs");
-    }
-
-    @Override
     public String getRestorePrefix() {
         return config.get(PRIAM_PRE + ".restore.prefix");
     }

--- a/priam/src/main/java/com/netflix/priam/connection/CassandraOperations.java
+++ b/priam/src/main/java/com/netflix/priam/connection/CassandraOperations.java
@@ -23,15 +23,15 @@ import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.health.CassandraMonitor;
 import com.netflix.priam.utils.RetryableCallable;
 import java.io.IOException;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import javax.inject.Inject;
 import org.apache.cassandra.db.ColumnFamilyStoreMBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 /** This class encapsulates interactions with Cassandra. Created by aagrawal on 6/19/18. */
 public class CassandraOperations implements ICassandraOperations {
@@ -222,7 +222,22 @@ public class CassandraOperations implements ICassandraOperations {
                 failedImports.addAll(importData(keyspace, table, tableDir.toString()));
             }
         } else {
-            recursiveMove(Paths.get(srcDir), Paths.get(configuration.getDataFileLocation()));
+            Path target = Paths.get(configuration.getDataFileLocation());
+            Path source = Paths.get(srcDir);
+            Files.walkFileTree(source, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                    Path targetDir = target.resolve(source.relativize(dir));
+                    Files.createDirectories(targetDir);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.move(file, target.resolve(source.relativize(file)), REPLACE_EXISTING);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
         }
         return failedImports;
     }

--- a/priam/src/main/java/com/netflix/priam/connection/CassandraOperations.java
+++ b/priam/src/main/java/com/netflix/priam/connection/CassandraOperations.java
@@ -31,7 +31,7 @@ import org.apache.cassandra.db.ColumnFamilyStoreMBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.nio.file.StandardCopyOption.*;
 
 /** This class encapsulates interactions with Cassandra. Created by aagrawal on 6/19/18. */
 public class CassandraOperations implements ICassandraOperations {
@@ -234,7 +234,7 @@ public class CassandraOperations implements ICassandraOperations {
 
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                    Files.move(file, target.resolve(source.relativize(file)), REPLACE_EXISTING);
+                    Files.move(file, target.resolve(source.relativize(file)), ATOMIC_MOVE, COPY_ATTRIBUTES);
                     return FileVisitResult.CONTINUE;
                 }
             });
@@ -256,26 +256,6 @@ public class CassandraOperations implements ICassandraOperations {
                     true /* invalidateCaches */,
                     false /* extendedVerify */,
                     false /* copyData */);
-        }
-    }
-
-    private void recursiveMove(Path source, Path destination) throws IOException {
-        Preconditions.checkState(Files.exists(source));
-        if (!Files.exists(destination)) {
-            if (!destination.toFile().mkdirs()) {
-                throw new IOException("Failed creating " + destination);
-            }
-        }
-        try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(source)) {
-            for (Path path : directoryStream) {
-                if (Files.isRegularFile(path)) {
-                    Files.move(path, destination.resolve(path.getFileName()));
-                } else if (Files.isDirectory(path)) {
-                    recursiveMove(path, destination.resolve(path.getFileName()));
-                } else {
-                    throw new IOException("Failed determining type of inode is " + path);
-                }
-            }
         }
     }
 }

--- a/priam/src/main/java/com/netflix/priam/connection/ICassandraOperations.java
+++ b/priam/src/main/java/com/netflix/priam/connection/ICassandraOperations.java
@@ -61,4 +61,10 @@ public interface ICassandraOperations {
     void forceKeyspaceFlush(String keyspaceName) throws Exception;
 
     List<Map<String, String>> gossipInfo() throws Exception;
+
+    /**
+     * import sstables from the directory at srcDir into the configured data directory. importAll
+     * Will just move them if Cassandra hasn't started.
+     */
+    List<String> importAll(String srcDir) throws Exception;
 }

--- a/priam/src/main/java/com/netflix/priam/health/CassandraMonitor.java
+++ b/priam/src/main/java/com/netflix/priam/health/CassandraMonitor.java
@@ -169,8 +169,8 @@ public class CassandraMonitor extends Task {
     }
 
     // Added for testing only
-    public static void setIsCassadraStarted() {
+    public static void setIsCassandraStarted(boolean newStartedState) {
         // Setting cassandra flag to true
-        isCassandraStarted.set(true);
+        isCassandraStarted.set(newStartedState);
     }
 }

--- a/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
@@ -29,7 +29,6 @@ import com.netflix.priam.scheduler.Task;
 import com.netflix.priam.utils.DateUtil;
 import com.netflix.priam.utils.RetryableCallable;
 import com.netflix.priam.utils.Sleeper;
-import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.file.Path;
@@ -39,7 +38,6 @@ import java.util.concurrent.Future;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -147,8 +145,6 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
                 instanceIdentity.getInstance().setToken(restoreToken.toString());
             }
             stopCassProcess();
-            File dataDir = new File(config.getDataFileLocation());
-            if (dataDir.exists() && dataDir.isDirectory()) FileUtils.cleanDirectory(dataDir);
             Optional<AbstractBackupPath> latestValidMetaFile =
                     BackupRestoreUtil.getLatestValidMetaPath(metaProxy, dateRange);
             if (!latestValidMetaFile.isPresent()) {

--- a/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
@@ -130,7 +130,6 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
         new RetryableCallable<Void>() {
             public Void retriableCall() throws Exception {
                 restore(dateRange);
-
                 // Wait for other server init to complete
                 sleeper.sleep(30000);
                 return null;
@@ -143,10 +142,8 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
         if (!postRestoreHook.hasValidParameters()) {
             throw new PostRestoreHookException("Invalid PostRestoreHook parameters");
         }
-
         Date endTime = new Date(dateRange.getEndTime().toEpochMilli());
         IMetaProxy metaProxy = metaV2Proxy;
-
         instanceState.getRestoreStatus().resetStatus();
         instanceState
                 .getRestoreStatus()
@@ -156,7 +153,6 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
         instanceState.getRestoreStatus().setExecutionStartTime(LocalDateTime.now());
         instanceState.setRestoreStatus(Status.STARTED);
         String origToken = instanceIdentity.getInstance().getToken();
-
         try {
             if (config.isRestoreClosestToken()) {
                 BigInteger restoreToken =
@@ -165,26 +161,20 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
                                 new Date(dateRange.getStartTime().toEpochMilli()));
                 instanceIdentity.getInstance().setToken(restoreToken.toString());
             }
-
             stopCassProcess();
-
             File dataDir = new File(config.getDataFileLocation());
             if (dataDir.exists() && dataDir.isDirectory()) FileUtils.cleanDirectory(dataDir);
-
             Optional<AbstractBackupPath> latestValidMetaFile =
                     BackupRestoreUtil.getLatestValidMetaPath(metaProxy, dateRange);
-
             if (!latestValidMetaFile.isPresent()) {
                 instanceState.getRestoreStatus().setExecutionEndTime(LocalDateTime.now());
                 instanceState.setRestoreStatus(Status.FAILED);
                 return;
             }
-
             logger.info("Meta file for restore {}", latestValidMetaFile.get().getRemotePath());
             instanceState
                     .getRestoreStatus()
                     .setSnapshotMetaFile(latestValidMetaFile.get().getRemotePath());
-
             List<AbstractBackupPath> allFiles =
                     BackupRestoreUtil.getMostRecentSnapshotPaths(
                             latestValidMetaFile.get(), metaProxy, pathProvider);
@@ -195,16 +185,11 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
                                 dateRange.getEndTime());
                 allFiles.addAll(metaProxy.getIncrementals(incrementalDateRange));
             }
-
             List<Future<Path>> futureList = new ArrayList<>(download(allFiles.iterator()));
-
             waitForCompletion(futureList);
-
             postRestoreHook.execute();
-
             instanceState.getRestoreStatus().setExecutionEndTime(LocalDateTime.now());
             instanceState.setRestoreStatus(Status.FINISHED);
-
             if (!config.doesCassandraStartManually()) cassProcess.start(true);
         } catch (Exception e) {
             instanceState.setRestoreStatus(Status.FAILED);

--- a/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
@@ -49,13 +49,12 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A means to perform a restore. This class contains the following characteristics: - It is agnostic
- * to the source type of the restore, this is determine by the injected IBackupFileSystem. - This
+ * to the source type of the restore, this is determined by the injected IBackupFileSystem. - This
  * class can be scheduled, i.e. it is a "Task". - When this class is executed, it uses its own
  * thread pool to execute the restores.
  */
 public abstract class AbstractRestore extends Task implements IRestoreStrategy {
     private static final Logger logger = LoggerFactory.getLogger(AbstractRestore.class);
-    private static BigInteger restoreToken;
     final IBackupFileSystem fs;
     final Sleeper sleeper;
     private final BackupRestoreUtil backupRestoreUtil;
@@ -94,7 +93,7 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
         this.postRestoreHook = postRestoreHook;
     }
 
-    public static final boolean isRestoreEnabled(IConfiguration conf, InstanceInfo instanceInfo) {
+    public static boolean isRestoreEnabled(IConfiguration conf, InstanceInfo instanceInfo) {
         boolean isRestoreMode = StringUtils.isNotBlank(conf.getRestoreSnapshot());
         boolean isBackedupRac =
                 (CollectionUtils.isEmpty(conf.getBackupRacs())
@@ -102,8 +101,7 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
         return (isRestoreMode && isBackedupRac);
     }
 
-    private List<Future<Path>> download(
-            Iterator<AbstractBackupPath> fsIterator, boolean waitForCompletion) throws Exception {
+    private List<Future<Path>> download(Iterator<AbstractBackupPath> fsIterator) throws Exception {
         List<Future<Path>> futureList = new ArrayList<>();
         while (fsIterator.hasNext()) {
             AbstractBackupPath temp = fsIterator.next();
@@ -126,10 +124,6 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
                                 + localFileHandler.getName());
             futureList.add(downloadFile(temp));
         }
-
-        // Wait for all download to finish that were started from this method.
-        if (waitForCompletion) waitForCompletion(futureList);
-
         return futureList;
     }
 
@@ -182,7 +176,7 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
 
         try {
             if (config.isRestoreClosestToken()) {
-                restoreToken =
+                BigInteger restoreToken =
                         tokenSelector.getClosestToken(
                                 new BigInteger(origToken),
                                 new Date(dateRange.getStartTime().toEpochMilli()));
@@ -225,8 +219,7 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
             }
 
             // Download snapshot which is listed in the meta file.
-            List<Future<Path>> futureList = new ArrayList<>();
-            futureList.addAll(download(allFiles.iterator(), false));
+            List<Future<Path>> futureList = new ArrayList<>(download(allFiles.iterator()));
 
             // Wait for all the futures to finish.
             waitForCompletion(futureList);

--- a/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
@@ -55,8 +55,6 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractRestore extends Task implements IRestoreStrategy {
     private static final Logger logger = LoggerFactory.getLogger(AbstractRestore.class);
-    private static final String JOBNAME = "AbstractRestore";
-    private static final String SYSTEM_KEYSPACE = "system";
     private static BigInteger restoreToken;
     final IBackupFileSystem fs;
     final Sleeper sleeper;
@@ -75,7 +73,6 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
     public AbstractRestore(
             IConfiguration config,
             IBackupFileSystem fs,
-            String name,
             Sleeper sleeper,
             Provider<AbstractBackupPath> pathProvider,
             InstanceIdentity instanceIdentity,
@@ -267,26 +264,4 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
      * @throws Exception If there is any error in downloading file from the remote file system.
      */
     protected abstract Future<Path> downloadFile(final AbstractBackupPath path) throws Exception;
-
-    final class BoundedList<E> extends LinkedList<E> {
-
-        private final int limit;
-
-        BoundedList(int limit) {
-            this.limit = limit;
-        }
-
-        @Override
-        public boolean add(E o) {
-            super.add(o);
-            while (size() > limit) {
-                super.remove();
-            }
-            return true;
-        }
-    }
-
-    public final int getDownloadTasksQueued() {
-        return fs.getDownloadTasksQueued();
-    }
 }

--- a/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
@@ -105,8 +105,7 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
         List<Future<Path>> futureList = new ArrayList<>();
         while (fsIterator.hasNext()) {
             AbstractBackupPath temp = fsIterator.next();
-            if (backupRestoreUtil.isFiltered(
-                    temp.getKeyspace(), temp.getColumnFamily())) { // is filtered?
+            if (backupRestoreUtil.isFiltered(temp.getKeyspace(), temp.getColumnFamily())) {
                 logger.info(
                         "Bypassing restoring file \"{}\" as it is part of the keyspace.columnfamily filter list.  Its keyspace:cf is: {}:{}",
                         temp.newRestoreFile(),
@@ -155,7 +154,6 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
     }
 
     public void restore(DateUtil.DateRange dateRange) throws Exception {
-        // fail early if post restore hook has invalid parameters
         if (!postRestoreHook.hasValidParameters()) {
             throw new PostRestoreHookException("Invalid PostRestoreHook parameters");
         }
@@ -163,7 +161,6 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
         Date endTime = new Date(dateRange.getEndTime().toEpochMilli());
         IMetaProxy metaProxy = metaV2Proxy;
 
-        // Set the restore status.
         instanceState.getRestoreStatus().resetStatus();
         instanceState
                 .getRestoreStatus()
@@ -183,14 +180,11 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
                 instanceIdentity.getInstance().setToken(restoreToken.toString());
             }
 
-            // Stop cassandra if its running
             stopCassProcess();
 
-            // Cleanup local data
             File dataDir = new File(config.getDataFileLocation());
             if (dataDir.exists() && dataDir.isDirectory()) FileUtils.cleanDirectory(dataDir);
 
-            // Find latest valid meta file.
             Optional<AbstractBackupPath> latestValidMetaFile =
                     BackupRestoreUtil.getLatestValidMetaPath(metaProxy, dateRange);
 
@@ -218,22 +212,17 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
                 allFiles.addAll(metaProxy.getIncrementals(incrementalDateRange));
             }
 
-            // Download snapshot which is listed in the meta file.
             List<Future<Path>> futureList = new ArrayList<>(download(allFiles.iterator()));
 
-            // Wait for all the futures to finish.
             waitForCompletion(futureList);
 
-            // Given that files are restored now, kick off post restore hook
             logger.info("Starting post restore hook");
             postRestoreHook.execute();
             logger.info("Completed executing post restore hook");
 
-            // Declare restore as finished.
             instanceState.getRestoreStatus().setExecutionEndTime(LocalDateTime.now());
             instanceState.setRestoreStatus(Status.FINISHED);
 
-            // Start cassandra if restore is successful.
             if (!config.doesCassandraStartManually()) cassProcess.start(true);
             else
                 logger.info(

--- a/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
@@ -25,7 +25,6 @@ import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.defaultimpl.ICassandraProcess;
 import com.netflix.priam.health.InstanceState;
 import com.netflix.priam.identity.InstanceIdentity;
-import com.netflix.priam.identity.config.InstanceInfo;
 import com.netflix.priam.scheduler.Task;
 import com.netflix.priam.utils.DateUtil;
 import com.netflix.priam.utils.RetryableCallable;
@@ -41,7 +40,6 @@ import java.util.concurrent.Future;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -93,12 +91,8 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
         this.postRestoreHook = postRestoreHook;
     }
 
-    public static boolean isRestoreEnabled(IConfiguration conf, InstanceInfo instanceInfo) {
-        boolean isRestoreMode = StringUtils.isNotBlank(conf.getRestoreSnapshot());
-        boolean isBackedupRac =
-                (CollectionUtils.isEmpty(conf.getBackupRacs())
-                        || conf.getBackupRacs().contains(instanceInfo.getRac()));
-        return (isRestoreMode && isBackedupRac);
+    public static boolean isRestoreEnabled(IConfiguration conf) {
+        return StringUtils.isNotBlank(conf.getRestoreSnapshot());
     }
 
     private List<Future<Path>> download(Iterator<AbstractBackupPath> fsIterator) throws Exception {
@@ -123,7 +117,7 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
 
     @Override
     public void execute() throws Exception {
-        if (!isRestoreEnabled(config, instanceIdentity.getInstanceInfo())) return;
+        if (!isRestoreEnabled(config)) return;
 
         logger.info("Starting restore for {}", config.getRestoreSnapshot());
         final DateUtil.DateRange dateRange = new DateUtil.DateRange(config.getRestoreSnapshot());

--- a/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.*;
 import java.util.concurrent.Future;
 import javax.inject.Inject;
@@ -136,16 +135,8 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
         if (!postRestoreHook.hasValidParameters()) {
             throw new PostRestoreHookException("Invalid PostRestoreHook parameters");
         }
-        Date endTime = new Date(dateRange.getEndTime().toEpochMilli());
         IMetaProxy metaProxy = metaV2Proxy;
-        instanceState.getRestoreStatus().resetStatus();
-        instanceState
-                .getRestoreStatus()
-                .setStartDateRange(
-                        LocalDateTime.ofInstant(dateRange.getStartTime(), ZoneId.of("UTC")));
-        instanceState.getRestoreStatus().setEndDateRange(DateUtil.convert(endTime));
-        instanceState.getRestoreStatus().setExecutionStartTime(LocalDateTime.now());
-        instanceState.setRestoreStatus(Status.STARTED);
+        instanceState.startRestore(dateRange);
         String origToken = instanceIdentity.getInstance().getToken();
         try {
             if (config.isRestoreClosestToken()) {
@@ -161,14 +152,11 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
             Optional<AbstractBackupPath> latestValidMetaFile =
                     BackupRestoreUtil.getLatestValidMetaPath(metaProxy, dateRange);
             if (!latestValidMetaFile.isPresent()) {
-                instanceState.getRestoreStatus().setExecutionEndTime(LocalDateTime.now());
-                instanceState.setRestoreStatus(Status.FAILED);
+                instanceState.endRestore(Status.FAILED, LocalDateTime.now());
                 return;
             }
             logger.info("Meta file for restore {}", latestValidMetaFile.get().getRemotePath());
-            instanceState
-                    .getRestoreStatus()
-                    .setSnapshotMetaFile(latestValidMetaFile.get().getRemotePath());
+            instanceState.setRestoreMetaFile(latestValidMetaFile.get().getRemotePath());
             List<AbstractBackupPath> allFiles =
                     BackupRestoreUtil.getMostRecentSnapshotPaths(
                             latestValidMetaFile.get(), metaProxy, pathProvider);
@@ -182,12 +170,10 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
             List<Future<Path>> futureList = new ArrayList<>(download(allFiles.iterator()));
             waitForCompletion(futureList);
             postRestoreHook.execute();
-            instanceState.getRestoreStatus().setExecutionEndTime(LocalDateTime.now());
-            instanceState.setRestoreStatus(Status.FINISHED);
+            instanceState.endRestore(Status.FINISHED, LocalDateTime.now());
             if (!config.doesCassandraStartManually()) cassProcess.start(true);
         } catch (Exception e) {
-            instanceState.setRestoreStatus(Status.FAILED);
-            instanceState.getRestoreStatus().setExecutionEndTime(LocalDateTime.now());
+            instanceState.endRestore(Status.FAILED, LocalDateTime.now());
             throw e;
         } finally {
             instanceIdentity.getInstance().setToken(origToken);

--- a/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
@@ -106,21 +106,8 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
         while (fsIterator.hasNext()) {
             AbstractBackupPath temp = fsIterator.next();
             if (backupRestoreUtil.isFiltered(temp.getKeyspace(), temp.getColumnFamily())) {
-                logger.info(
-                        "Bypassing restoring file \"{}\" as it is part of the keyspace.columnfamily filter list.  Its keyspace:cf is: {}:{}",
-                        temp.newRestoreFile(),
-                        temp.getKeyspace(),
-                        temp.getColumnFamily());
                 continue;
             }
-
-            File localFileHandler = temp.newRestoreFile();
-            if (logger.isDebugEnabled())
-                logger.debug(
-                        "Created local file name: "
-                                + localFileHandler.getAbsolutePath()
-                                + File.pathSeparator
-                                + localFileHandler.getName());
             futureList.add(downloadFile(temp));
         }
         return futureList;
@@ -142,15 +129,14 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
         final DateUtil.DateRange dateRange = new DateUtil.DateRange(config.getRestoreSnapshot());
         new RetryableCallable<Void>() {
             public Void retriableCall() throws Exception {
-                logger.info("Attempting restore");
                 restore(dateRange);
-                logger.info("Restore completed");
 
                 // Wait for other server init to complete
                 sleeper.sleep(30000);
                 return null;
             }
         }.call();
+        logger.info("Restore complete.");
     }
 
     public void restore(DateUtil.DateRange dateRange) throws Exception {
@@ -189,14 +175,12 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
                     BackupRestoreUtil.getLatestValidMetaPath(metaProxy, dateRange);
 
             if (!latestValidMetaFile.isPresent()) {
-                logger.info("No valid snapshot meta file found, Restore Failed.");
                 instanceState.getRestoreStatus().setExecutionEndTime(LocalDateTime.now());
                 instanceState.setRestoreStatus(Status.FAILED);
                 return;
             }
 
-            logger.info(
-                    "Snapshot Meta file for restore {}", latestValidMetaFile.get().getRemotePath());
+            logger.info("Meta file for restore {}", latestValidMetaFile.get().getRemotePath());
             instanceState
                     .getRestoreStatus()
                     .setSnapshotMetaFile(latestValidMetaFile.get().getRemotePath());
@@ -216,21 +200,15 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
 
             waitForCompletion(futureList);
 
-            logger.info("Starting post restore hook");
             postRestoreHook.execute();
-            logger.info("Completed executing post restore hook");
 
             instanceState.getRestoreStatus().setExecutionEndTime(LocalDateTime.now());
             instanceState.setRestoreStatus(Status.FINISHED);
 
             if (!config.doesCassandraStartManually()) cassProcess.start(true);
-            else
-                logger.info(
-                        "config.doesCassandraStartManually() is set to True, hence Cassandra needs to be started manually ...");
         } catch (Exception e) {
             instanceState.setRestoreStatus(Status.FAILED);
             instanceState.getRestoreStatus().setExecutionEndTime(LocalDateTime.now());
-            logger.error("Error while trying to restore: {}", e.getMessage(), e);
             throw e;
         } finally {
             instanceIdentity.getInstance().setToken(origToken);

--- a/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/AbstractRestore.java
@@ -166,6 +166,7 @@ public abstract class AbstractRestore extends Task implements IRestoreStrategy {
             waitForCompletion(futureList);
             List<String> failedImports = cassOps.importAll(config.getRestoreDataLocation());
             if (!failedImports.isEmpty()) {
+                failedImports.forEach(failure -> logger.warn("Failed to import {}", failure));
                 instanceState.endRestore(Status.FAILED, LocalDateTime.now());
             } else {
                 postRestoreHook.execute();

--- a/priam/src/main/java/com/netflix/priam/restore/Restore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/Restore.java
@@ -19,6 +19,7 @@ package com.netflix.priam.restore;
 import com.netflix.priam.backup.AbstractBackupPath;
 import com.netflix.priam.backup.IBackupFileSystem;
 import com.netflix.priam.config.IConfiguration;
+import com.netflix.priam.connection.ICassandraOperations;
 import com.netflix.priam.defaultimpl.ICassandraProcess;
 import com.netflix.priam.health.InstanceState;
 import com.netflix.priam.identity.InstanceIdentity;
@@ -46,7 +47,8 @@ public class Restore extends AbstractRestore {
             InstanceIdentity instanceIdentity,
             RestoreTokenSelector tokenSelector,
             InstanceState instanceState,
-            IPostRestoreHook postRestoreHook) {
+            IPostRestoreHook postRestoreHook,
+            ICassandraOperations cassandraOperations) {
         super(
                 config,
                 fs,
@@ -56,7 +58,8 @@ public class Restore extends AbstractRestore {
                 tokenSelector,
                 cassProcess,
                 instanceState,
-                postRestoreHook);
+                postRestoreHook,
+                cassandraOperations);
     }
 
     @Override

--- a/priam/src/main/java/com/netflix/priam/restore/Restore.java
+++ b/priam/src/main/java/com/netflix/priam/restore/Restore.java
@@ -30,14 +30,11 @@ import java.util.concurrent.Future;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Main class for restoring data from backup. Backup restored using this way are not encrypted. */
 @Singleton
 public class Restore extends AbstractRestore {
     public static final String JOBNAME = "AUTO_RESTORE_JOB";
-    private static final Logger logger = LoggerFactory.getLogger(Restore.class);
 
     @Inject
     public Restore(
@@ -53,7 +50,6 @@ public class Restore extends AbstractRestore {
         super(
                 config,
                 fs,
-                JOBNAME,
                 sleeper,
                 pathProvider,
                 instanceIdentity,

--- a/priam/src/main/java/com/netflix/priam/tuner/StandardTuner.java
+++ b/priam/src/main/java/com/netflix/priam/tuner/StandardTuner.java
@@ -67,7 +67,7 @@ public class StandardTuner implements ICassandraTuner {
         map.put("listen_address", hostname);
         map.put("rpc_address", hostname);
         // Dont bootstrap in restore mode
-        if (!Restore.isRestoreEnabled(config, instanceInfo)) {
+        if (!Restore.isRestoreEnabled(config)) {
             map.put("auto_bootstrap", config.getAutoBoostrap());
         } else {
             map.put("auto_bootstrap", false);

--- a/priam/src/test/groovy/com/netflix/priam/cluser/management/TestCompaction.groovy
+++ b/priam/src/test/groovy/com/netflix/priam/cluser/management/TestCompaction.groovy
@@ -150,7 +150,7 @@ class TestCompaction extends Specification {
 
 
     private static int concurrentRuns(int size) {
-        CassandraMonitor.setIsCassadraStarted()
+        CassandraMonitor.setIsCassandraStarted(true)
         ExecutorService threads = Executors.newFixedThreadPool(size)
         List<Callable<Boolean>> torun = new ArrayList<>(size)
         for (int i = 0; i < size; i++) {

--- a/priam/src/test/java/com/netflix/priam/backup/BRTestModule.java
+++ b/priam/src/test/java/com/netflix/priam/backup/BRTestModule.java
@@ -28,6 +28,8 @@ import com.netflix.priam.config.FakeBackupRestoreConfig;
 import com.netflix.priam.config.FakeConfiguration;
 import com.netflix.priam.config.IBackupRestoreConfig;
 import com.netflix.priam.config.IConfiguration;
+import com.netflix.priam.connection.CassandraOperations;
+import com.netflix.priam.connection.ICassandraOperations;
 import com.netflix.priam.cred.ICredential;
 import com.netflix.priam.defaultimpl.FakeCassandraProcess;
 import com.netflix.priam.defaultimpl.ICassandraProcess;
@@ -78,5 +80,6 @@ public class BRTestModule extends AbstractModule {
         bind(IMetaProxy.class).annotatedWith(Names.named("v2")).to(MetaV2Proxy.class);
         bind(DynamicRateLimiter.class).to(FakeDynamicRateLimiter.class);
         bind(Clock.class).toInstance(Clock.fixed(Instant.EPOCH, ZoneId.systemDefault()));
+        bind(ICassandraOperations.class).to(CassandraOperations.class).in(Scopes.SINGLETON);
     }
 }

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestBackupTTLTask.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestBackupTTLTask.java
@@ -198,10 +198,11 @@ public class TestBackupTTLTask {
     }
 
     @Test
-    public void testRestoreMode(@Mocked InstanceState state) throws Exception {
+    public void testRestoreMode(@Mocked InstanceState.RestoreStatus restoreStatus)
+            throws Exception {
         new Expectations() {
             {
-                state.getRestoreStatus().getStatus();
+                restoreStatus.getStatus();
                 result = Status.STARTED;
             }
         };

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestBackupV2Service.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestBackupV2Service.java
@@ -201,6 +201,8 @@ public class TestBackupV2Service {
                 result = "-1";
                 configuration.isIncrementalBackupEnabled();
                 result = true;
+                configuration.getDataFileLocation();
+                result = "target/data";
                 backupRestoreConfig.enableV2Backups();
                 result = true;
                 backupRestoreConfig.getBackupVerificationCronExpression();

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestBackupV2Service.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestBackupV2Service.java
@@ -22,6 +22,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.netflix.priam.backup.AbstractBackup;
 import com.netflix.priam.backup.BRTestModule;
+import com.netflix.priam.backup.BackupRestoreUtil;
 import com.netflix.priam.config.IBackupRestoreConfig;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.connection.JMXNodeTool;
@@ -116,7 +117,8 @@ public class TestBackupV2Service {
 
         // snapshot V2 name should not be there.
         Set<Path> backupPaths =
-                AbstractBackup.getBackupDirectories(configuration, AbstractBackup.SNAPSHOT_FOLDER);
+                BackupRestoreUtil.getBackupDirectories(
+                        configuration.getDataFileLocation(), AbstractBackup.SNAPSHOT_FOLDER);
         for (Path backupPath : backupPaths) {
             Assert.assertFalse(Files.exists(Paths.get(backupPath.toString(), snapshotName)));
             Assert.assertTrue(Files.exists(Paths.get(backupPath.toString(), snapshotV1Name)));

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestBackupVerificationTask.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestBackupVerificationTask.java
@@ -151,10 +151,11 @@ public class TestBackupVerificationTask {
     }
 
     @Test
-    public void testRestoreMode(@Mocked InstanceState state) throws Exception {
+    public void testRestoreMode(@Mocked InstanceState.RestoreStatus restoreStatus)
+            throws Exception {
         new Expectations() {
             {
-                state.getRestoreStatus().getStatus();
+                restoreStatus.getStatus();
                 result = Status.STARTED;
             }
         };

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestMetaV2Proxy.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestMetaV2Proxy.java
@@ -17,10 +17,7 @@
 
 package com.netflix.priam.backupv2;
 
-<<<<<<< HEAD
 import com.google.common.collect.ImmutableList;
-=======
->>>>>>> d51863c2 (Change IMetaProxy API to return an ImmutableList of AbstractBackupPaths when fetching incrementals. The iterators are always fully materialized. Also, remove the now-redundant method from BackupRestoreUtil that merely wrapped the MetaProxy call.)
 import com.google.common.truth.Truth;
 import com.google.inject.Guice;
 import com.google.inject.Injector;

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestMetaV2Proxy.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestMetaV2Proxy.java
@@ -17,7 +17,10 @@
 
 package com.netflix.priam.backupv2;
 
+<<<<<<< HEAD
 import com.google.common.collect.ImmutableList;
+=======
+>>>>>>> d51863c2 (Change IMetaProxy API to return an ImmutableList of AbstractBackupPaths when fetching incrementals. The iterators are always fully materialized. Also, remove the now-redundant method from BackupRestoreUtil that merely wrapped the MetaProxy call.)
 import com.google.common.truth.Truth;
 import com.google.inject.Guice;
 import com.google.inject.Injector;

--- a/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
+++ b/priam/src/test/java/com/netflix/priam/config/FakeConfiguration.java
@@ -43,6 +43,7 @@ public class FakeConfiguration implements IConfiguration {
     private String partitioner;
     private String diskFailurePolicy;
     private int blockForPeersTimeoutInSecs;
+    private String dataFileLocation;
 
     public Map<String, String> fakeProperties = new HashMap<>();
 
@@ -339,5 +340,17 @@ public class FakeConfiguration implements IConfiguration {
     @Override
     public int getBlockForPeersTimeoutInSecs() {
         return this.blockForPeersTimeoutInSecs;
+    }
+
+    public FakeConfiguration setDataFileLocation(String dataFileLocation) {
+        this.dataFileLocation = dataFileLocation;
+        return this;
+    }
+
+    @Override
+    public String getDataFileLocation() {
+        return dataFileLocation == null
+                ? IConfiguration.super.getDataFileLocation()
+                : dataFileLocation;
     }
 }

--- a/priam/src/test/java/com/netflix/priam/connection/TestCassandraOperations.java
+++ b/priam/src/test/java/com/netflix/priam/connection/TestCassandraOperations.java
@@ -17,12 +17,20 @@
 
 package com.netflix.priam.connection;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Files;
+import com.google.common.truth.Truth;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.mchange.io.FileUtils;
 import com.netflix.priam.backup.BRTestModule;
+import com.netflix.priam.config.FakeConfiguration;
 import com.netflix.priam.config.IConfiguration;
+import com.netflix.priam.health.CassandraMonitor;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import mockit.Expectations;
@@ -30,17 +38,34 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
 import org.apache.cassandra.tools.NodeProbe;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.TestName;
 
 /** Created by aagrawal on 3/1/19. */
 public class TestCassandraOperations {
     private final String gossipInfo1 = "src/test/resources/gossipInfoSample_1.txt";
     @Mocked private NodeProbe nodeProbe;
     @Mocked private JMXNodeTool jmxNodeTool;
+    private FakeConfiguration config;
     private static CassandraOperations cassandraOperations;
+    private static final String BASE_DIR = "base";
+    private static final String RESTORE_DIR = "restore";
+    private static final String DATA_DIR = "data";
+    private static final String KS = "ks";
+    private static final String TB = "tb";
+    private static final String SI = "si";
+    private static final String DATAFILE = "datafile";
+    private static final String SI_DATAFILE = "si_datafile";
 
-    public TestCassandraOperations() {
+    @Rule public TestName name = new TestName();
+
+    @BeforeClass
+    public static void prepBeforeAllTests() {
+        deleteBaseDirectoryForAllTests();
+    }
+
+    @Before
+    public void prepareTest() throws IOException {
         new MockUp<JMXNodeTool>() {
             @Mock
             NodeProbe instance(IConfiguration config) {
@@ -48,13 +73,29 @@ public class TestCassandraOperations {
             }
         };
         Injector injector = Guice.createInjector(new BRTestModule());
-        if (cassandraOperations == null)
-            cassandraOperations = injector.getInstance(CassandraOperations.class);
+        cassandraOperations = injector.getInstance(CassandraOperations.class);
+        Paths.get(getRestoreDir(), KS, TB, SI).toFile().mkdirs();
+        Files.touch(Paths.get(getRestoreDir(), KS, TB, DATAFILE).toFile());
+        Files.touch(Paths.get(getRestoreDir(), KS, TB, SI, SI_DATAFILE).toFile());
+        config = (FakeConfiguration) injector.getInstance(IConfiguration.class);
+        config.setDataFileLocation(getDataDir());
+        CassandraMonitor.setIsCassandraStarted(false);
+    }
+
+    @After
+    public void cleanup() {
+        org.apache.commons.io.FileUtils.deleteQuietly(Paths.get(getRestoreDir()).toFile());
+        org.apache.commons.io.FileUtils.deleteQuietly(Paths.get(getDataDir()).toFile());
+        config.setDataFileLocation(null);
+    }
+
+    @AfterClass
+    public static void cleanupAfterAllTests() {
+        deleteBaseDirectoryForAllTests();
     }
 
     @Test
     public void testGossipInfo() throws Exception {
-
         String gossipInfoFromNodetool = FileUtils.getContentsAsString(new File(gossipInfo1));
         new Expectations() {
             {
@@ -79,5 +120,88 @@ public class TestCassandraOperations {
                             if (gossipInfo.get("PUBLIC_IP").equalsIgnoreCase("127.0.0.1"))
                                 Assert.assertEquals("[123,234]", gossipInfo.get("TOKENS"));
                         });
+    }
+
+    @Test
+    public void testRestoreViaMove_dataDirectoryIsCreated() throws IOException {
+        cassandraOperations.importAll(getRestoreDir());
+        Truth.assertThat(Paths.get(getDataDir()).toFile().exists());
+    }
+
+    @Test
+    public void testRestoreViaMove_keyspaceDirectoryIsCreated() throws IOException {
+        cassandraOperations.importAll(getRestoreDir());
+        Truth.assertThat(Paths.get(getDataDir(), KS).toFile().exists());
+    }
+
+    @Test
+    public void testRestoreViaMove_tableDirectoryIsCreated() throws IOException {
+        cassandraOperations.importAll(getRestoreDir());
+        Truth.assertThat(Paths.get(getDataDir(), KS, TB).toFile().exists());
+    }
+
+    @Test
+    public void testRestoreViaMove_secondaryIndexDirectoryIsCreated() throws IOException {
+        cassandraOperations.importAll(getRestoreDir());
+        Truth.assertThat(Paths.get(getDataDir(), KS, TB, SI).toFile().exists());
+    }
+
+    @Test
+    public void testRestoreViaMove_dataFileIsMoved() throws IOException {
+        cassandraOperations.importAll(getRestoreDir());
+        Truth.assertThat(Paths.get(getDataDir(), KS, TB, DATAFILE).toFile().exists());
+    }
+
+    @Test
+    public void testRestoreViaMove_dataFileIsRemovedFromOrigin() throws IOException {
+        cassandraOperations.importAll(getRestoreDir());
+        Truth.assertThat(Paths.get(getRestoreDir(), KS, TB, DATAFILE).toFile().exists()).isFalse();
+    }
+
+    @Test
+    public void testRestoreViaMove_secondaryIndexFileIsMoved() throws IOException {
+        cassandraOperations.importAll(getRestoreDir());
+        Truth.assertThat(Paths.get(getDataDir(), KS, TB, SI, SI_DATAFILE).toFile().exists());
+    }
+
+    @Test
+    public void testRestoreViaMove_secondaryIndexFileIsRemovedFromOrigin() throws IOException {
+        cassandraOperations.importAll(getRestoreDir());
+        Truth.assertThat(Paths.get(getRestoreDir(), KS, TB, SI, SI_DATAFILE).toFile().exists())
+                .isFalse();
+    }
+
+    @Test
+    public void testRestoreViaImport() throws IOException {
+        CassandraMonitor.setIsCassandraStarted(true);
+        new Expectations() {
+            {
+                nodeProbe.importNewSSTables(
+                        KS,
+                        TB,
+                        ImmutableSet.of(Paths.get(getRestoreDir(), KS, TB).toString()),
+                        false /* resetLevel */,
+                        false /* clearRepaired */,
+                        true /* verifySSTables */,
+                        true /* verifyTokens */,
+                        true /* invalidateCaches */,
+                        false /* extendedVerify */,
+                        false /* copyData */);
+                result = new ArrayList<>();
+            }
+        };
+        cassandraOperations.importAll(getRestoreDir());
+    }
+
+    private static void deleteBaseDirectoryForAllTests() {
+        org.apache.commons.io.FileUtils.deleteQuietly(Paths.get(BASE_DIR).toFile());
+    }
+
+    private String getRestoreDir() {
+        return BASE_DIR + "/" + name.getMethodName() + RESTORE_DIR;
+    }
+
+    private String getDataDir() {
+        return BASE_DIR + "/" + name.getMethodName() + DATA_DIR;
     }
 }

--- a/priam/src/test/java/com/netflix/priam/health/TestCassandraMonitor.java
+++ b/priam/src/test/java/com/netflix/priam/health/TestCassandraMonitor.java
@@ -63,7 +63,7 @@ public class TestCassandraMonitor {
 
         Assert.assertFalse(CassandraMonitor.hasCassadraStarted());
 
-        CassandraMonitor.setIsCassadraStarted();
+        CassandraMonitor.setIsCassandraStarted(true);
         Assert.assertTrue(CassandraMonitor.hasCassadraStarted());
 
         monitor.execute();


### PR DESCRIPTION
6369b6aa 2024-05-02 | Cease stopping Cassandra in the restore process and reveal the ability to restore to a staging area and then import or move the data depending on whether Cassandra is running.
4ece8d3a 2024-05-01 | Move getBackupDirectories to BackupRestoreUtil and change its signature to cease requiring an IConfiguration but rather just take the data directory path as a String.
6b3d45a8 2024-04-10 | Cease wiping the data directory in advance of restore. It is counter-intuitive and will be empty in practice in most cases anyway.
f10289fd 2024-04-10 | Consolidate restore status API.
4d6d07f3 2024-03-09 | Remove backup racs as that configuration is not used in practice and is not relevant to whether a restore should be attempted.
aa3dffe7 2024-03-09 | Remove redundant vertical whitespace.
8c23800c 2024-03-09 | Remove redundant logging.
646973d8 2024-03-09 | Remove all non-javadoc comments that don't provide warnings to future maintainers.
8d18f511 2024-03-09 | Remove waitForCompletion parameter to download method which is always false in practice. Remove final modifier on static method. Make static property an instance variable instead. Use parameterized constructor call in place of two lines.
ce6c7c10 2024-03-09 | Remove unused code from our restore tooling.