### PR TITLE
Persist validation markers to S3 for UCC.

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/RemoteBackupPath.java
+++ b/priam/src/main/java/com/netflix/priam/aws/RemoteBackupPath.java
@@ -50,7 +50,7 @@ public class RemoteBackupPath extends AbstractBackupPath {
     /* This will ensure that there is some randomness in the path at the start so that remote file systems
     can hash the contents better when we have lot of clusters backing up at the same remote location.
     */
-    private String prependHash(String appName) {
+    public static String prependHash(String appName) {
         return String.format("%d_%s", appName.hashCode() % 10000, appName);
     }
 

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -17,13 +17,13 @@
 package com.netflix.priam.aws;
 
 import com.google.common.base.Preconditions;
+import com.netflix.priam.aws.auth.IS3Credential;
 import com.netflix.priam.backup.AbstractBackupPath;
 import com.netflix.priam.backup.BackupRestoreException;
 import com.netflix.priam.backup.DynamicRateLimiter;
 import com.netflix.priam.backup.RangeReadInputStream;
 import com.netflix.priam.compress.ChunkedStream;
 import com.netflix.priam.compress.CompressionType;
-import com.netflix.priam.aws.auth.IS3Credential;
 import com.netflix.priam.compress.ICompression;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.identity.config.InstanceInfo;
@@ -31,21 +31,6 @@ import com.netflix.priam.merics.BackupMetrics;
 import com.netflix.priam.notification.BackupNotificationMgr;
 import com.netflix.priam.utils.BoundedExponentialRetryCallable;
 import com.netflix.priam.utils.SystemUtils;
-import java.io.*;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Provider;
-import javax.inject.Singleton;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +38,17 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import java.io.*;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /** Implementation of IBackupFileSystem for S3 */
 @Singleton
@@ -109,11 +105,13 @@ public class S3FileSystem extends S3FileSystemBase {
 
     @Override
     public void putObject(String bucket, String key, String value) {
-        s3Client.putObject(bucket, key, value);
+        s3Client.putObject(
+                PutObjectRequest.builder().bucket(bucket).key(key).build(),
+                RequestBody.fromBytes(value.getBytes()));
     }
 
-    private ObjectMetadata getObjectMetadata(File file) {
-        ObjectMetadata ret = new ObjectMetadata();
+    private Map<String, String> getFileMetadata(File file) {
+            Map<String, String> metadata = new HashMap<>();
         long lastModified = file.lastModified();
         long fileSize = file.length();
 

--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -107,8 +107,13 @@ public class S3FileSystem extends S3FileSystemBase {
         }
     }
 
-    private Map<String, String> getFileMetadata(File file) {
-        Map<String, String> metadata = new HashMap<>();
+    @Override
+    public void putObject(String bucket, String key, String value) {
+        s3Client.putObject(bucket, key, value);
+    }
+
+    private ObjectMetadata getObjectMetadata(File file) {
+        ObjectMetadata ret = new ObjectMetadata();
         long lastModified = file.lastModified();
         long fileSize = file.length();
 

--- a/priam/src/main/java/com/netflix/priam/backup/IBackupFileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/backup/IBackupFileSystem.java
@@ -175,4 +175,7 @@ public interface IBackupFileSystem {
 
     /** Add remote backup path to the object cache*/
     void addObjectCache(Path remotePath);
+    
+    /** Synchronously put the contents of an in-memory String to the blob store. **/
+    void putObject(String bucket, String key, String value);
 }

--- a/priam/src/main/java/com/netflix/priam/backupv2/BackupVerificationTask.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/BackupVerificationTask.java
@@ -44,11 +44,12 @@ public class BackupVerificationTask extends Task {
     private static final Logger logger = LoggerFactory.getLogger(BackupVerificationTask.class);
     public static final String JOBNAME = "BackupVerificationService";
 
-    private IBackupRestoreConfig backupRestoreConfig;
-    private BackupVerification backupVerification;
-    private BackupMetrics backupMetrics;
-    private InstanceState instanceState;
-    private BackupNotificationMgr backupNotificationMgr;
+    private final IBackupRestoreConfig backupRestoreConfig;
+    private final BackupVerification backupVerification;
+    private final BackupMetrics backupMetrics;
+    private final InstanceState instanceState;
+    private final BackupNotificationMgr backupNotificationMgr;
+    private final SnapshotValidationMarkerWriter snapshotValidationMarkerWriter;
 
     @Inject
     public BackupVerificationTask(
@@ -57,13 +58,15 @@ public class BackupVerificationTask extends Task {
             BackupVerification backupVerification,
             BackupMetrics backupMetrics,
             InstanceState instanceState,
-            BackupNotificationMgr backupNotificationMgr) {
+            BackupNotificationMgr backupNotificationMgr,
+            SnapshotValidationMarkerWriter snapshotValidationMarkerWriter) {
         super(configuration);
         this.backupRestoreConfig = backupRestoreConfig;
         this.backupVerification = backupVerification;
         this.backupMetrics = backupMetrics;
         this.instanceState = instanceState;
         this.backupNotificationMgr = backupNotificationMgr;
+        this.snapshotValidationMarkerWriter = snapshotValidationMarkerWriter;
     }
 
     @Override
@@ -104,6 +107,7 @@ public class BackupVerificationTask extends Task {
                                     snapshotKey);
                             backupNotificationMgr.notify(
                                     snapshotKey, result.getStart().toInstant());
+                            snapshotValidationMarkerWriter.write(snapshotKey);
                         });
 
         if (verifiedBackups.isEmpty()) {

--- a/priam/src/main/java/com/netflix/priam/backupv2/BackupVerificationTask.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/BackupVerificationTask.java
@@ -49,7 +49,7 @@ public class BackupVerificationTask extends Task {
     private final BackupMetrics backupMetrics;
     private final InstanceState instanceState;
     private final BackupNotificationMgr backupNotificationMgr;
-    private final SnapshotValidationMarkerWriter snapshotValidationMarkerWriter;
+    private final SnapshotVerificationMarkerWriter snapshotVerificationMarkerWriter;
 
     @Inject
     public BackupVerificationTask(
@@ -59,14 +59,14 @@ public class BackupVerificationTask extends Task {
             BackupMetrics backupMetrics,
             InstanceState instanceState,
             BackupNotificationMgr backupNotificationMgr,
-            SnapshotValidationMarkerWriter snapshotValidationMarkerWriter) {
+            SnapshotVerificationMarkerWriter snapshotVerificationMarkerWriter) {
         super(configuration);
         this.backupRestoreConfig = backupRestoreConfig;
         this.backupVerification = backupVerification;
         this.backupMetrics = backupMetrics;
         this.instanceState = instanceState;
         this.backupNotificationMgr = backupNotificationMgr;
-        this.snapshotValidationMarkerWriter = snapshotValidationMarkerWriter;
+        this.snapshotVerificationMarkerWriter = snapshotVerificationMarkerWriter;
     }
 
     @Override
@@ -107,7 +107,7 @@ public class BackupVerificationTask extends Task {
                                     snapshotKey);
                             backupNotificationMgr.notify(
                                     snapshotKey, result.getStart().toInstant());
-                            snapshotValidationMarkerWriter.write(snapshotKey);
+                            snapshotVerificationMarkerWriter.write(snapshotKey);
                         });
 
         if (verifiedBackups.isEmpty()) {

--- a/priam/src/main/java/com/netflix/priam/backupv2/SnapshotValidationMarkerWriter.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/SnapshotValidationMarkerWriter.java
@@ -1,0 +1,53 @@
+package com.netflix.priam.backupv2;
+
+import com.netflix.priam.aws.RemoteBackupPath;
+import com.netflix.priam.backup.AbstractBackupPath;
+import com.netflix.priam.backup.IBackupFileSystem;
+import com.netflix.priam.config.IConfiguration;
+import com.netflix.priam.identity.config.InstanceInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+public class SnapshotValidationMarkerWriter {
+    private static final Logger logger = LoggerFactory.getLogger(SnapshotValidationMarkerWriter.class);
+    private static final String METADATA_PREFIX = "metadata";
+    private final IConfiguration config;
+    private final InstanceInfo instanceInfo;
+    private final Provider<AbstractBackupPath> pathProvider;
+    private final IBackupFileSystem fs;
+
+    @Inject
+    public SnapshotValidationMarkerWriter(
+            IConfiguration config,
+            InstanceInfo instanceInfo,
+            Provider<AbstractBackupPath> pathProvider,
+            IBackupFileSystem fs) {
+        this.config = config;
+        this.instanceInfo = instanceInfo;
+        this.pathProvider = pathProvider;
+        this.fs = fs;
+    }
+
+    public void write(String remotePath) {
+        AbstractBackupPath path = pathProvider.get();
+        path.parseRemote(remotePath);
+        String key = AbstractBackupPath.PATH_JOINER.join(
+                METADATA_PREFIX,
+                RemoteBackupPath.prependHash(path.getClusterName()),
+                path.getLastModified().toEpochMilli(),
+                instanceInfo.getRac(),
+                path.getToken());
+        try {
+            fs.putObject(config.getBackupPrefix(), key, remotePath);
+        } catch (Exception e) {
+            logger.error("Failed to put snapshot verification marker. bucket: {}, key: {}, value: {}, message: {}",
+                    config.getBackupPrefix(),
+                    key,
+                    remotePath,
+                    e.getLocalizedMessage());
+        }
+    }
+}

--- a/priam/src/main/java/com/netflix/priam/backupv2/SnapshotVerificationMarkerWriter.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/SnapshotVerificationMarkerWriter.java
@@ -1,9 +1,7 @@
 package com.netflix.priam.backupv2;
 
-import com.amazonaws.services.s3.model.PutObjectResult;
 import com.netflix.priam.aws.RemoteBackupPath;
 import com.netflix.priam.backup.AbstractBackupPath;
-import com.netflix.priam.backup.BackupRestoreException;
 import com.netflix.priam.backup.IBackupFileSystem;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.identity.config.InstanceInfo;

--- a/priam/src/main/java/com/netflix/priam/backupv2/SnapshotVerificationMarkerWriter.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/SnapshotVerificationMarkerWriter.java
@@ -11,8 +11,8 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
-public class SnapshotValidationMarkerWriter {
-    private static final Logger logger = LoggerFactory.getLogger(SnapshotValidationMarkerWriter.class);
+public class SnapshotVerificationMarkerWriter {
+    private static final Logger logger = LoggerFactory.getLogger(SnapshotVerificationMarkerWriter.class);
     private static final String METADATA_PREFIX = "metadata";
     private final IConfiguration config;
     private final InstanceInfo instanceInfo;
@@ -20,7 +20,7 @@ public class SnapshotValidationMarkerWriter {
     private final IBackupFileSystem fs;
 
     @Inject
-    public SnapshotValidationMarkerWriter(
+    public SnapshotVerificationMarkerWriter(
             IConfiguration config,
             InstanceInfo instanceInfo,
             Provider<AbstractBackupPath> pathProvider,

--- a/priam/src/main/java/com/netflix/priam/backupv2/SnapshotVerificationMarkerWriter.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/SnapshotVerificationMarkerWriter.java
@@ -1,10 +1,13 @@
 package com.netflix.priam.backupv2;
 
+import com.amazonaws.services.s3.model.PutObjectResult;
 import com.netflix.priam.aws.RemoteBackupPath;
 import com.netflix.priam.backup.AbstractBackupPath;
+import com.netflix.priam.backup.BackupRestoreException;
 import com.netflix.priam.backup.IBackupFileSystem;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.identity.config.InstanceInfo;
+import com.netflix.priam.utils.BoundedExponentialRetryCallable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +44,13 @@ public class SnapshotVerificationMarkerWriter {
                 instanceInfo.getRac(),
                 path.getToken());
         try {
-            fs.putObject(config.getBackupPrefix(), key, remotePath);
+            new BoundedExponentialRetryCallable<Void>(0, 0, 3) {
+                @Override
+                public Void retriableCall() throws Exception {
+                    fs.putObject(config.getBackupPrefix(), key, remotePath);
+                    return null;
+                }
+            }.call();
         } catch (Exception e) {
             logger.error("Failed to put snapshot verification marker. bucket: {}, key: {}, value: {}, message: {}",
                     config.getBackupPrefix(),

--- a/priam/src/main/java/com/netflix/priam/resources/BackupServletV2.java
+++ b/priam/src/main/java/com/netflix/priam/resources/BackupServletV2.java
@@ -24,6 +24,7 @@ import com.netflix.priam.backupv2.BackupTTLTask;
 import com.netflix.priam.backupv2.BackupV2Service;
 import com.netflix.priam.backupv2.IMetaProxy;
 import com.netflix.priam.backupv2.SnapshotMetaTask;
+import com.netflix.priam.backupv2.*;
 import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.notification.BackupNotificationMgr;
 import com.netflix.priam.utils.DateUtil;
@@ -63,6 +64,7 @@ public class BackupServletV2 {
     private final BackupNotificationMgr backupNotificationMgr;
     private final IConfiguration config;
     private final DirectorySize directorySize;
+    private final SnapshotValidationMarkerWriter snapshotValidationMarkerWriter;
 
     private static final String REST_SUCCESS = "[\"ok\"]";
 
@@ -78,7 +80,8 @@ public class BackupServletV2 {
             BackupV2Service backupService,
             BackupNotificationMgr backupNotificationMgr,
             IConfiguration config,
-            DirectorySize directorySize) {
+            DirectorySize directorySize,
+            SnapshotValidationMarkerWriter snapshotValidationMarkerWriter) {
         this.backupStatusMgr = backupStatusMgr;
         this.backupVerification = backupVerification;
         this.snapshotMetaService = snapshotMetaService;
@@ -90,6 +93,7 @@ public class BackupServletV2 {
         this.backupNotificationMgr = backupNotificationMgr;
         this.config = config;
         this.directorySize = directorySize;
+        this.snapshotValidationMarkerWriter = snapshotValidationMarkerWriter;
     }
 
     @GET
@@ -164,6 +168,7 @@ public class BackupServletV2 {
                 result.get().remotePath);
 
         backupNotificationMgr.notify(result.get().remotePath, result.get().snapshotInstant);
+        snapshotValidationMarkerWriter.write(result.get().remotePath);
 
         return Response.ok(result.get().toString()).build();
     }

--- a/priam/src/main/java/com/netflix/priam/resources/BackupServletV2.java
+++ b/priam/src/main/java/com/netflix/priam/resources/BackupServletV2.java
@@ -18,7 +18,6 @@
 package com.netflix.priam.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.priam.PriamServer;
 import com.netflix.priam.backup.*;
 import com.netflix.priam.backupv2.BackupTTLTask;
 import com.netflix.priam.backupv2.BackupV2Service;
@@ -64,7 +63,7 @@ public class BackupServletV2 {
     private final BackupNotificationMgr backupNotificationMgr;
     private final IConfiguration config;
     private final DirectorySize directorySize;
-    private final SnapshotValidationMarkerWriter snapshotValidationMarkerWriter;
+    private final SnapshotVerificationMarkerWriter snapshotVerificationMarkerWriter;
 
     private static final String REST_SUCCESS = "[\"ok\"]";
 
@@ -81,7 +80,7 @@ public class BackupServletV2 {
             BackupNotificationMgr backupNotificationMgr,
             IConfiguration config,
             DirectorySize directorySize,
-            SnapshotValidationMarkerWriter snapshotValidationMarkerWriter) {
+            SnapshotVerificationMarkerWriter snapshotVerificationMarkerWriter) {
         this.backupStatusMgr = backupStatusMgr;
         this.backupVerification = backupVerification;
         this.snapshotMetaService = snapshotMetaService;
@@ -93,7 +92,7 @@ public class BackupServletV2 {
         this.backupNotificationMgr = backupNotificationMgr;
         this.config = config;
         this.directorySize = directorySize;
-        this.snapshotValidationMarkerWriter = snapshotValidationMarkerWriter;
+        this.snapshotVerificationMarkerWriter = snapshotVerificationMarkerWriter;
     }
 
     @GET
@@ -168,7 +167,7 @@ public class BackupServletV2 {
                 result.get().remotePath);
 
         backupNotificationMgr.notify(result.get().remotePath, result.get().snapshotInstant);
-        snapshotValidationMarkerWriter.write(result.get().remotePath);
+        snapshotVerificationMarkerWriter.write(result.get().remotePath);
 
         return Response.ok(result.get().toString()).build();
     }

--- a/priam/src/test/java/com/netflix/priam/backup/FakeBackupFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/FakeBackupFileSystem.java
@@ -141,4 +141,9 @@ public class FakeBackupFileSystem extends AbstractFileSystem {
         addFile(path.getRemotePath());
         return path.getBackupFile().length();
     }
+    
+    @Override
+    public void putObject(String bucket, String key, String value) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/priam/src/test/java/com/netflix/priam/backup/NullBackupFileSystem.java
+++ b/priam/src/test/java/com/netflix/priam/backup/NullBackupFileSystem.java
@@ -72,4 +72,7 @@ public class NullBackupFileSystem extends AbstractFileSystem {
             throws BackupRestoreException {
         return 0;
     }
+
+    @Override
+    public void putObject(String bucket, String key, String value) {}
 }

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestBackupVerificationTask.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestBackupVerificationTask.java
@@ -188,7 +188,7 @@ public class TestBackupVerificationTask {
         BackupMetadata backupMetadata = new BackupMetadata("12345", new Date());
         backupMetadata.setLastValidated(
                 new Date(Instant.now().plus(1, ChronoUnit.HOURS).toEpochMilli()));
-        backupMetadata.setSnapshotLocation("bucket/path/to/file.db");
+        backupMetadata.setSnapshotLocation("useast1-cass-test-1/test_backup/-1002_cass_compromised_credentials/-3074457343809683002/META_V2/1762448400000/SNAPPY/PLAINTEXT/meta_v2_202511061700.json");
         return backupMetadata;
     }
 }

--- a/priam/src/test/java/com/netflix/priam/resources/BackupServletV2Test.java
+++ b/priam/src/test/java/com/netflix/priam/resources/BackupServletV2Test.java
@@ -264,7 +264,7 @@ public class BackupServletV2Test {
         BackupVerificationResult result = new BackupVerificationResult();
         result.valid = true;
         result.manifestAvailable = true;
-        result.remotePath = "some_random";
+        result.remotePath = "test_backup/-1002_cass_compromised_credentials/-3074457343809683002/META_V2/1762448400000/SNAPPY/PLAINTEXT/meta_v2_202511061700.json";
         result.filesMatched = 123;
         result.snapshotInstant = Instant.EPOCH;
         return result;


### PR DESCRIPTION
This persists an alternative location for backup metadata in S3 in case of unavailability of the primary source of truth. Tests are in progress and will be added in a follow-up commit. I have confirmed it WAI in practice.