### PR TITLE
Upload system.local to backups. Don't restore it.

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backup/BackupRestoreUtil.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupRestoreUtil.java
@@ -40,13 +40,12 @@ public class BackupRestoreUtil {
             ImmutableMap.of(
                     "system",
                     Arrays.asList(
-                            "local",
                             "peers",
                             "hints",
                             "compactions_in_progress",
                             "LocationInfo"));
     private static final Map<String, List<String>> EXTRA_TABLES_TO_EXCLUDE_FROM_RESTORE =
-            ImmutableMap.of("system", Arrays.asList("peers_v2"));
+            ImmutableMap.of("system", Arrays.asList("peers_v2", "local"));
 
     @Inject
     public BackupRestoreUtil(String configIncludeFilter, String configExcludeFilter) {

--- a/priam/src/test/groovy/com.netflix.priam/backup/TestBackupRestoreUtil.groovy
+++ b/priam/src/test/groovy/com.netflix.priam/backup/TestBackupRestoreUtil.groovy
@@ -50,7 +50,7 @@ class TestBackupRestoreUtil extends Specification {
         "abc.cd"            | "abc.*"             | "abc"    | "cd"         				|| true
         "abc.*"             | "abc.*"             | "abc"    | "cd"         				|| true
         "abc.*,def.*"       | "abc.*"             | "def"    | "ab"         				|| false
-        null                | null                | "system"   | "local"    				|| true
+        null                | null                | "system"   | "local"    				|| false
         null                | null                | "system"   | "peers"    				|| true
         null                | null                | "system"   | "hints"    				|| true
         null                | null                | "system"   | "compactions_in_progress"  || true

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackup.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackup.java
@@ -148,7 +148,7 @@ public class TestBackup {
         }
         IncrementalBackup backup = injector.getInstance(IncrementalBackup.class);
         backup.execute();
-        Assert.assertEquals(7, filesystem.uploadedFiles.size());
+        Assert.assertEquals(9, filesystem.uploadedFiles.size());
         for (String filePath : expectedFiles)
             Assert.assertTrue(filesystem.uploadedFiles.contains(filePath));
     }


### PR DESCRIPTION
This allows partitioner information to be read from S3 when pulling.