### PR TITLE
Add a ChangelogExecutor interface to avoid circular dependency issue

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backupv2/SnapshotMetaTask.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/SnapshotMetaTask.java
@@ -29,6 +29,7 @@ import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.connection.CassandraOperations;
 import com.netflix.priam.health.CassandraMonitor;
 import com.netflix.priam.identity.InstanceIdentity;
+import com.netflix.priam.scheduler.ChangelogExecutor;
 import com.netflix.priam.scheduler.CronTimer;
 import com.netflix.priam.scheduler.TaskTimer;
 import com.netflix.priam.utils.DateUtil;
@@ -95,6 +96,7 @@ public class SnapshotMetaTask extends AbstractBackup {
     private final IBackupRestoreConfig backupRestoreConfig;
     private final BackupVerification backupVerification;
     private final BackupHelper backupHelper;
+    private final ChangelogExecutor changelogExecutor;
 
     private enum MetaStep {
         META_GENERATION,
@@ -114,7 +116,7 @@ public class SnapshotMetaTask extends AbstractBackup {
             CassandraOperations cassandraOperations,
             Clock clock,
             IBackupRestoreConfig backupRestoreConfig,
-            BackupVerification backupVerification) {
+            BackupVerification backupVerification, ChangelogExecutor changelogExecutor) {
         super(config);
         this.config = config;
         this.backupHelper = backupHelper;
@@ -129,6 +131,7 @@ public class SnapshotMetaTask extends AbstractBackup {
                         config.getSnapshotIncludeCFList(), config.getSnapshotExcludeCFList());
         this.metaFileWriter = metaFileWriter;
         this.metaProxy = metaProxy;
+        this.changelogExecutor = changelogExecutor;
         this.threadPool = Executors.newSingleThreadExecutor();
     }
 
@@ -201,6 +204,9 @@ public class SnapshotMetaTask extends AbstractBackup {
             logger.warn("SnapshotMetaService is already running! Try again later.");
             throw new IllegalStateException("SnapshotMetaService already running");
         }
+
+        // Execute the changelog task to sync up schema before taking the snapshot
+        changelogExecutor.executeChangelogTask();
 
         // Save start snapshot status
         Instant snapshotInstant = clock.instant();

--- a/priam/src/main/java/com/netflix/priam/scheduler/ChangelogExecutor.java
+++ b/priam/src/main/java/com/netflix/priam/scheduler/ChangelogExecutor.java
@@ -1,0 +1,5 @@
+package com.netflix.priam.scheduler;
+
+public interface ChangelogExecutor {
+    void executeChangelogTask() throws Exception;
+}


### PR DESCRIPTION
Add a ChangelogExecutor interface to avoid circular dependency issue in SnapshotMetaTask for sync up schema before taking a snapshot. 