### PR TITLE
Fix uncontrolled data used in path expression

### DIFF
--- a/priam/src/main/java/com/netflix/priam/resources/CassandraAdmin.java
+++ b/priam/src/main/java/com/netflix/priam/resources/CassandraAdmin.java
@@ -28,6 +28,8 @@ import com.netflix.priam.defaultimpl.ICassandraProcess;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.util.Iterator;
 import java.util.List;
@@ -490,18 +492,36 @@ public class CassandraAdmin {
 
     /*
     @parm in - absolute path on disk of compressed file.
-    @param out - absolute path on disk for output, decompressed file
+    @param out - file name for output, decompressed file (will be placed in a restricted directory)
     @parapm compression algorithn -- optional and if not provided, defaults to Snappy
     */
     @GET
     @Path("/decompress")
     public Response decompress(@QueryParam("in") String in, @QueryParam("out") String out)
             throws Exception {
+        // Define a safe output directory. In a real system, consider making this configurable.
+        final Path safeOutputDir = Paths.get("/tmp/priam_decompress_out").toAbsolutePath().normalize();
+        // Validate 'out' is a simple filename, does not contain parent directory traversal, separators, or absolute path
+        if (out == null || out.isEmpty()
+                || out.contains("..")
+                || out.contains("/") || out.contains("\\")
+                || Paths.get(out).isAbsolute()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity("Invalid output file name: possible path traversal detected.").build();
+        }
+        // Resolve file path within safe directory
+        Path outputPath = safeOutputDir.resolve(out).normalize().toAbsolutePath();
+        if (!outputPath.startsWith(safeOutputDir)) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity("Invalid output file name: not allowed outside safe output directory.").build();
+        }
+        // Ensure output directory exists
+        java.nio.file.Files.createDirectories(safeOutputDir);
         SnappyCompression compress = new SnappyCompression();
-        compress.decompressAndClose(new FileInputStream(in), new FileOutputStream(out));
+        compress.decompressAndClose(new FileInputStream(in), new FileOutputStream(outputPath.toString()));
         JSONObject object = new JSONObject();
         object.put("Input compressed file", in);
-        object.put("Output decompress file", out);
+        object.put("Output decompress file", outputPath.toString());
         return Response.ok(object.toString(), MediaType.APPLICATION_JSON).build();
     }
 }


### PR DESCRIPTION
Accessing paths controlled by users can allow an attacker to access unexpected resources. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files. Paths that are naively constructed from data controlled by a user may be absolute paths, or may contain unexpected special characters such as "..". Such a path could point anywhere on the file system.


fix this issue must validate the `out` path parameter to ensure it cannot reference unintended files or directories. The best approach, given this is likely a privileged admin endpoint, is to:
- Restrict writes to files only under a controlled, specific directory (for example, a well-defined "output" folder).
- Normalize the constructed path, and check that it lies within (not outside) the intended directory, before proceeding.
- Optionally, enforce additional restrictions such as forbidden characters, no absolute paths, and check that the filename portion is a regular file name.

Changes required:
- Add a well-known "safe" output directory (either as a constant, property, or injected value—here, hardcoded for clarity).
- Construct the output file path by resolving the user input relative to this directory, normalize the resulting path, and check it falls within the output directory.
- Reject requests with an appropriate error message if the path is invalid.
- Add necessary imports for `java.nio.file.Paths` and `java.nio.file.Path`, and replace `FileOutputStream(out)` with the safe, validated file path.

All changes are within `priam/src/main/java/com/netflix/priam/resources/CassandraAdmin.java`.


