### PR TITLE
Only allow reusable ByteBuffers when not compressing.

### DIFF
--- a/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
+++ b/priam/src/main/java/com/netflix/priam/aws/S3FileSystem.java
@@ -138,7 +138,7 @@ public class S3FileSystem extends S3FileSystemBase {
 
     private long uploadMultipart(AbstractBackupPath path, Instant target)
             throws BackupRestoreException {
-        if (config.useReusableBufferForMultipartUploads()) {
+        if (config.useReusableBufferForMultipartUploads() && path.getCompression() == CompressionType.NONE) {
             return uploadMultipartWithBuffers(path, target);
         } else {
             return uploadMultipartLegacy(path, target);
@@ -355,7 +355,7 @@ public class S3FileSystem extends S3FileSystemBase {
         if (localFile.length() >= config.getBackupChunkSize())
             return uploadMultipart(path, target);
 
-        if (config.useReusableBufferForMultipartUploads()) {
+        if (config.useReusableBufferForMultipartUploads() && path.getCompression() == CompressionType.NONE) {
             return uploadFileWithByteBuffer(path, target);
         } else {
             return uploadFileWithByteArray(path, target);


### PR DESCRIPTION
Snappy-compression doesn't work in that code path.