### PR TITLE
Change default compression transition time to be far in the future rather than the epoch.

### DIFF
--- a/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
+++ b/priam/src/main/java/com/netflix/priam/config/IConfiguration.java
@@ -1104,7 +1104,7 @@ public interface IConfiguration {
      * @return the milliseconds since the epoch of the transition time.
      */
     default long getCompressionTransitionEpochMillis() {
-        return 0L;
+        return Long.MAX_VALUE;
     }
 
     /** @return whether to enable auto_snapshot */


### PR DESCRIPTION
This implies that just changing the compression mode will not immediately lead to a dangerous situation in which recent backups could be deleted erroneously.